### PR TITLE
Reset the values of the forms for creating teams, namespaces and members

### DIFF
--- a/app/assets/javascripts/teams.js.coffee
+++ b/app/assets/javascripts/teams.js.coffee
@@ -1,9 +1,12 @@
 $(document).on "page:change", ->
   $('#add_team_user_btn').on 'click', (event) =>
+    $('#team_user_user').val('')
+    $('#team_user_role').val('viewer')
     $('#add_team_user_form').toggle 400, "swing", ->
-      if $('#add_team_user_form').css("display") == "block"
+      if $('#add_team_user_form').is(':visible')
         $('#add_team_user_btn i').addClass("fa-chevron-up")
         $('#add_team_user_btn i').removeClass("fa-chevron-down")
+        $('#team_user_user').focus()
       else
         $('#add_team_user_btn i').removeClass("fa-chevron-up")
         $('#add_team_user_btn i').addClass("fa-chevron-down")
@@ -14,19 +17,23 @@ $(document).on "page:change", ->
       $('#change_role_team_user_' + event.currentTarget.value).toggle()
 
   $('#add_namespace_btn').on 'click', (event) =>
+    $('#namespace_namespace').val('')
     $('#add_namespace_form').toggle 400, "swing", ->
       if $('#add_namespace_form').is(':visible')
         $('#add_namespace_btn i').addClass("fa-chevron-up")
         $('#add_namespace_btn i').removeClass("fa-chevron-down")
+        $('#namespace_namespace').focus()
       else
         $('#add_namespace_btn i').removeClass("fa-chevron-up")
         $('#add_namespace_btn i').addClass("fa-chevron-down")
 
   $('#add_team_btn').on 'click', (event) =>
+    $('#team_name').val('')
     $('#add_team_form').toggle 400, "swing", ->
       if $('#add_team_form').is(':visible')
         $('#add_team_btn i').addClass("fa-chevron-up")
         $('#add_team_btn i').removeClass("fa-chevron-down")
+        $('#team_name').focus()
       else
         $('#add_team_btn i').removeClass("fa-chevron-up")
         $('#add_team_btn i').addClass("fa-chevron-down")

--- a/app/views/teams/index.html.slim
+++ b/app/views/teams/index.html.slim
@@ -1,7 +1,7 @@
 .clearfix
   .pull-right
     a#add_team_btn[class="btn btn-primary js-toggle-button" role="button"]
-      | Create 
+      | Create
       i[class="fa fa-chevron-down"]
 
 #add_team_form[class="collapse"]
@@ -9,7 +9,7 @@
       .form-group
         = f.label :name, {class: 'control-label col-md-2'}
         .col-md-7
-          = f.text_field(:name, class: 'form-control')
+          = f.text_field(:name, class: 'form-control', required: true)
       .form-group
         .[class='col-md-offset-2 col-md-7']
           = f.submit('Add', class: 'btn btn-primary')

--- a/app/views/teams/show.html.slim
+++ b/app/views/teams/show.html.slim
@@ -18,7 +18,7 @@ ul
   .clearfix
     .pull-right
       a[id="add_team_user_btn" class="btn btn-primary js-toggle-button" role="button"]
-        | Add members 
+        | Add members
         i[class="fa fa-chevron-down"]
   .[id="add_team_user_form" class="collapse"]
     = form_for :team_user, url: team_users_path, remote: true, html: {id: 'new-team-user-form', class: 'form-horizontal', role: 'form'} do |f|
@@ -30,7 +30,7 @@ ul
       .form-group
         = f.label :user, {class: 'control-label col-md-2'}
         .col-md-7
-          = f.text_field(:user, class: 'form-control', placeholder: 'Name')
+          = f.text_field(:user, class: 'form-control', placeholder: 'Name', required: true)
       .form-group
         .[class='col-md-offset-2 col-md-7']
           = f.submit('Add', class: 'btn btn-primary')
@@ -72,7 +72,7 @@ p It is possible to add read only (pull) access to all Portus users by toggling
   .clearfix
     .pull-right
       a[id="add_namespace_btn" class="btn btn-primary js-toggle-button" role="button"]
-        | Add namespace 
+        | Add namespace
         i[class="fa fa-chevron-down"]
   .[id="add_namespace_form" class="collapse"]
     = form_for :namespace, url: namespaces_path, remote: true, html: {id: 'new-namespace-form', class: 'form-horizontal', role: 'form'} do |f|
@@ -80,7 +80,7 @@ p It is possible to add read only (pull) access to all Portus users by toggling
       .form-group
         = f.label :namespace, {class: 'control-label col-md-2'}
         .col-md-7
-          = f.text_field(:namespace, class: 'form-control', placeholder: 'Name')
+          = f.text_field(:namespace, class: 'form-control', placeholder: 'Name', required: true)
       .form-group
         .[class='col-md-offset-2 col-md-7']
           = f.submit('Add', class: 'btn btn-primary')


### PR DESCRIPTION
This commit also adds the 'required' attribute where needed and it sets the
focus on the element to be filled.

Signed-off-by: Miquel Sabaté <mikisabate@gmail.com>