### PR TITLE
Show the 'owned by' information when displaying namespaces

### DIFF
--- a/app/views/namespaces/_namespace.html.slim
+++ b/app/views/namespaces/_namespace.html.slim
@@ -1,5 +1,7 @@
 tr[id="namespace_#{namespace.id}"]
   td= link_to namespace.name, namespace
+  - if show_owner
+    td= link_to namespace.team.name, namespace.team
   td= namespace.repositories.count
   td
     - if is_namespace_owner?(namespace)

--- a/app/views/namespaces/index.html.slim
+++ b/app/views/namespaces/index.html.slim
@@ -9,13 +9,15 @@ p A namespace groups a series of repositories.
     .table-responsive
       table[class="table table-stripped table-hover"]
         col.col-50
-        col.col-40
+        col.col-20
+        col.col-20
         col.col-10
         thead
           tr
             th Name
+            th Owner
             th Repositories
             th Public
         tbody
           - @namespaces.each do |namespace|
-            = render(namespace)
+            = render partial: 'namespace', locals: { show_owner: true, namespace: namespace}

--- a/app/views/namespaces/show.html.slim
+++ b/app/views/namespaces/show.html.slim
@@ -1,6 +1,14 @@
+h1= "Namespace #{@namespace.name}"
+
+- if @namespace.name != current_user.username
+  p
+    | This namespace is owned by the 
+    = link_to @namespace.team.name, @namespace.team
+    |  team.
+
 .[class="panel panel-default"]
   .panel-heading
-    h1= "Namespace #{@namespace.name}"
+    h3[class='panel-title panel-heading'] Repositories part of '#{@namespace.name}'
   .panel-body
     .table-responsive
       table[class="table table-stripped table-hover"]

--- a/app/views/teams/show.html.slim
+++ b/app/views/teams/show.html.slim
@@ -102,4 +102,4 @@ p It is possible to add read only (pull) access to all Portus users by toggling
             th Public
         tbody#namespaces
           - @team.namespaces.each do |namespace|
-            = render(namespace)
+            = render partial: 'namespaces/namespace', locals: { show_owner: false, namespace: namespace }


### PR DESCRIPTION
This fixes issue #37 

## Namespaces index

I don't know how to hide the owner for personal repositories in a nice way...

![namespace index](https://cloud.githubusercontent.com/assets/22728/7515582/82d2d248-f4c8-11e4-8356-d6449262af4b.png)

## Namespace show

### Personal namespace 

No information is shown

![personal namespace](https://cloud.githubusercontent.com/assets/22728/7515592/98eddd02-f4c8-11e4-8b53-28952f6e5e42.png)

### Non personal namespace

Information is shown. I am not really happy about how we are showing it though,

![team namespace](https://cloud.githubusercontent.com/assets/22728/7515599/aaa9bfa2-f4c8-11e4-9d1c-59314f72faf2.png)


