### PR TITLE
Add class to interact with a Docker Registry server

### DIFF
--- a/app/models/registry.rb
+++ b/app/models/registry.rb
@@ -1,0 +1,110 @@
+class Registry
+  class NoBearerRealmException < RuntimeError
+  end
+
+  class AuthorizationError < RuntimeError
+  end
+
+  class ManifestNotFoundError < RuntimeError
+  end
+
+  class CredentialsMissingError < RuntimeError
+  end
+
+  def initialize(host, use_ssl=true, username=nil, password=nil)
+    @host = host
+    @use_ssl = use_ssl
+    @base_url = "http#{'s' if @use_ssl}://#{@host}/v2/"
+    @username = username
+    @password = password
+  end
+
+  def has_credentials?
+    @username && @password
+  end
+
+  def manifest(repository, tag='latest')
+    res = get_request("#{repository}/manifests/#{tag}")
+    if res.code.to_i == 200
+      JSON.parse(res.body)
+    elsif res.code.to_i == 404
+      fail ManifestNotFoundError, "Cannot find manifest for #{repository}:#{tag}"
+    else
+      fail "Something went wrong while fetching manifest for #{repository}:#{tag}:" \
+        "[#{res.code}] - #{res.body}"
+    end
+  end
+
+  def get_request(path, request_auth_token=true)
+    uri = URI.join(@base_url, path)
+    req = Net::HTTP::Get.new(uri)
+    req['Authorization'] = "Bearer #{@token}" if @token
+
+    res = Net::HTTP.start(
+      uri.hostname,
+      uri.port,
+      use_ssl: uri.scheme == 'https') do |http|
+      http.request(req)
+    end
+
+    if res.code.to_i == 401
+      if request_auth_token
+        request_auth_token(res)
+        return get_request(path, false)
+      else
+        fail AuthorizationError, "Cannot obtain authentication token, check your username and password: #{res}"
+      end
+    else
+      res
+    end
+  end
+
+  private
+
+  def request_auth_token(unhauthorized_response)
+    bearer_realm, query = parse_unhauthorized_response(unhauthorized_response)
+
+    uri = URI("#{bearer_realm}?#{query.to_query}")
+
+    req = Net::HTTP::Get.new(uri)
+    req.basic_auth(@username, @password) if has_credentials?
+
+    res = Net::HTTP.start(
+      uri.hostname,
+      uri.port,
+      use_ssl: uri.scheme == 'https') do |http|
+      http.request(req)
+    end
+
+    if res.code.to_i == 200
+      @token = JSON.parse(res.body)['token']
+    else
+      @token = nil
+      fail AuthorizationError, "Cannot obtain authorization token: #{res}"
+    end
+  end
+
+  def parse_unhauthorized_response(res)
+    auth_args = res.to_hash['www-authenticate'].first.split(',').each_with_object({}) do |i,h|
+      key,val = i.split('=')
+      h[key] = val.gsub('"', '')
+    end
+
+    unless has_credentials?
+      fail CredentialsMissingError, "Registry #{@host} has authorization enabled, "\
+        'user credentials not specified'
+    end
+
+    query_params = {
+      'service' => auth_args['service'],
+      'account' => @username
+    }
+    query_params['scope'] = auth_args['scope'] if auth_args.key?('scope')
+
+    unless auth_args.key?('Bearer realm')
+      fail(NoBearerRealmException, 'Cannot find bearer realm')
+    end
+
+    [auth_args['Bearer realm'], query_params]
+  end
+end

--- a/spec/classes/registry_spec.rb
+++ b/spec/classes/registry_spec.rb
@@ -1,0 +1,95 @@
+require 'rails_helper'
+
+describe Registry do
+  let(:registry_server) { 'registry.test.lan' }
+  let(:username) { 'flavio' }
+  let(:password) { 'this is a test' }
+
+  it 'handle ssl' do
+    begin
+      VCR.turned_off do
+        WebMock.disable_net_connect!
+        s = stub_request(:get, "https://#{registry_server}/v2/")
+        registry = Registry.new(registry_server)
+        registry.get_request('')
+        expect(s).to have_been_requested
+      end
+    ensure
+      WebMock.allow_net_connect!
+    end
+  end
+
+  it 'fails if the registry has authentication enabled and no credentials are set' do
+    path = ''
+    registry = Registry.new(registry_server, false)
+    VCR.use_cassette('registry/missing_credentials', record: :none) do
+      expect do
+        registry.get_request(path)
+      end.to raise_error(Registry::CredentialsMissingError)
+    end
+  end
+
+  context 'authenticating with Registry server' do
+    let(:path) { '' }
+
+    it 'can obtain an authentication token' do
+      registry = Registry.new(
+        registry_server,
+        false,
+        username,
+        password)
+
+      VCR.use_cassette('registry/successful_authentication', record: :none) do
+        res = registry.get_request(path)
+        expect(res).to be_a(Net::HTTPOK)
+      end
+    end
+
+    it 'raise an exception when the user credentials are wrong' do
+      registry = Registry.new(
+        registry_server,
+        false,
+        username,
+        'wrong password')
+
+      VCR.use_cassette('registry/wrong_authentication', record: :none) do
+        expect do
+          registry.get_request(path)
+        end.to raise_error(Registry::AuthorizationError)
+      end
+    end
+  end
+
+  context 'fetching Image manifest' do
+    let(:repository) { 'foo/busybox' }
+    let(:tag) { '1.0.0' }
+
+    it 'authenticates and fetches the image manifest' do
+      VCR.use_cassette('registry/get_image_manifest', record: :none) do
+        registry = Registry.new(
+          registry_server,
+          false,
+          username,
+          password)
+
+        manifest = registry.manifest(repository, tag)
+        expect(manifest['name']).to eq(repository)
+        expect(manifest['tag']).to eq(tag)
+      end
+    end
+
+    it 'fails if the image is not found' do
+      VCR.use_cassette('registry/get_missing_image_manifest', record: :none) do
+        registry = Registry.new(
+          registry_server,
+          false,
+          username,
+          password)
+
+        expect do
+          registry.manifest(repository, '2.0.0')
+        end.to raise_error(Registry::ManifestNotFoundError)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require 'simplecov'
-require 'webmock'
+require 'webmock/rspec'
 require 'vcr'
 
 SimpleCov.minimum_coverage 100

--- a/spec/vcr_cassettes/registry/get_image_manifest.yml
+++ b/spec/vcr_cassettes/registry/get_image_manifest.yml
@@ -1,0 +1,338 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://registry.test.lan/v2/foo/busybox/manifests/1.0.0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - registry.test.lan
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Docker-Distribution-Api-Version:
+      - registry/2.0
+      Www-Authenticate:
+      - Bearer realm="http://portus.test.lan/v2/token",service="registry.test.lan",scope="repository:foo/busybox:pull"
+      Date:
+      - Mon, 20 Apr 2015 10:06:19 GMT
+      Content-Length:
+      - '170'
+    body:
+      encoding: UTF-8
+      string: |
+        {"errors":[{"code":"UNAUTHORIZED","message":"access to the requested resource is not authorized","detail":[{"Type":"repository","Name":"foo/busybox","Action":"pull"}]}]}
+    http_version: 
+  recorded_at: Mon, 20 Apr 2015 10:06:19 GMT
+- request:
+    method: get
+    uri: http://flavio:this%20is%20a%20test@portus.test.lan/v2/token?account=flavio&scope=repository:foo/busybox:pull&service=registry.test.lan
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - portus.test.lan
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 20 Apr 2015 10:06:19 GMT
+      Server:
+      - Apache
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Runtime:
+      - '0.115523'
+      X-Request-Id:
+      - 1a232902-8558-41c1-9c5e-164080569a8d
+      Connection:
+      - close
+      X-Powered-By:
+      - Phusion Passenger 5.0.6
+      Set-Cookie:
+      - _portus_session=VFU2WXlJZzhZdTZOQVFvMjIzazVmVzlOTTFoMWgrNmVSTlZNWEZDREdoVnkvU2xpRncyNWZOd3RIOEp3bHlVSk1Vd3hCQzAzN254TWZhWGN5b2pPalE9PS0tWE1kYUt2YzRCdDFvUHFScmlQM3dkQT09--d26763035bc1fa0174b24b547a5cad6afe025219;
+        path=/; HttpOnly
+      Etag:
+      - W/"f00e2419e64032a9035d3718c6cd523f"
+      Status:
+      - 200 OK
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlBUV1Q6Rk5KRTo3VFc3OlVMSTc6RFpRQTpKSkpJOlJESlE6Mk03NjpIRDZHOlpSU0M6VlBJRjpPNUJVIn0.eyJpc3MiOiJwb3J0dXMudGVzdC5sYW4iLCJzdWIiOiJmbGF2aW8iLCJhdWQiOiJyZWdpc3RyeS50ZXN0LmxhbiIsImV4cCI6MTQyOTUyNDY4MCwibmJmIjoxNDI5NTI0MzgwLCJpYXQiOjE0Mjk1MjQzODAsImp0aSI6ImVEUHVNb0NwYWZNcEpyZUx2UVZ2VHNtUzdqa2N0NmhLZDZqcGhKR2pCdCIsImFjY2VzcyI6W3sidHlwZSI6InJlcG9zaXRvcnkiLCJuYW1lIjoiZm9vL2J1c3lib3giLCJhY3Rpb25zIjpbInB1bGwiXX1dfQ.E_CKjyUSGXYj1qw34OsMAqtUNFNgWkdyrs_SS8OGHp6D3MBgwo9xC8BJW2H8_1FCX8gqasqpzs8cDp67xsbHwCzG1PxOQces917xqiBJm5v41lsyO9HU1UJHhJKMfLSDehx8ltkYO3eGpz0LkDtF8APh3T1R1lhBNlZUQdnHwMsrRklOV7_TNm7QkN1R3zeUQ5rQUgOqgVsJ7YEEdxl_NXRh4q2MokLomUXTOGIrMLxK6W1DYNiTPWrpXiso7EvNa3xLCwK7ZMQCD5i6Eg0pjuRKenaQsWGuLatglyDQQNYyuhWUJU24VGHPgFubuhhm7sKpU13vI-M_-AD3im_M9zy0E6F53op3GXSPvhYYPEMgfuzU_8F2bC0duCAKQwJwbN-IAIyrbOlj_d90OaGDA-Y8JRUVPn2OV_0xo6LFGu6LqXKj8r1CcEfHAdVHMGKB1mEvYUAZP1WIDg1pE3TqFii9N0oWkY4-IikEQ8ykU02yxsGTbzbkQw59L3P7_Fo02ChhhPLyUB_L185OFdhyFPvMUL7AoYQmz5DdUsKe6EQK9WNs5T2dUGiE0drrSHA-kWn2XZmFy6ZLKjGsccJWrtOvvRlc9M6lA3GqxsMYyH8zyEsnzERcGvTV2uNpkyLsSAprHR69RwXBrIgwMvlPVc40W3LoLSNa90Ja4R270jk"}'
+    http_version: 
+  recorded_at: Mon, 20 Apr 2015 10:06:20 GMT
+- request:
+    method: get
+    uri: http://registry.test.lan/v2/foo/busybox/manifests/1.0.0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - registry.test.lan
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlBUV1Q6Rk5KRTo3VFc3OlVMSTc6RFpRQTpKSkpJOlJESlE6Mk03NjpIRDZHOlpSU0M6VlBJRjpPNUJVIn0.eyJpc3MiOiJwb3J0dXMudGVzdC5sYW4iLCJzdWIiOiJmbGF2aW8iLCJhdWQiOiJyZWdpc3RyeS50ZXN0LmxhbiIsImV4cCI6MTQyOTUyNDY4MCwibmJmIjoxNDI5NTI0MzgwLCJpYXQiOjE0Mjk1MjQzODAsImp0aSI6ImVEUHVNb0NwYWZNcEpyZUx2UVZ2VHNtUzdqa2N0NmhLZDZqcGhKR2pCdCIsImFjY2VzcyI6W3sidHlwZSI6InJlcG9zaXRvcnkiLCJuYW1lIjoiZm9vL2J1c3lib3giLCJhY3Rpb25zIjpbInB1bGwiXX1dfQ.E_CKjyUSGXYj1qw34OsMAqtUNFNgWkdyrs_SS8OGHp6D3MBgwo9xC8BJW2H8_1FCX8gqasqpzs8cDp67xsbHwCzG1PxOQces917xqiBJm5v41lsyO9HU1UJHhJKMfLSDehx8ltkYO3eGpz0LkDtF8APh3T1R1lhBNlZUQdnHwMsrRklOV7_TNm7QkN1R3zeUQ5rQUgOqgVsJ7YEEdxl_NXRh4q2MokLomUXTOGIrMLxK6W1DYNiTPWrpXiso7EvNa3xLCwK7ZMQCD5i6Eg0pjuRKenaQsWGuLatglyDQQNYyuhWUJU24VGHPgFubuhhm7sKpU13vI-M_-AD3im_M9zy0E6F53op3GXSPvhYYPEMgfuzU_8F2bC0duCAKQwJwbN-IAIyrbOlj_d90OaGDA-Y8JRUVPn2OV_0xo6LFGu6LqXKj8r1CcEfHAdVHMGKB1mEvYUAZP1WIDg1pE3TqFii9N0oWkY4-IikEQ8ykU02yxsGTbzbkQw59L3P7_Fo02ChhhPLyUB_L185OFdhyFPvMUL7AoYQmz5DdUsKe6EQK9WNs5T2dUGiE0drrSHA-kWn2XZmFy6ZLKjGsccJWrtOvvRlc9M6lA3GqxsMYyH8zyEsnzERcGvTV2uNpkyLsSAprHR69RwXBrIgwMvlPVc40W3LoLSNa90Ja4R270jk
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '9247'
+      Content-Type:
+      - application/json; charset=utf-8
+      Docker-Content-Digest:
+      - sha256:b0fa49f7764cba82400015705707a924454abd246d91aa3ddff35fdc9f029534
+      Docker-Distribution-Api-Version:
+      - registry/2.0
+      Date:
+      - Mon, 20 Apr 2015 10:06:20 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICAibmFtZSI6ICJmb28vYnVzeWJveCIsCiAgICJ0YWciOiAiMS4wLjAi
+        LAogICAiYXJjaGl0ZWN0dXJlIjogImFtZDY0IiwKICAgImZzTGF5ZXJzIjog
+        WwogICAgICB7CiAgICAgICAgICJibG9iU3VtIjogInNoYTI1NjphM2VkOTVj
+        YWViMDJmZmU2OGNkZDlmZDg0NDA2NjgwYWU5M2Q2MzNjYjE2NDIyZDAwZThh
+        N2MyMjk1NWI0NmQ0IgogICAgICB9LAogICAgICB7CiAgICAgICAgICJibG9i
+        U3VtIjogInNoYTI1NjphM2VkOTVjYWViMDJmZmU2OGNkZDlmZDg0NDA2Njgw
+        YWU5M2Q2MzNjYjE2NDIyZDAwZThhN2MyMjk1NWI0NmQ0IgogICAgICB9LAog
+        ICAgICB7CiAgICAgICAgICJibG9iU3VtIjogInNoYTI1NjoxZGIwOWFkYjVk
+        ZGQ3ZjFhMDdiNmQ1ODVhN2RiNzQ3YTUxYzdiZDE3NDE4ZDQ3ZTkxZjkwMWJk
+        ZjQyMGFiZDY2IgogICAgICB9LAogICAgICB7CiAgICAgICAgICJibG9iU3Vt
+        IjogInNoYTI1NjphM2VkOTVjYWViMDJmZmU2OGNkZDlmZDg0NDA2NjgwYWU5
+        M2Q2MzNjYjE2NDIyZDAwZThhN2MyMjk1NWI0NmQ0IgogICAgICB9LAogICAg
+        ICB7CiAgICAgICAgICJibG9iU3VtIjogInNoYTI1NjphM2VkOTVjYWViMDJm
+        ZmU2OGNkZDlmZDg0NDA2NjgwYWU5M2Q2MzNjYjE2NDIyZDAwZThhN2MyMjk1
+        NWI0NmQ0IgogICAgICB9CiAgIF0sCiAgICJoaXN0b3J5IjogWwogICAgICB7
+        CiAgICAgICAgICJ2MUNvbXBhdGliaWxpdHkiOiAie1wiaWRcIjpcIjQ5ODZi
+        ZjhjMTUzNjNkMWM1ZDE1NTEyZDUyNjZmODc3N2JmYmE0OTc0YWM1NmUzMjcw
+        ZTc3NjBmNmYwYTgxMjVcIixcInBhcmVudFwiOlwiZWExMzE0OTk0NWNiNmIx
+        ZTc0NmJmMjgwMzJmMDJlOWI1YTc5MzUyMzQ4MWEwYTE4NjQ1ZmM3N2FkNTNj
+        NGVhMlwiLFwiY3JlYXRlZFwiOlwiMjAxNC0xMi0zMVQyMjoyMzo1Ni45NDM0
+        MDM2NjhaXCIsXCJjb250YWluZXJcIjpcIjgzZGNmMzZhZDEwNDJiOTBmNGVh
+        OGIyZWJiNjBlNjFiMmYxYTQ1MWE4ODNlMDRiMzg4YmUyOTlhZDM4MmIyNTlc
+        IixcImNvbnRhaW5lcl9jb25maWdcIjp7XCJIb3N0bmFtZVwiOlwiN2Y2NzQ5
+        MTU5ODBkXCIsXCJEb21haW5uYW1lXCI6XCJcIixcIlVzZXJcIjpcIlwiLFwi
+        TWVtb3J5XCI6MCxcIk1lbW9yeVN3YXBcIjowLFwiQ3B1U2hhcmVzXCI6MCxc
+        IkNwdXNldFwiOlwiXCIsXCJBdHRhY2hTdGRpblwiOmZhbHNlLFwiQXR0YWNo
+        U3Rkb3V0XCI6ZmFsc2UsXCJBdHRhY2hTdGRlcnJcIjpmYWxzZSxcIlBvcnRT
+        cGVjc1wiOm51bGwsXCJFeHBvc2VkUG9ydHNcIjpudWxsLFwiVHR5XCI6ZmFs
+        c2UsXCJPcGVuU3RkaW5cIjpmYWxzZSxcIlN0ZGluT25jZVwiOmZhbHNlLFwi
+        RW52XCI6W1wiUEFUSD0vdXNyL2xvY2FsL3NiaW46L3Vzci9sb2NhbC9iaW46
+        L3Vzci9zYmluOi91c3IvYmluOi9zYmluOi9iaW5cIl0sXCJDbWRcIjpbXCIv
+        YmluL3NoXCIsXCItY1wiLFwiIyhub3ApIENNRCBbL2Jpbi9zaF1cIl0sXCJJ
+        bWFnZVwiOlwiZWExMzE0OTk0NWNiNmIxZTc0NmJmMjgwMzJmMDJlOWI1YTc5
+        MzUyMzQ4MWEwYTE4NjQ1ZmM3N2FkNTNjNGVhMlwiLFwiVm9sdW1lc1wiOm51
+        bGwsXCJXb3JraW5nRGlyXCI6XCJcIixcIkVudHJ5cG9pbnRcIjpudWxsLFwi
+        TmV0d29ya0Rpc2FibGVkXCI6ZmFsc2UsXCJNYWNBZGRyZXNzXCI6XCJcIixc
+        Ik9uQnVpbGRcIjpbXSxcIkxhYmVsc1wiOm51bGx9LFwiZG9ja2VyX3ZlcnNp
+        b25cIjpcIjEuNC4xXCIsXCJhdXRob3JcIjpcIkrDqXLDtG1lIFBldGF6em9u
+        aSBcXHUwMDNjamVyb21lQGRvY2tlci5jb21cXHUwMDNlXCIsXCJjb25maWdc
+        Ijp7XCJIb3N0bmFtZVwiOlwiN2Y2NzQ5MTU5ODBkXCIsXCJEb21haW5uYW1l
+        XCI6XCJcIixcIlVzZXJcIjpcIlwiLFwiTWVtb3J5XCI6MCxcIk1lbW9yeVN3
+        YXBcIjowLFwiQ3B1U2hhcmVzXCI6MCxcIkNwdXNldFwiOlwiXCIsXCJBdHRh
+        Y2hTdGRpblwiOmZhbHNlLFwiQXR0YWNoU3Rkb3V0XCI6ZmFsc2UsXCJBdHRh
+        Y2hTdGRlcnJcIjpmYWxzZSxcIlBvcnRTcGVjc1wiOm51bGwsXCJFeHBvc2Vk
+        UG9ydHNcIjpudWxsLFwiVHR5XCI6ZmFsc2UsXCJPcGVuU3RkaW5cIjpmYWxz
+        ZSxcIlN0ZGluT25jZVwiOmZhbHNlLFwiRW52XCI6W1wiUEFUSD0vdXNyL2xv
+        Y2FsL3NiaW46L3Vzci9sb2NhbC9iaW46L3Vzci9zYmluOi91c3IvYmluOi9z
+        YmluOi9iaW5cIl0sXCJDbWRcIjpbXCIvYmluL3NoXCJdLFwiSW1hZ2VcIjpc
+        ImVhMTMxNDk5NDVjYjZiMWU3NDZiZjI4MDMyZjAyZTliNWE3OTM1MjM0ODFh
+        MGExODY0NWZjNzdhZDUzYzRlYTJcIixcIlZvbHVtZXNcIjpudWxsLFwiV29y
+        a2luZ0RpclwiOlwiXCIsXCJFbnRyeXBvaW50XCI6bnVsbCxcIk5ldHdvcmtE
+        aXNhYmxlZFwiOmZhbHNlLFwiTWFjQWRkcmVzc1wiOlwiXCIsXCJPbkJ1aWxk
+        XCI6W10sXCJMYWJlbHNcIjpudWxsfSxcImFyY2hpdGVjdHVyZVwiOlwiYW1k
+        NjRcIixcIm9zXCI6XCJsaW51eFwiLFwiU2l6ZVwiOjB9XG4iCiAgICAgIH0s
+        CiAgICAgIHsKICAgICAgICAgInYxQ29tcGF0aWJpbGl0eSI6ICJ7XCJpZFwi
+        OlwiNDk4NmJmOGMxNTM2M2QxYzVkMTU1MTJkNTI2NmY4Nzc3YmZiYTQ5NzRh
+        YzU2ZTMyNzBlNzc2MGY2ZjBhODEyNVwiLFwicGFyZW50XCI6XCJlYTEzMTQ5
+        OTQ1Y2I2YjFlNzQ2YmYyODAzMmYwMmU5YjVhNzkzNTIzNDgxYTBhMTg2NDVm
+        Yzc3YWQ1M2M0ZWEyXCIsXCJjcmVhdGVkXCI6XCIyMDE0LTEyLTMxVDIyOjIz
+        OjU2Ljk0MzQwMzY2OFpcIixcImNvbnRhaW5lclwiOlwiODNkY2YzNmFkMTA0
+        MmI5MGY0ZWE4YjJlYmI2MGU2MWIyZjFhNDUxYTg4M2UwNGIzODhiZTI5OWFk
+        MzgyYjI1OVwiLFwiY29udGFpbmVyX2NvbmZpZ1wiOntcIkhvc3RuYW1lXCI6
+        XCI3ZjY3NDkxNTk4MGRcIixcIkRvbWFpbm5hbWVcIjpcIlwiLFwiVXNlclwi
+        OlwiXCIsXCJNZW1vcnlcIjowLFwiTWVtb3J5U3dhcFwiOjAsXCJDcHVTaGFy
+        ZXNcIjowLFwiQ3B1c2V0XCI6XCJcIixcIkF0dGFjaFN0ZGluXCI6ZmFsc2Us
+        XCJBdHRhY2hTdGRvdXRcIjpmYWxzZSxcIkF0dGFjaFN0ZGVyclwiOmZhbHNl
+        LFwiUG9ydFNwZWNzXCI6bnVsbCxcIkV4cG9zZWRQb3J0c1wiOm51bGwsXCJU
+        dHlcIjpmYWxzZSxcIk9wZW5TdGRpblwiOmZhbHNlLFwiU3RkaW5PbmNlXCI6
+        ZmFsc2UsXCJFbnZcIjpbXCJQQVRIPS91c3IvbG9jYWwvc2JpbjovdXNyL2xv
+        Y2FsL2JpbjovdXNyL3NiaW46L3Vzci9iaW46L3NiaW46L2JpblwiXSxcIkNt
+        ZFwiOltcIi9iaW4vc2hcIixcIi1jXCIsXCIjKG5vcCkgQ01EIFsvYmluL3No
+        XVwiXSxcIkltYWdlXCI6XCJlYTEzMTQ5OTQ1Y2I2YjFlNzQ2YmYyODAzMmYw
+        MmU5YjVhNzkzNTIzNDgxYTBhMTg2NDVmYzc3YWQ1M2M0ZWEyXCIsXCJWb2x1
+        bWVzXCI6bnVsbCxcIldvcmtpbmdEaXJcIjpcIlwiLFwiRW50cnlwb2ludFwi
+        Om51bGwsXCJOZXR3b3JrRGlzYWJsZWRcIjpmYWxzZSxcIk1hY0FkZHJlc3Nc
+        IjpcIlwiLFwiT25CdWlsZFwiOltdLFwiTGFiZWxzXCI6bnVsbH0sXCJkb2Nr
+        ZXJfdmVyc2lvblwiOlwiMS40LjFcIixcImF1dGhvclwiOlwiSsOpcsO0bWUg
+        UGV0YXp6b25pIFxcdTAwM2NqZXJvbWVAZG9ja2VyLmNvbVxcdTAwM2VcIixc
+        ImNvbmZpZ1wiOntcIkhvc3RuYW1lXCI6XCI3ZjY3NDkxNTk4MGRcIixcIkRv
+        bWFpbm5hbWVcIjpcIlwiLFwiVXNlclwiOlwiXCIsXCJNZW1vcnlcIjowLFwi
+        TWVtb3J5U3dhcFwiOjAsXCJDcHVTaGFyZXNcIjowLFwiQ3B1c2V0XCI6XCJc
+        IixcIkF0dGFjaFN0ZGluXCI6ZmFsc2UsXCJBdHRhY2hTdGRvdXRcIjpmYWxz
+        ZSxcIkF0dGFjaFN0ZGVyclwiOmZhbHNlLFwiUG9ydFNwZWNzXCI6bnVsbCxc
+        IkV4cG9zZWRQb3J0c1wiOm51bGwsXCJUdHlcIjpmYWxzZSxcIk9wZW5TdGRp
+        blwiOmZhbHNlLFwiU3RkaW5PbmNlXCI6ZmFsc2UsXCJFbnZcIjpbXCJQQVRI
+        PS91c3IvbG9jYWwvc2JpbjovdXNyL2xvY2FsL2JpbjovdXNyL3NiaW46L3Vz
+        ci9iaW46L3NiaW46L2JpblwiXSxcIkNtZFwiOltcIi9iaW4vc2hcIl0sXCJJ
+        bWFnZVwiOlwiZWExMzE0OTk0NWNiNmIxZTc0NmJmMjgwMzJmMDJlOWI1YTc5
+        MzUyMzQ4MWEwYTE4NjQ1ZmM3N2FkNTNjNGVhMlwiLFwiVm9sdW1lc1wiOm51
+        bGwsXCJXb3JraW5nRGlyXCI6XCJcIixcIkVudHJ5cG9pbnRcIjpudWxsLFwi
+        TmV0d29ya0Rpc2FibGVkXCI6ZmFsc2UsXCJNYWNBZGRyZXNzXCI6XCJcIixc
+        Ik9uQnVpbGRcIjpbXSxcIkxhYmVsc1wiOm51bGx9LFwiYXJjaGl0ZWN0dXJl
+        XCI6XCJhbWQ2NFwiLFwib3NcIjpcImxpbnV4XCIsXCJTaXplXCI6MH1cbiIK
+        ICAgICAgfSwKICAgICAgewogICAgICAgICAidjFDb21wYXRpYmlsaXR5Ijog
+        IntcImlkXCI6XCJlYTEzMTQ5OTQ1Y2I2YjFlNzQ2YmYyODAzMmYwMmU5YjVh
+        NzkzNTIzNDgxYTBhMTg2NDVmYzc3YWQ1M2M0ZWEyXCIsXCJwYXJlbnRcIjpc
+        ImRmNzU0NmY5ZjA2MGEyMjY4MDI0YzhhMjMwZDg2Mzk4Nzg1ODVkZWZjYzFi
+        YzZmNzlkMjcyOGExMzk1Nzg3MWJcIixcImNyZWF0ZWRcIjpcIjIwMTQtMTIt
+        MzFUMjI6MjM6NTYuMTkwNzk3NzkyWlwiLFwiY29udGFpbmVyXCI6XCI3ZjY3
+        NDkxNTk4MGRiY2FmYjMwOTZmYTgyMzY5YzI5NDMxOTQ0ODZkY2I0ZTU4NWUz
+        NDkwYTJlNjZjNTMwZTQ0XCIsXCJjb250YWluZXJfY29uZmlnXCI6e1wiSG9z
+        dG5hbWVcIjpcIjdmNjc0OTE1OTgwZFwiLFwiRG9tYWlubmFtZVwiOlwiXCIs
+        XCJVc2VyXCI6XCJcIixcIk1lbW9yeVwiOjAsXCJNZW1vcnlTd2FwXCI6MCxc
+        IkNwdVNoYXJlc1wiOjAsXCJDcHVzZXRcIjpcIlwiLFwiQXR0YWNoU3RkaW5c
+        IjpmYWxzZSxcIkF0dGFjaFN0ZG91dFwiOmZhbHNlLFwiQXR0YWNoU3RkZXJy
+        XCI6ZmFsc2UsXCJQb3J0U3BlY3NcIjpudWxsLFwiRXhwb3NlZFBvcnRzXCI6
+        bnVsbCxcIlR0eVwiOmZhbHNlLFwiT3BlblN0ZGluXCI6ZmFsc2UsXCJTdGRp
+        bk9uY2VcIjpmYWxzZSxcIkVudlwiOltcIlBBVEg9L3Vzci9sb2NhbC9zYmlu
+        Oi91c3IvbG9jYWwvYmluOi91c3Ivc2JpbjovdXNyL2Jpbjovc2JpbjovYmlu
+        XCJdLFwiQ21kXCI6W1wiL2Jpbi9zaFwiLFwiLWNcIixcIiMobm9wKSBBREQg
+        ZmlsZTo4Y2Y1MTdkOTBmZTc5NTQ3YzQ3NDY0MWNjMWU2NDI1ODUwZTA0YWJi
+        ZDg4NTY3MThmN2U0YTE4NGVhODc4NTM4IGluIC9cIl0sXCJJbWFnZVwiOlwi
+        ZGY3NTQ2ZjlmMDYwYTIyNjgwMjRjOGEyMzBkODYzOTg3ODU4NWRlZmNjMWJj
+        NmY3OWQyNzI4YTEzOTU3ODcxYlwiLFwiVm9sdW1lc1wiOm51bGwsXCJXb3Jr
+        aW5nRGlyXCI6XCJcIixcIkVudHJ5cG9pbnRcIjpudWxsLFwiTmV0d29ya0Rp
+        c2FibGVkXCI6ZmFsc2UsXCJNYWNBZGRyZXNzXCI6XCJcIixcIk9uQnVpbGRc
+        IjpbXSxcIkxhYmVsc1wiOm51bGx9LFwiZG9ja2VyX3ZlcnNpb25cIjpcIjEu
+        NC4xXCIsXCJhdXRob3JcIjpcIkrDqXLDtG1lIFBldGF6em9uaSBcXHUwMDNj
+        amVyb21lQGRvY2tlci5jb21cXHUwMDNlXCIsXCJjb25maWdcIjp7XCJIb3N0
+        bmFtZVwiOlwiN2Y2NzQ5MTU5ODBkXCIsXCJEb21haW5uYW1lXCI6XCJcIixc
+        IlVzZXJcIjpcIlwiLFwiTWVtb3J5XCI6MCxcIk1lbW9yeVN3YXBcIjowLFwi
+        Q3B1U2hhcmVzXCI6MCxcIkNwdXNldFwiOlwiXCIsXCJBdHRhY2hTdGRpblwi
+        OmZhbHNlLFwiQXR0YWNoU3Rkb3V0XCI6ZmFsc2UsXCJBdHRhY2hTdGRlcnJc
+        IjpmYWxzZSxcIlBvcnRTcGVjc1wiOm51bGwsXCJFeHBvc2VkUG9ydHNcIjpu
+        dWxsLFwiVHR5XCI6ZmFsc2UsXCJPcGVuU3RkaW5cIjpmYWxzZSxcIlN0ZGlu
+        T25jZVwiOmZhbHNlLFwiRW52XCI6W1wiUEFUSD0vdXNyL2xvY2FsL3NiaW46
+        L3Vzci9sb2NhbC9iaW46L3Vzci9zYmluOi91c3IvYmluOi9zYmluOi9iaW5c
+        Il0sXCJDbWRcIjpudWxsLFwiSW1hZ2VcIjpcImRmNzU0NmY5ZjA2MGEyMjY4
+        MDI0YzhhMjMwZDg2Mzk4Nzg1ODVkZWZjYzFiYzZmNzlkMjcyOGExMzk1Nzg3
+        MWJcIixcIlZvbHVtZXNcIjpudWxsLFwiV29ya2luZ0RpclwiOlwiXCIsXCJF
+        bnRyeXBvaW50XCI6bnVsbCxcIk5ldHdvcmtEaXNhYmxlZFwiOmZhbHNlLFwi
+        TWFjQWRkcmVzc1wiOlwiXCIsXCJPbkJ1aWxkXCI6W10sXCJMYWJlbHNcIjpu
+        dWxsfSxcImFyY2hpdGVjdHVyZVwiOlwiYW1kNjRcIixcIm9zXCI6XCJsaW51
+        eFwiLFwiU2l6ZVwiOjI0Mjk3Mjh9XG4iCiAgICAgIH0sCiAgICAgIHsKICAg
+        ICAgICAgInYxQ29tcGF0aWJpbGl0eSI6ICJ7XCJpZFwiOlwiZGY3NTQ2Zjlm
+        MDYwYTIyNjgwMjRjOGEyMzBkODYzOTg3ODU4NWRlZmNjMWJjNmY3OWQyNzI4
+        YTEzOTU3ODcxYlwiLFwicGFyZW50XCI6XCI1MTExMzZlYTNjNWE2NGYyNjRi
+        NzhiNTQzMzYxNGFlYzU2MzEwM2I0ZDQ3MDJmM2JhN2Q0ZDI2OThlMjJjMTU4
+        XCIsXCJjcmVhdGVkXCI6XCIyMDE0LTEwLTAxVDIwOjQ2OjA3LjI2MzM1MTkx
+        MlpcIixcImNvbnRhaW5lclwiOlwiMjE0N2ExN2NiMWIyZDY2MjZlZDc4ZTVl
+        ZjhiYTRjNzFjZTgyYzg4NGJjM2I1N2FiMDFlNjExNGZmMzU3Y2VhNFwiLFwi
+        Y29udGFpbmVyX2NvbmZpZ1wiOntcIkhvc3RuYW1lXCI6XCIyMTQ3YTE3Y2Ix
+        YjJcIixcIkRvbWFpbm5hbWVcIjpcIlwiLFwiVXNlclwiOlwiXCIsXCJNZW1v
+        cnlcIjowLFwiTWVtb3J5U3dhcFwiOjAsXCJDcHVTaGFyZXNcIjowLFwiQ3B1
+        c2V0XCI6XCJcIixcIkF0dGFjaFN0ZGluXCI6ZmFsc2UsXCJBdHRhY2hTdGRv
+        dXRcIjpmYWxzZSxcIkF0dGFjaFN0ZGVyclwiOmZhbHNlLFwiUG9ydFNwZWNz
+        XCI6bnVsbCxcIkV4cG9zZWRQb3J0c1wiOm51bGwsXCJUdHlcIjpmYWxzZSxc
+        Ik9wZW5TdGRpblwiOmZhbHNlLFwiU3RkaW5PbmNlXCI6ZmFsc2UsXCJFbnZc
+        IjpbXCJQQVRIPS91c3IvbG9jYWwvc2JpbjovdXNyL2xvY2FsL2JpbjovdXNy
+        L3NiaW46L3Vzci9iaW46L3NiaW46L2JpblwiXSxcIkNtZFwiOltcIi9iaW4v
+        c2hcIixcIi1jXCIsXCIjKG5vcCkgTUFJTlRBSU5FUiBKw6lyw7RtZSBQZXRh
+        enpvbmkgXFx1MDAzY2plcm9tZUBkb2NrZXIuY29tXFx1MDAzZVwiXSxcIklt
+        YWdlXCI6XCI1MTExMzZlYTNjNWE2NGYyNjRiNzhiNTQzMzYxNGFlYzU2MzEw
+        M2I0ZDQ3MDJmM2JhN2Q0ZDI2OThlMjJjMTU4XCIsXCJWb2x1bWVzXCI6bnVs
+        bCxcIldvcmtpbmdEaXJcIjpcIlwiLFwiRW50cnlwb2ludFwiOm51bGwsXCJO
+        ZXR3b3JrRGlzYWJsZWRcIjpmYWxzZSxcIk1hY0FkZHJlc3NcIjpcIlwiLFwi
+        T25CdWlsZFwiOltdLFwiTGFiZWxzXCI6bnVsbH0sXCJkb2NrZXJfdmVyc2lv
+        blwiOlwiMS4yLjBcIixcImF1dGhvclwiOlwiSsOpcsO0bWUgUGV0YXp6b25p
+        IFxcdTAwM2NqZXJvbWVAZG9ja2VyLmNvbVxcdTAwM2VcIixcImNvbmZpZ1wi
+        OntcIkhvc3RuYW1lXCI6XCIyMTQ3YTE3Y2IxYjJcIixcIkRvbWFpbm5hbWVc
+        IjpcIlwiLFwiVXNlclwiOlwiXCIsXCJNZW1vcnlcIjowLFwiTWVtb3J5U3dh
+        cFwiOjAsXCJDcHVTaGFyZXNcIjowLFwiQ3B1c2V0XCI6XCJcIixcIkF0dGFj
+        aFN0ZGluXCI6ZmFsc2UsXCJBdHRhY2hTdGRvdXRcIjpmYWxzZSxcIkF0dGFj
+        aFN0ZGVyclwiOmZhbHNlLFwiUG9ydFNwZWNzXCI6bnVsbCxcIkV4cG9zZWRQ
+        b3J0c1wiOm51bGwsXCJUdHlcIjpmYWxzZSxcIk9wZW5TdGRpblwiOmZhbHNl
+        LFwiU3RkaW5PbmNlXCI6ZmFsc2UsXCJFbnZcIjpbXCJQQVRIPS91c3IvbG9j
+        YWwvc2JpbjovdXNyL2xvY2FsL2JpbjovdXNyL3NiaW46L3Vzci9iaW46L3Ni
+        aW46L2JpblwiXSxcIkNtZFwiOm51bGwsXCJJbWFnZVwiOlwiNTExMTM2ZWEz
+        YzVhNjRmMjY0Yjc4YjU0MzM2MTRhZWM1NjMxMDNiNGQ0NzAyZjNiYTdkNGQy
+        Njk4ZTIyYzE1OFwiLFwiVm9sdW1lc1wiOm51bGwsXCJXb3JraW5nRGlyXCI6
+        XCJcIixcIkVudHJ5cG9pbnRcIjpudWxsLFwiTmV0d29ya0Rpc2FibGVkXCI6
+        ZmFsc2UsXCJNYWNBZGRyZXNzXCI6XCJcIixcIk9uQnVpbGRcIjpbXSxcIkxh
+        YmVsc1wiOm51bGx9LFwiYXJjaGl0ZWN0dXJlXCI6XCJhbWQ2NFwiLFwib3Nc
+        IjpcImxpbnV4XCIsXCJTaXplXCI6MH1cbiIKICAgICAgfSwKICAgICAgewog
+        ICAgICAgICAidjFDb21wYXRpYmlsaXR5IjogIntcImlkXCI6XCI1MTExMzZl
+        YTNjNWE2NGYyNjRiNzhiNTQzMzYxNGFlYzU2MzEwM2I0ZDQ3MDJmM2JhN2Q0
+        ZDI2OThlMjJjMTU4XCIsXCJjb21tZW50XCI6XCJJbXBvcnRlZCBmcm9tIC1c
+        IixcImNyZWF0ZWRcIjpcIjIwMTMtMDYtMTNUMTQ6MDM6NTAuODIxNzY5LTA3
+        OjAwXCIsXCJjb250YWluZXJfY29uZmlnXCI6e1wiSG9zdG5hbWVcIjpcIlwi
+        LFwiRG9tYWlubmFtZVwiOlwiXCIsXCJVc2VyXCI6XCJcIixcIk1lbW9yeVwi
+        OjAsXCJNZW1vcnlTd2FwXCI6MCxcIkNwdVNoYXJlc1wiOjAsXCJDcHVzZXRc
+        IjpcIlwiLFwiQXR0YWNoU3RkaW5cIjpmYWxzZSxcIkF0dGFjaFN0ZG91dFwi
+        OmZhbHNlLFwiQXR0YWNoU3RkZXJyXCI6ZmFsc2UsXCJQb3J0U3BlY3NcIjpu
+        dWxsLFwiRXhwb3NlZFBvcnRzXCI6bnVsbCxcIlR0eVwiOmZhbHNlLFwiT3Bl
+        blN0ZGluXCI6ZmFsc2UsXCJTdGRpbk9uY2VcIjpmYWxzZSxcIkVudlwiOm51
+        bGwsXCJDbWRcIjpudWxsLFwiSW1hZ2VcIjpcIlwiLFwiVm9sdW1lc1wiOm51
+        bGwsXCJXb3JraW5nRGlyXCI6XCJcIixcIkVudHJ5cG9pbnRcIjpudWxsLFwi
+        TmV0d29ya0Rpc2FibGVkXCI6ZmFsc2UsXCJNYWNBZGRyZXNzXCI6XCJcIixc
+        Ik9uQnVpbGRcIjpudWxsLFwiTGFiZWxzXCI6bnVsbH0sXCJkb2NrZXJfdmVy
+        c2lvblwiOlwiMC40LjBcIixcImFyY2hpdGVjdHVyZVwiOlwieDg2XzY0XCIs
+        XCJTaXplXCI6MH1cbiIKICAgICAgfQogICBdLAogICAic2NoZW1hVmVyc2lv
+        biI6IDEsCiAgICJzaWduYXR1cmVzIjogWwogICAgICB7CiAgICAgICAgICJo
+        ZWFkZXIiOiB7CiAgICAgICAgICAgICJqd2siOiB7CiAgICAgICAgICAgICAg
+        ICJjcnYiOiAiUC0yNTYiLAogICAgICAgICAgICAgICAia2lkIjogIk9IN0Q6
+        NlY1WjpLVkJUOk5ZVU46V1pUNzozR1VBOk81TEM6UDdFNTpGWk9NOkdRRlU6
+        UFBJVzo3RTM3IiwKICAgICAgICAgICAgICAgImt0eSI6ICJFQyIsCiAgICAg
+        ICAgICAgICAgICJ4IjogIjZWOGpjR0hNZmFIV1diaHE4a1lTcExKOWw1eVVL
+        dlQ5X1hmRi1SSTUwcjgiLAogICAgICAgICAgICAgICAieSI6ICJIVUk4T3Qw
+        Mi1qRmctVWdEdExTbVBDdmUzSV82ZzFjcVlTRG53WndadWxZIgogICAgICAg
+        ICAgICB9LAogICAgICAgICAgICAiYWxnIjogIkVTMjU2IgogICAgICAgICB9
+        LAogICAgICAgICAic2lnbmF0dXJlIjogIjBFYUdUSWpEUlNqb2tfc0N5N0lr
+        QW45OHYxYUR6UXZza2hmbVNxYTNuTW15clNLS1oxdmIxaWZIaTF5XzBDSzNU
+        ZVJtdUotbzdZOTluYjVBZFdVeWdRIiwKICAgICAgICAgInByb3RlY3RlZCI6
+        ICJleUptYjNKdFlYUk1aVzVuZEdnaU9qZzJNREFzSW1admNtMWhkRlJoYVd3
+        aU9pSkRiakFpTENKMGFXMWxJam9pTWpBeE5TMHdOQzB4TjFReE16b3pNam93
+        TlZvaWZRIgogICAgICB9CiAgIF0KfQ==
+    http_version: 
+  recorded_at: Mon, 20 Apr 2015 10:06:20 GMT
+recorded_with: VCR 2.9.3

--- a/spec/vcr_cassettes/registry/get_missing_image_manifest.yml
+++ b/spec/vcr_cassettes/registry/get_missing_image_manifest.yml
@@ -1,0 +1,131 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://registry.test.lan/v2/foo/busybox/manifests/2.0.0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - registry.test.lan
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Docker-Distribution-Api-Version:
+      - registry/2.0
+      Www-Authenticate:
+      - Bearer realm="http://portus.test.lan/v2/token",service="registry.test.lan",scope="repository:foo/busybox:pull"
+      Date:
+      - Mon, 20 Apr 2015 10:11:01 GMT
+      Content-Length:
+      - '170'
+    body:
+      encoding: UTF-8
+      string: |
+        {"errors":[{"code":"UNAUTHORIZED","message":"access to the requested resource is not authorized","detail":[{"Type":"repository","Name":"foo/busybox","Action":"pull"}]}]}
+    http_version: 
+  recorded_at: Mon, 20 Apr 2015 10:11:01 GMT
+- request:
+    method: get
+    uri: http://flavio:this%20is%20a%20test@portus.test.lan/v2/token?account=flavio&scope=repository:foo/busybox:pull&service=registry.test.lan
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - portus.test.lan
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 20 Apr 2015 10:11:01 GMT
+      Server:
+      - Apache
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Runtime:
+      - '0.158316'
+      X-Request-Id:
+      - 03b8ee44-3dee-4506-9236-495bb9e901b4
+      Connection:
+      - close
+      X-Powered-By:
+      - Phusion Passenger 5.0.6
+      Set-Cookie:
+      - _portus_session=K2RkaUU3V0RCWjJMUVBDaGhRTG9jUXBBbk5rL2lZZG5YOTZmY3ZpMEE5M2hRU01HOXFxcGhsckxSandVNlRSMkd6QVNNM0tJd2FyVFJvRnVDNHlYRHc9PS0tQ0ZFV0pRSHBjR1RuSWdFN1N1NHI5UT09--b166fb80ecc5d0f214f2d4a8217c73f436c5619f;
+        path=/; HttpOnly
+      Etag:
+      - W/"0894f6876bc8e50af7444c78d307b20e"
+      Status:
+      - 200 OK
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlBUV1Q6Rk5KRTo3VFc3OlVMSTc6RFpRQTpKSkpJOlJESlE6Mk03NjpIRDZHOlpSU0M6VlBJRjpPNUJVIn0.eyJpc3MiOiJwb3J0dXMudGVzdC5sYW4iLCJzdWIiOiJmbGF2aW8iLCJhdWQiOiJyZWdpc3RyeS50ZXN0LmxhbiIsImV4cCI6MTQyOTUyNDk2MSwibmJmIjoxNDI5NTI0NjYxLCJpYXQiOjE0Mjk1MjQ2NjEsImp0aSI6Ijl4ak16VEJ1YnFZRDJKM1JzcHlLWVJkZWFGcWVEUllRRlk0R1BlajdabSIsImFjY2VzcyI6W3sidHlwZSI6InJlcG9zaXRvcnkiLCJuYW1lIjoiZm9vL2J1c3lib3giLCJhY3Rpb25zIjpbInB1bGwiXX1dfQ.o5oDGAeMSsmjVBaCK0JAfBheH7lPlR0HvjCq5pV-i6pDvcZ3V5thMBLBxaxxMJ0oX2WB3U9tjjQs7nSnYaGu-4-WFHBOYnDYHIB0tAQUBryelPc_bfwbp85Jkg4IDXhxDvOjJUkmZOcLhRW1saQSs4Y55rpHDKSb8W2R4JfZCxIBD0FlFh5Wl2ypj3zddVqO__SN4vSv9s70xLJFI-4Dk4XWU5mV0m4rHfZjpG4bplmfdmeEww_bnnZ0AN6AaW3KR-wk_6jsQzK_HVE9BiB9GlZT7okvpjJQlgNM1k2MBg4A-Ecc2KdbqEokN9t5KOGAqN6UZKHE9gVbOsYQvR-xJeUOGB3xFQAF6INRZkyk8CTbsNTFcTOslRAMt_dTVcKeDnRheZY9aTNgI7WxthNu93-zt8O9jbOpfQphjylAI-gtKulbDPmKChhSJglX6rkKaEDhhJzGbnGYYLXRroFHhbnuKRh7uJrBYdDEVJqyk8hE6iQp2ON2ZEvQTjpYd_ZX8rMeFrraCaxcKm-zQdjqfx0co3kB8YdF6ujRnQdXssPqHF4IXvfE5DKY9Uo2brhqFmoCYaDta9uRRiy19MYwVCiMKpDYHs_NrygLVnbtr8ECJ9sol7x1yyH06Dw6boJET9DEIy4aH1bdkY5WPoKCM2qdbODC7MBgpY2sTJfzEZY"}'
+    http_version: 
+  recorded_at: Mon, 20 Apr 2015 10:11:01 GMT
+- request:
+    method: get
+    uri: http://registry.test.lan/v2/foo/busybox/manifests/2.0.0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - registry.test.lan
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlBUV1Q6Rk5KRTo3VFc3OlVMSTc6RFpRQTpKSkpJOlJESlE6Mk03NjpIRDZHOlpSU0M6VlBJRjpPNUJVIn0.eyJpc3MiOiJwb3J0dXMudGVzdC5sYW4iLCJzdWIiOiJmbGF2aW8iLCJhdWQiOiJyZWdpc3RyeS50ZXN0LmxhbiIsImV4cCI6MTQyOTUyNDk2MSwibmJmIjoxNDI5NTI0NjYxLCJpYXQiOjE0Mjk1MjQ2NjEsImp0aSI6Ijl4ak16VEJ1YnFZRDJKM1JzcHlLWVJkZWFGcWVEUllRRlk0R1BlajdabSIsImFjY2VzcyI6W3sidHlwZSI6InJlcG9zaXRvcnkiLCJuYW1lIjoiZm9vL2J1c3lib3giLCJhY3Rpb25zIjpbInB1bGwiXX1dfQ.o5oDGAeMSsmjVBaCK0JAfBheH7lPlR0HvjCq5pV-i6pDvcZ3V5thMBLBxaxxMJ0oX2WB3U9tjjQs7nSnYaGu-4-WFHBOYnDYHIB0tAQUBryelPc_bfwbp85Jkg4IDXhxDvOjJUkmZOcLhRW1saQSs4Y55rpHDKSb8W2R4JfZCxIBD0FlFh5Wl2ypj3zddVqO__SN4vSv9s70xLJFI-4Dk4XWU5mV0m4rHfZjpG4bplmfdmeEww_bnnZ0AN6AaW3KR-wk_6jsQzK_HVE9BiB9GlZT7okvpjJQlgNM1k2MBg4A-Ecc2KdbqEokN9t5KOGAqN6UZKHE9gVbOsYQvR-xJeUOGB3xFQAF6INRZkyk8CTbsNTFcTOslRAMt_dTVcKeDnRheZY9aTNgI7WxthNu93-zt8O9jbOpfQphjylAI-gtKulbDPmKChhSJglX6rkKaEDhhJzGbnGYYLXRroFHhbnuKRh7uJrBYdDEVJqyk8hE6iQp2ON2ZEvQTjpYd_ZX8rMeFrraCaxcKm-zQdjqfx0co3kB8YdF6ujRnQdXssPqHF4IXvfE5DKY9Uo2brhqFmoCYaDta9uRRiy19MYwVCiMKpDYHs_NrygLVnbtr8ECJ9sol7x1yyH06Dw6boJET9DEIy4aH1bdkY5WPoKCM2qdbODC7MBgpY2sTJfzEZY
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Docker-Distribution-Api-Version:
+      - registry/2.0
+      Date:
+      - Mon, 20 Apr 2015 10:11:01 GMT
+      Content-Length:
+      - '125'
+      Content-Type:
+      - text/plain; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: |
+        {"errors":[{"code":"MANIFEST_UNKNOWN","message":"manifest unknown","detail":"unknown manifest name=foo/busybox tag=2.0.0"}]}
+    http_version: 
+  recorded_at: Mon, 20 Apr 2015 10:11:01 GMT
+recorded_with: VCR 2.9.3

--- a/spec/vcr_cassettes/registry/missing_credentials.yml
+++ b/spec/vcr_cassettes/registry/missing_credentials.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://registry.test.lan/v2/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - registry.test.lan
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Docker-Distribution-Api-Version:
+      - registry/2.0
+      Www-Authenticate:
+      - Bearer realm="http://portus.test.lan/v2/token",service="registry.test.lan"
+      Date:
+      - Mon, 20 Apr 2015 10:28:38 GMT
+      Content-Length:
+      - '114'
+    body:
+      encoding: UTF-8
+      string: |
+        {"errors":[{"code":"UNAUTHORIZED","message":"access to the requested resource is not authorized","detail":null}]}
+    http_version: 
+  recorded_at: Mon, 20 Apr 2015 10:28:38 GMT
+recorded_with: VCR 2.9.3

--- a/spec/vcr_cassettes/registry/successful_authentication.yml
+++ b/spec/vcr_cassettes/registry/successful_authentication.yml
@@ -1,0 +1,130 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://registry.test.lan/v2/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - registry.test.lan
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Docker-Distribution-Api-Version:
+      - registry/2.0
+      Www-Authenticate:
+      - Bearer realm="http://portus.test.lan/v2/token",service="registry.test.lan"
+      Date:
+      - Mon, 20 Apr 2015 09:44:11 GMT
+      Content-Length:
+      - '114'
+    body:
+      encoding: UTF-8
+      string: |
+        {"errors":[{"code":"UNAUTHORIZED","message":"access to the requested resource is not authorized","detail":null}]}
+    http_version: 
+  recorded_at: Mon, 20 Apr 2015 09:44:11 GMT
+- request:
+    method: get
+    uri: http://flavio:this%20is%20a%20test@portus.test.lan/v2/token?account=flavio&service=registry.test.lan
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - portus.test.lan
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 20 Apr 2015 09:44:11 GMT
+      Server:
+      - Apache
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Runtime:
+      - '0.309957'
+      X-Request-Id:
+      - ebea8bde-1cfd-418a-a8aa-5429402f2803
+      Connection:
+      - close
+      X-Powered-By:
+      - Phusion Passenger 5.0.6
+      Set-Cookie:
+      - _portus_session=eGsxNDBXWUtQTkp6MGhXVUVBWWdjL2ZIenZRaTYzT2ZnbzRpSWtxZk00TnA4aW5qNS9KUDRmY1NSTEZZamhuWFFORGgvT280VkgvczZDb3RVbVltd1E9PS0tbUdDRWY4MkVPMFdCOWhHcHQ1aFJiUT09--19afe7c43ac1fe3294746168f90733bede7f4237;
+        path=/; HttpOnly
+      Etag:
+      - W/"c3df63603e82f374bbefa71358bb7886"
+      Status:
+      - 200 OK
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlBUV1Q6Rk5KRTo3VFc3OlVMSTc6RFpRQTpKSkpJOlJESlE6Mk03NjpIRDZHOlpSU0M6VlBJRjpPNUJVIn0.eyJpc3MiOiJwb3J0dXMudGVzdC5sYW4iLCJzdWIiOiJmbGF2aW8iLCJhdWQiOiJyZWdpc3RyeS50ZXN0LmxhbiIsImV4cCI6MTQyOTUyMzM1MiwibmJmIjoxNDI5NTIzMDUyLCJpYXQiOjE0Mjk1MjMwNTIsImp0aSI6Inc4YnRUaUVTaDN4TWNYdU5YWlBtZWE5cXRhZWdzRVNOUG9BaFZMNHl3RyJ9.krXq32ehbyly6BXr5sQUwKbvzvY7eyt8Vj3odwffWp7bO-Ysl7Whv0LJcENSw-BStgkiwKPlkMX4oUhQAa0r8EHkDjgJJ2lZWDEsyz5XIoBX2MsNGR4sZLs-gvNTw0X5Pugt2KGlCUbxxxOavSgBiKZmGKh3jvZQdQekKjo8wZUsTCLpMP0efj6LNvNcc3Vb_9Fw7mV3G4TLdopajVX3h2SMNZerOb3KLzjtOmnsV3dqTI69cXRFzCj4Jt7uSq2TsETbx2__UkY0EObuY6_jS0QqDqHpVRxhpZeJRw1pSngZJ6P2mh4iFg-Uhpl2qrF4c3aEbgIW50F9gIkBySY9o77TweagDjIaTy7E9nGRwJToVT8dY-Nm6X7--AFDEQk_VH3IJro8_yx88yR44RPRmh4aEiF6WCQAo87v6YJmMICotBQnUxtRyiwGcAhrbfEI5FuYOZ52_dqJyCOfKOnvqguau_Nv4_85xIzAV4gZaKs0s3qMYuVfcxQDWmqIp1jy7HOH9vQST-GLaa--boX_5am6qjOopLFVXj108FS-moOu9SIOPqRDqF0ZpVDlBsHXviqdPOaItwhh0z4IkfHv1Ngq8EdyWT2-AqZ7W410knA_nOX2jzPreJFbWYVQYhdxQceT9tD4mbePg1qlGY1SGH8NqqI8CHjmuezIo1SLijY"}'
+    http_version: 
+  recorded_at: Mon, 20 Apr 2015 09:44:12 GMT
+- request:
+    method: get
+    uri: http://registry.test.lan/v2/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - registry.test.lan
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlBUV1Q6Rk5KRTo3VFc3OlVMSTc6RFpRQTpKSkpJOlJESlE6Mk03NjpIRDZHOlpSU0M6VlBJRjpPNUJVIn0.eyJpc3MiOiJwb3J0dXMudGVzdC5sYW4iLCJzdWIiOiJmbGF2aW8iLCJhdWQiOiJyZWdpc3RyeS50ZXN0LmxhbiIsImV4cCI6MTQyOTUyMzM1MiwibmJmIjoxNDI5NTIzMDUyLCJpYXQiOjE0Mjk1MjMwNTIsImp0aSI6Inc4YnRUaUVTaDN4TWNYdU5YWlBtZWE5cXRhZWdzRVNOUG9BaFZMNHl3RyJ9.krXq32ehbyly6BXr5sQUwKbvzvY7eyt8Vj3odwffWp7bO-Ysl7Whv0LJcENSw-BStgkiwKPlkMX4oUhQAa0r8EHkDjgJJ2lZWDEsyz5XIoBX2MsNGR4sZLs-gvNTw0X5Pugt2KGlCUbxxxOavSgBiKZmGKh3jvZQdQekKjo8wZUsTCLpMP0efj6LNvNcc3Vb_9Fw7mV3G4TLdopajVX3h2SMNZerOb3KLzjtOmnsV3dqTI69cXRFzCj4Jt7uSq2TsETbx2__UkY0EObuY6_jS0QqDqHpVRxhpZeJRw1pSngZJ6P2mh4iFg-Uhpl2qrF4c3aEbgIW50F9gIkBySY9o77TweagDjIaTy7E9nGRwJToVT8dY-Nm6X7--AFDEQk_VH3IJro8_yx88yR44RPRmh4aEiF6WCQAo87v6YJmMICotBQnUxtRyiwGcAhrbfEI5FuYOZ52_dqJyCOfKOnvqguau_Nv4_85xIzAV4gZaKs0s3qMYuVfcxQDWmqIp1jy7HOH9vQST-GLaa--boX_5am6qjOopLFVXj108FS-moOu9SIOPqRDqF0ZpVDlBsHXviqdPOaItwhh0z4IkfHv1Ngq8EdyWT2-AqZ7W410knA_nOX2jzPreJFbWYVQYhdxQceT9tD4mbePg1qlGY1SGH8NqqI8CHjmuezIo1SLijY
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+      Docker-Distribution-Api-Version:
+      - registry/2.0
+      Date:
+      - Mon, 20 Apr 2015 09:44:12 GMT
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Mon, 20 Apr 2015 09:44:12 GMT
+recorded_with: VCR 2.9.3

--- a/spec/vcr_cassettes/registry/wrong_authentication.yml
+++ b/spec/vcr_cassettes/registry/wrong_authentication.yml
@@ -1,0 +1,92 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://registry.test.lan/v2/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - registry.test.lan
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Docker-Distribution-Api-Version:
+      - registry/2.0
+      Www-Authenticate:
+      - Bearer realm="http://portus.test.lan/v2/token",service="registry.test.lan"
+      Date:
+      - Mon, 20 Apr 2015 09:49:56 GMT
+      Content-Length:
+      - '114'
+    body:
+      encoding: UTF-8
+      string: |
+        {"errors":[{"code":"UNAUTHORIZED","message":"access to the requested resource is not authorized","detail":null}]}
+    http_version: 
+  recorded_at: Mon, 20 Apr 2015 09:49:56 GMT
+- request:
+    method: get
+    uri: http://flavio:wrong%20password@portus.test.lan/v2/token?account=flavio&service=registry.test.lan
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - portus.test.lan
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Date:
+      - Mon, 20 Apr 2015 09:49:56 GMT
+      Server:
+      - Apache
+      Cache-Control:
+      - no-cache
+      X-Runtime:
+      - '0.086172'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Www-Authenticate:
+      - Basic realm="Application"
+      X-Request-Id:
+      - d02be261-0671-4a97-864c-9648121dee2b
+      Connection:
+      - close
+      X-Powered-By:
+      - Phusion Passenger 5.0.6
+      Status:
+      - 401 Unauthorized
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"error":"Invalid username or password."}'
+    http_version: 
+  recorded_at: Mon, 20 Apr 2015 09:49:57 GMT
+recorded_with: VCR 2.9.3


### PR DESCRIPTION
Add Registry class. This can be used to fetch additional information
from a Docker registry v2 using its API.

Right now the Registry class can authenticate against the registry and
fetch the manifest of a Docker image available on the it.