### PR TITLE
UI: review how to change the public attribute of a namespace

### DIFF
--- a/app/assets/javascripts/namespaces.js.coffee
+++ b/app/assets/javascripts/namespaces.js.coffee
@@ -1,0 +1,5 @@
+$(document).on "page:change", ->
+  for btn_edit_namespace in $(".btn-edit-namespace")
+    $(btn_edit_namespace).on 'click', (event) =>
+      $('#namespace_' + event.currentTarget.value + ' td .visibility').toggle()
+      $('#change_namespace_' + event.currentTarget.value).toggle()

--- a/app/views/namespaces/_namespace.html.slim
+++ b/app/views/namespaces/_namespace.html.slim
@@ -2,13 +2,20 @@ tr[id="namespace_#{namespace.id}"]
   td= link_to namespace.name, namespace
   td= namespace.repositories.count
   td
-    - if is_namespace_owner?(namespace)
+    .visibility
+      i[class="fa fa-eye#{namespace.public? ? '': '-slash'} fa-lg"]
+    .[id="change_namespace_#{namespace.id}" class="collapse"]
       a[class="btn btn-default"
-          data-remote="true"
-          data-method="put"
-          rel="nofollow"
-          href=url_for(toggle_public_namespace_path(namespace))
-          ]
+        data-remote="true"
+        data-method="put"
+        rel="nofollow"
+        href=url_for(toggle_public_namespace_path(namespace))]
           i[class="fa fa-toggle-#{namespace.public? ? 'on': 'off'} fa-lg"]
+  td
+    - if is_namespace_owner?(namespace)
+      button[class="btn btn-default btn-edit-namespace" value="#{namespace.id}"]
+        i[class="fa fa-pencil fa-lg"]
     - else
-      i[class="fa fa-toggle-#{namespace.public? ? 'on': 'off'} fa-lg"]
+      button[class="btn btn-default btn-edit-namespace" disabled]
+        i[class="fa fa-pencil fa-lg"]
+

--- a/app/views/namespaces/index.html.slim
+++ b/app/views/namespaces/index.html.slim
@@ -9,13 +9,15 @@ p A namespace groups a series of repositories.
     .table-responsive
       table[class="table table-stripped table-hover"]
         col.col-50
-        col.col-40
+        col.col-30
+        col.col-10
         col.col-10
         thead
           tr
             th Name
             th Repositories
             th Public
+            th Edit
         tbody
           - @namespaces.each do |namespace|
             = render(namespace)

--- a/app/views/namespaces/toggle_public.js.erb
+++ b/app/views/namespaces/toggle_public.js.erb
@@ -1,5 +1,7 @@
-$('#namespace_<%= namespace.id %> td a i').addClass("fa-toggle-<%= namespace.public? ? 'on' : 'off' %>");
-$('#namespace_<%= namespace.id %> td a i').removeClass("fa-toggle-<%= namespace.public? ? 'off' : 'on' %>");
+$('#namespace_<%= namespace.id %> td .visibility i').addClass("fa-eye<%= namespace.public? ? '' : '-slash' %>");
+$('#namespace_<%= namespace.id %> td .visibility i').removeClass("fa-eye<%= namespace.public? ? '-slash' : '' %>");
 
 $('#notice p').html("Namespace '<%= namespace.name %>' is now <%= namespace.public? ? 'public' : 'private' %>");
 $('#notice').fadeIn();
+$('#namespace_<%= namespace.id %> td .visibility').toggle();
+$('#change_namespace_<%= namespace.id %>').toggle();

--- a/app/views/team_users/_team_user.html.slim
+++ b/app/views/team_users/_team_user.html.slim
@@ -8,7 +8,6 @@ tr[id="team_user_#{team_user.id}"]
           = f.select(:role, TeamUser.roles.keys.map {|role| [role.titleize,role]}, {}, {class: 'form-control'})
           .[class='col-md-offset-2 col-md-7']
         = f.submit('Save', class: 'btn btn-primary')
-        .errors
   - if is_team_owner?(team_user.team)
     td
       button[class="btn btn-default btn-edit-role"

--- a/app/views/teams/show.html.slim
+++ b/app/views/teams/show.html.slim
@@ -93,13 +93,15 @@ p It is possible to add read only (pull) access to all Portus users by toggling
       table[class="table table-striped table-hover"]
         colgroup
           col.col-50
-          col.col-40
+          col.col-30
+          col.col-10
           col.col-10
         thead
           tr
             th Namespace
             th Repositories
             th Public
+            th Edit
         tbody#namespaces
           - @team.namespaces.each do |namespace|
             = render(namespace)


### PR DESCRIPTION
Made everything more consistent with the rest of the UI.

## When showing namespaces

The 'edit' button is enabled only for the users with the appropriate rights.

![namespace edit index](https://cloud.githubusercontent.com/assets/22728/7518224/fbbc2676-f4d9-11e4-81d7-505e33f9ac00.png)

## Edit mode enabled

The old switch is shown

![namespace edit mode](https://cloud.githubusercontent.com/assets/22728/7518234/057a72b2-f4da-11e4-983a-07f023de3ef9.png)

## Switch clicked

A notification is shown (like before). The switch disappears and the "eye" icon is shown, the value of the eye reflects the new status of the namespace.
