### PR TITLE
Team roles

### DIFF
--- a/app/controllers/api/v2/tokens_controller.rb
+++ b/app/controllers/api/v2/tokens_controller.rb
@@ -4,7 +4,6 @@ class Api::V2::TokensController < Api::BaseController
 
   def show
     if params[:scope]
-      logger.info "SCOPE is #{params[:scope]}"
       auth_scope, scopes = scope_handler(params[:scope])
       scopes.each do |scope|
         authorize auth_scope.resource, "#{scope}?".to_sym

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -4,10 +4,13 @@ class Team < ActiveRecord::Base
 
   has_many :namespaces
 
-  # Users & owners
   has_many :team_users
   has_many :users, through: :team_users
-  has_many :owners, -> { where 'team_users.owner': true },
+  has_many :owners, -> { where 'team_users.role' => TeamUser.roles['owner'] },
+    through: :team_users, source: :user
+  has_many :contributors, -> { where 'team_users.role' => TeamUser.roles['contributor'] },
+    through: :team_users, source: :user
+  has_many :viewers, -> { where 'team_users.role' => TeamUser.roles['viewer'] },
     through: :team_users, source: :user
 
   before_create :downcase?

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -15,6 +15,10 @@ class Team < ActiveRecord::Base
 
   before_create :downcase?
 
+  def create_team_namespace!
+    Namespace.find_or_create_by!(team: self, name: name)
+  end
+
   private
 
   def downcase?

--- a/app/models/team_user.rb
+++ b/app/models/team_user.rb
@@ -1,4 +1,12 @@
+# Class describing a memeber of a team
+
+# Meaning of the role column:
+#   * viewer: has RO access to the namespaces associated with the team
+#   * contributor: has RW access to the namespaces associated with the team
+#   * owner: like contributor, but can also manage the team
 class TeamUser < ActiveRecord::Base
+  enum role: [:viewer, :contributor, :owner]
+
   belongs_to :team
   belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,12 +8,10 @@ class User < ActiveRecord::Base
   has_many :team_users
   has_many :teams, through: :team_users
 
-  def create_personal_namespace!
-    team = Team.find_by(name: username)
-    if team.nil?
-      team = Team.create!(name: username, owners: [self])
+  def create_personal_team!
+    if Team.find_by(name: username).nil?
+      Team.create!(name: username, owners: [self])
     end
-    Namespace.find_or_create_by!(team: team, name: username)
   end
 
   def personal_namespace

--- a/app/observers/team_observer.rb
+++ b/app/observers/team_observer.rb
@@ -1,0 +1,7 @@
+class TeamObserver < ActiveRecord::Observer
+
+  def after_create(team)
+    team.create_team_namespace!
+  end
+
+end

--- a/app/observers/user_observer.rb
+++ b/app/observers/user_observer.rb
@@ -1,7 +1,7 @@
 class UserObserver < ActiveRecord::Observer
 
   def after_create(user)
-    user.create_personal_namespace!
+    user.create_personal_team!
   end
 
 end

--- a/app/policies/namespace_policy.rb
+++ b/app/policies/namespace_policy.rb
@@ -8,11 +8,14 @@ class NamespacePolicy
   end
 
   def pull?
-    push?
+    # All the members of the team have READ access
+    namespace.team.users.exists?(user.id)
   end
 
   def push?
-    namespace.team.users.exists?(user.id)
+    # only owners and contributors have WRITE access
+    namespace.team.owners.exists?(user.id) ||
+    namespace.team.contributors.exists?(user.id)
   end
 
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,6 +23,6 @@ module Portus
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
 
-    config.active_record.observers = :user_observer
+    config.active_record.observers = :user_observer, :team_observer
   end
 end

--- a/db/migrate/20150429102443_add_role_to_team_user.rb
+++ b/db/migrate/20150429102443_add_role_to_team_user.rb
@@ -1,0 +1,6 @@
+class AddRoleToTeamUser < ActiveRecord::Migration
+  def change
+    add_column :team_users, :role, :integer, default: TeamUser.roles['viewer']
+    remove_column :team_users, :owner
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150428081530) do
+ActiveRecord::Schema.define(version: 20150429102443) do
 
   create_table "namespaces", force: :cascade do |t|
     t.string   "name"
@@ -45,9 +45,9 @@ ActiveRecord::Schema.define(version: 20150428081530) do
   create_table "team_users", force: :cascade do |t|
     t.integer  "user_id"
     t.integer  "team_id"
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
-    t.boolean  "owner",      default: false
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
+    t.integer  "role",       default: 0
   end
 
   add_index "team_users", ["team_id"], name: "index_team_users_on_team_id"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -14,7 +14,7 @@ describe User do
       team = Team.find_by!(name: subject.username)
       Namespace.find_by!(name: subject.username)
       tu = TeamUser.find_by!(user: subject, team: team)
-      assert tu.owner
+      expect(team.owners).to include(subject)
     end
 
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,13 +7,13 @@ describe User do
   it { should validate_uniqueness_of(:email) }
   it { should validate_uniqueness_of(:username) }
 
-  describe '#create_personal_namespace!' do
+  describe '#create_personal_team!' do
 
     it 'creates a team and a namespace with the name of username' do
-      subject.create_personal_namespace!
+      subject.create_personal_team!
       team = Team.find_by!(name: subject.username)
       Namespace.find_by!(name: subject.username)
-      tu = TeamUser.find_by!(user: subject, team: team)
+      TeamUser.find_by!(user: subject, team: team)
       expect(team.owners).to include(subject)
     end
 

--- a/spec/observers/user_observer_spec.rb
+++ b/spec/observers/user_observer_spec.rb
@@ -6,8 +6,8 @@ describe UserObserver do
 
   describe 'after_create' do
 
-    it 'calls create_personal_namespace! on a user' do
-      expect(user).to receive(:create_personal_namespace!)
+    it 'calls create_personal_team! on a user' do
+      expect(user).to receive(:create_personal_team!)
       described_class.instance.after_create(user)
     end
 


### PR DESCRIPTION
This PR introduces the concept of user roles within a team, as requested by the 1st milestone (see issue #16).

A team can have three types of users:
  * viewers: RO access
  * contributors: RW access
  * owners: like contributors, but have also access to the admin panel of the team