### PR TITLE
Make admin a 1st class citizen

### DIFF
--- a/app/assets/stylesheets/variables.css.less
+++ b/app/assets/stylesheets/variables.css.less
@@ -98,9 +98,9 @@
 
 // overview
 @overview-icon-color:                   @white;
-@overview-icon-times-contacted-bg:      @blue;
-@overview-icon-visits-bg:               @dark-green;
-@overview-icon-new-articles-bg:         @orange;
+@overview-icon-users-bg:                @blue;
+@overview-icon-teams-bg:                @dark-green;
+@overview-icon-namespaces-bg:           @orange;
 @overview-icon-popular-article-bg:      @purple;
 
 

--- a/app/assets/stylesheets/vendor/panels.css.less
+++ b/app/assets/stylesheets/vendor/panels.css.less
@@ -104,14 +104,14 @@
     height: 2em;
     text-align: center;
 //    .fa-2x;
-    &.times-visited {
-      background: @overview-icon-times-contacted-bg;
+    &.users {
+      background: @overview-icon-users-bg;
     }
-    &.visits {
-      background: @overview-icon-visits-bg;
+    &.teams {
+      background: @overview-icon-teams-bg;
     }
-    &.new-articles {
-      background: @overview-icon-new-articles-bg;
+    &.namespaces {
+      background: @overview-icon-namespaces-bg;
     }
     &.popular-article {
       background: @overview-icon-popular-article-bg;

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,0 +1,10 @@
+class Admin::BaseController < ApplicationController
+  before_action :ensure_admin!
+
+  protected
+
+  def ensure_admin!
+    deny_access unless current_user.admin?
+  end
+
+end

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,0 +1,4 @@
+class Admin::DashboardController < Admin::BaseController
+  def index
+  end
+end

--- a/app/controllers/admin/namespaces_controller.rb
+++ b/app/controllers/admin/namespaces_controller.rb
@@ -1,0 +1,6 @@
+class Admin::NamespacesController < Admin::BaseController
+  def index
+    @namespaces = Namespace.all
+    render template: 'namespaces/index'
+  end
+end

--- a/app/controllers/admin/teams_controller.rb
+++ b/app/controllers/admin/teams_controller.rb
@@ -1,0 +1,8 @@
+class Admin::TeamsController < Admin::BaseController
+
+  def index
+    @teams = Team.all
+    render template: 'teams/index'
+  end
+
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,20 @@
+class Admin::UsersController < Admin::BaseController
+  respond_to :html, :js
+
+  def index
+    @users = User.all
+  end
+
+  # PATCH/PUT /admin/user/1/toggle_admin
+  def toggle_admin
+    user = User.find(params[:id])
+    user.update_attributes(admin: !(user.admin?))
+    if user == current_user
+      # This user is no longer an admin
+      render js: "window.location = '/'"
+    else
+      render template: 'admin/users/toggle_admin', locals: { user: user }
+    end
+  end
+
+end

--- a/app/controllers/namespaces_controller.rb
+++ b/app/controllers/namespaces_controller.rb
@@ -41,7 +41,6 @@ class NamespacesController < ApplicationController
   def toggle_public
     authorize @namespace
 
-    #authorize @namespace
     @namespace.update_attributes(public: !(@namespace.public?))
     render template: 'namespaces/toggle_public', locals: { namespace: @namespace }
   end

--- a/app/controllers/team_users_controller.rb
+++ b/app/controllers/team_users_controller.rb
@@ -29,7 +29,7 @@ class TeamUsersController < ApplicationController
     authorize @team_user
     team = @team_user.team
     locals = { error: nil }
-    seppuku = @team_user.user == current_user
+    seppuku = @team_user.user == current_user && !current_user.admin?
     if team.owners.exists?(@team_user.user.id) &&
       team.owners.count == 1
       locals[:error] = 'Cannot remove the only owner of the team'

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,7 @@
 module ApplicationHelper
 
-  def is_namespace_owner?(namespace)
-    namespace.team.owners.exists?(current_user.id)
+  def can_manage_namespace?(namespace)
+    current_user.admin? || namespace.team.owners.exists?(current_user.id)
   end
 
 end

--- a/app/helpers/teams_helper.rb
+++ b/app/helpers/teams_helper.rb
@@ -1,7 +1,7 @@
 module TeamsHelper
 
-  def is_team_owner?(team)
-    team.owners.exists?(current_user.id)
+  def can_manage_team?(team)
+    current_user.admin? || team.owners.exists?(current_user.id)
   end
 
   def role_within_team(team)

--- a/app/helpers/teams_helper.rb
+++ b/app/helpers/teams_helper.rb
@@ -5,6 +5,12 @@ module TeamsHelper
   end
 
   def role_within_team(team)
-    team.team_users.find_by(user_id: current_user.id).role
+    team_user = team.team_users.find_by(user_id: current_user.id)
+    if team_user
+      team_user.role.titleize
+    else
+      # That happens when the admin user access a team he's not part of
+      '-'
+    end
   end
 end

--- a/app/policies/namespace_policy.rb
+++ b/app/policies/namespace_policy.rb
@@ -10,11 +10,12 @@ class NamespacePolicy
   def pull?
     # All the members of the team have READ access or anyone if
     # the namespace is public
-    namespace.public? || namespace.team.users.exists?(user.id)
+    user.admin? || namespace.public? || namespace.team.users.exists?(user.id)
   end
 
   def push?
     # only owners and contributors have WRITE access
+    user.admin? ||
     namespace.team.owners.exists?(user.id) ||
     namespace.team.contributors.exists?(user.id)
   end
@@ -28,7 +29,7 @@ class NamespacePolicy
   end
 
   def toggle_public?
-    namespace.team.owners.exists?(user.id)
+    user.admin? || namespace.team.owners.exists?(user.id)
   end
 
   class Scope

--- a/app/policies/team_policy.rb
+++ b/app/policies/team_policy.rb
@@ -8,7 +8,7 @@ class TeamPolicy
   end
 
   def is_member?
-    @team.users.exists?(user.id)
+    user.admin? || @team.users.exists?(user.id)
   end
 
   alias_method :show?, :is_member?

--- a/app/policies/team_user_policy.rb
+++ b/app/policies/team_user_policy.rb
@@ -8,7 +8,7 @@ class TeamUserPolicy
   end
 
   def is_owner?
-    @team_user.team.owners.exists?(user.id)
+    user.admin? || @team_user.team.owners.exists?(user.id)
   end
 
   alias_method :destroy?, :is_owner?

--- a/app/views/admin/dashboard/index.html.slim
+++ b/app/views/admin/dashboard/index.html.slim
@@ -6,7 +6,7 @@
       .panel-body
         .row
           .col-xs-4
-            i.fa.fa-user.times-visited
+            i.fa.fa-user.users
           .col-xs-8
             span.fa-3x= User.count
 
@@ -17,7 +17,7 @@
       .panel-body
         .row
           .col-xs-4
-            i.fa.fa-users.new-articles
+            i.fa.fa-users.teams
           .col-xs-8
             span.fa-3x= Team.count
 
@@ -30,6 +30,6 @@
       .panel-body
         .row
           .col-xs-4
-            i.fa.fa-ship.visits
+            i.fa.fa-ship.namespaces
           .col-xs-8
             span.fa-3x= Namespace.count

--- a/app/views/admin/dashboard/index.html.slim
+++ b/app/views/admin/dashboard/index.html.slim
@@ -1,0 +1,35 @@
+.row
+  .[class="col-md-3 col-xs-6"]
+    .panel-overview
+      .panel-heading
+        = link_to 'Users', admin_users_path
+      .panel-body
+        .row
+          .col-xs-4
+            i.fa.fa-user.times-visited
+          .col-xs-8
+            span.fa-3x= User.count
+
+  .[class="col-md-3 col-xs-6"]
+    .panel-overview
+      .panel-heading
+        = link_to 'Teams', admin_teams_path
+      .panel-body
+        .row
+          .col-xs-4
+            i.fa.fa-users.new-articles
+          .col-xs-8
+            span.fa-3x= Team.count
+
+  .clearfix.visible-xs-block
+
+  .[class="col-md-3 col-xs-6"]
+    .panel-overview
+      .panel-heading
+        = link_to 'Namespaces', admin_namespaces_path
+      .panel-body
+        .row
+          .col-xs-4
+            i.fa.fa-ship.visits
+          .col-xs-8
+            span.fa-3x= Namespace.count

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -1,0 +1,34 @@
+h1 Users
+
+.[class="panel panel-default"]
+  .panel-heading
+    h2[class='panel-title panel-heading'] Registered users
+  .panel-body
+    .table-responsive
+      table[class="table table-stripped table-hover"]
+        col.col-40
+        col.col-40
+        col.col-10
+        col.col-10
+        thead
+          tr
+            th Name
+            th Email
+            th Admin
+            th Namespaces
+            th Teams
+        tbody
+          - @users.each do |user|
+            tr[id="user_#{user.id}"]
+              td= user.username
+              td= user.email
+              td
+                a[class="btn btn-default"
+                  data-remote="true"
+                  data-method="put"
+                  rel="nofollow"
+                  href=url_for(toggle_admin_admin_user_path(user))]
+                    i[class="fa fa-toggle-#{user.admin? ? 'on': 'off'} fa-lg"]
+
+              td= user.teams.reduce(0){ |sum, t| sum += t.namespaces.count}
+              td= user.teams.count

--- a/app/views/admin/users/toggle_admin.js.erb
+++ b/app/views/admin/users/toggle_admin.js.erb
@@ -1,0 +1,5 @@
+$('#user_<%= user.id %> td a i').addClass("fa-toggle-<%= user.admin? ? 'on' : 'off' %>");
+$('#user_<%= user.id %> td a i').removeClass("fa-toggle-<%= user.admin? ? 'off' : 'on' %>");
+
+$('#notice p').html("User '<%= user.username %>' is <%= user.admin? ? 'now' : 'no longer' %> an admin");
+$('#notice').fadeIn();

--- a/app/views/namespaces/_namespace.html.slim
+++ b/app/views/namespaces/_namespace.html.slim
@@ -2,7 +2,7 @@ tr[id="namespace_#{namespace.id}"]
   td= link_to namespace.name, namespace
   td= namespace.repositories.count
   td
-    - if is_namespace_owner?(namespace)
+    - if can_manage_namespace?(namespace)
       a[class="btn btn-default"
           data-remote="true"
           data-method="put"

--- a/app/views/namespaces/index.html.slim
+++ b/app/views/namespaces/index.html.slim
@@ -18,4 +18,4 @@ p A namespace groups a series of repositories.
             th Public
         tbody
           - @namespaces.each do |namespace|
-            = render(namespace)
+            = render partial: 'namespaces/namespace', locals: {namespace: namespace}

--- a/app/views/shared/_aside.html.slim
+++ b/app/views/shared/_aside.html.slim
@@ -12,3 +12,10 @@ aside
         | Teams
       - if current_page?(url_for teams_path)
         .list-selected
+    - if current_user.admin?
+      li.active
+        a[href="#{url_for controller: 'admin/dashboard', action: 'index'}"]
+          i[class="fa fa-cogs"]
+          | Admin
+        - if current_page?(url_for controller: 'admin/dashboard', action: 'index')
+          .list-selected

--- a/app/views/team_users/_team_user.html.slim
+++ b/app/views/team_users/_team_user.html.slim
@@ -9,7 +9,7 @@ tr[id="team_user_#{team_user.id}"]
           .[class='col-md-offset-2 col-md-7']
         = f.submit('Save', class: 'btn btn-primary')
         .errors
-  - if is_team_owner?(team_user.team)
+  - if can_manage_team?(team_user.team)
     td
       button[class="btn btn-default btn-edit-role"
         value="#{team_user.id}"]

--- a/app/views/teams/index.html.slim
+++ b/app/views/teams/index.html.slim
@@ -16,7 +16,10 @@
 
 .[class="panel panel-default"]
   .[class="panel-heading clearfix"]
-    h2[class="panel-title pull-left"]Teams you are member of
+    - if current_page?(url_for admin_teams_path)
+      h2[class="panel-title pull-left"]Teams
+    - else
+      h2[class="panel-title pull-left"]Teams you are member of
   .panel-body
     .table-responsive
       table[class="table table-striped table-hover"]
@@ -33,6 +36,6 @@
             th Number of namespaces
         tbody#teams
           - @teams.each do |team|
-            = render(team)
+            = render partial: 'teams/team', locals: { team: team }
 
 

--- a/app/views/teams/show.html.slim
+++ b/app/views/teams/show.html.slim
@@ -14,7 +14,7 @@ ul
     i Owner
     | : like 'contributor', but can also manage the team.
 
-- if is_team_owner?(@team)
+- if can_manage_team?(@team)
   .clearfix
     .pull-right
       a[id="add_team_user_btn" class="btn btn-primary js-toggle-button" role="button"]
@@ -42,7 +42,7 @@ ul
     .table-responsive
       table[class="table table-striped table-hover"]
         colgroup
-          - if is_team_owner?(@team)
+          - if can_manage_team?(@team)
             col.col-40
             col.col-40
             col.col-10
@@ -54,7 +54,7 @@ ul
           tr
             th User
             th Role
-            - if is_team_owner?(@team)
+            - if can_manage_team?(@team)
               th Edit
               th Remove
         tbody#team_users
@@ -68,7 +68,7 @@ p A team can own one or more namespaces. By default all the namespaces can
 p It is possible to add read only (pull) access to all Portus users by toggling
   the "public" flag.
 
-- if is_team_owner?(@team)
+- if can_manage_team?(@team)
   .clearfix
     .pull-right
       a[id="add_namespace_btn" class="btn btn-primary js-toggle-button" role="button"]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,5 +16,14 @@ Rails.application.routes.draw do
     end
   end
 
+  namespace :admin do
+    resources :dashboard, only: [ :index ]
+    resources :namespaces, only: [ :index ]
+    resources :teams, only: [ :index ]
+    resources :users, only: [ :index ] do
+      put 'toggle_admin', on: :member
+    end
+  end
+
   resource :dashboard, only: [ :show ]
 end

--- a/spec/controllers/admin/dashboard_controller_spec.rb
+++ b/spec/controllers/admin/dashboard_controller_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe Admin::DashboardController, type: :controller do
+
+  let(:admin) { create(:user, admin: true) }
+  let(:user) { create(:user) }
+
+  context 'as admin user' do
+    before :each do
+      sign_in admin
+    end
+
+    describe 'GET #index' do
+      it 'returns http success' do
+        get :index
+        expect(response).to have_http_status(:success)
+      end
+    end
+  end
+
+  context 'not logged into portus' do
+    describe 'GET #index' do
+      it 'redirects to login page' do
+        get :index
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  context 'as normal user' do
+    before :each do
+      sign_in user
+    end
+
+    describe 'GET #index' do
+      it 'blocks access' do
+        get :index
+        expect(response.status).to eq(401)
+      end
+    end
+  end
+
+end

--- a/spec/controllers/admin/namespaces_controller_spec.rb
+++ b/spec/controllers/admin/namespaces_controller_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe Admin::NamespacesController, type: :controller do
+
+  let(:admin) { create(:user, admin: true) }
+  let(:user) { create(:user) }
+
+  context 'as admin user' do
+    before :each do
+      sign_in admin
+    end
+
+    describe 'GET #index' do
+      it 'returns http success' do
+        get :index
+        expect(response).to have_http_status(:success)
+      end
+    end
+  end
+
+  context 'not logged into portus' do
+    describe 'GET #index' do
+      it 'redirects to login page' do
+        get :index
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  context 'as normal user' do
+    before :each do
+      sign_in user
+    end
+
+    describe 'GET #index' do
+      it 'blocks access' do
+        get :index
+        expect(response.status).to eq(401)
+      end
+    end
+  end
+
+end

--- a/spec/controllers/admin/teams_controller_spec.rb
+++ b/spec/controllers/admin/teams_controller_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe Admin::TeamsController, type: :controller do
+
+  let(:admin) { create(:user, admin: true) }
+  let(:user) { create(:user) }
+
+  context 'as admin user' do
+    before :each do
+      sign_in admin
+    end
+
+    describe 'GET #index' do
+      it 'returns http success' do
+        get :index
+        expect(response).to have_http_status(:success)
+      end
+    end
+  end
+
+  context 'not logged into portus' do
+    describe 'GET #index' do
+      it 'redirects to login page' do
+        get :index
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  context 'as normal user' do
+    before :each do
+      sign_in user
+    end
+
+    describe 'GET #index' do
+      it 'blocks access' do
+        get :index
+        expect(response.status).to eq(401)
+      end
+    end
+  end
+
+end

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.describe Admin::UsersController, type: :controller do
+
+  let(:admin) { create(:user, admin: true) }
+  let(:user) { create(:user) }
+
+  context 'as admin user' do
+    before :each do
+      sign_in admin
+    end
+
+    describe 'GET #index' do
+      it 'returns http success' do
+        get :index
+        expect(response).to have_http_status(:success)
+      end
+    end
+  end
+
+  context 'not logged into portus' do
+    describe 'GET #index' do
+      it 'redirects to login page' do
+        get :index
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  context 'as normal user' do
+    before :each do
+      sign_in user
+    end
+
+    describe 'GET #index' do
+      it 'blocks access' do
+        get :index
+        expect(response.status).to eq(401)
+      end
+    end
+  end
+
+  context 'PUT toggle admin' do
+    before :each do
+      sign_in admin
+    end
+
+    it 'changes the admin value of an user'do
+      put :toggle_admin, id: user.id, format: :js
+
+      user.reload
+      expect(user).to be_admin
+      expect(response.status).to eq 200
+    end
+
+    it 'changes the admin value and redirects to the root when the user changes himself' do
+      put :toggle_admin, id: admin.id, format: :js
+
+      admin.reload
+      expect(admin).not_to be_admin
+      expect(response.body).to eq("window.location = '/'")
+    end
+
+  end
+
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe ApplicationHelper, type: :helper do
 
+  let(:admin)       { create(:user, admin: true) }
   let(:owner)       { create(:user) }
   let(:viewer)      { create(:user) }
   let(:contributor) { create(:user) }
@@ -13,20 +14,25 @@ RSpec.describe ApplicationHelper, type: :helper do
   end
   let(:namespace) { create(:namespace, team: team) }
 
-  describe 'is_namespace_owner?' do
+  describe 'can_manage_namespace?' do
     it 'returns true if current user is an owner of the namespace' do
       sign_in owner
-      expect(helper.is_namespace_owner?(namespace)).to be true
+      expect(helper.can_manage_namespace?(namespace)).to be true
     end
 
     it 'returns false if current user is a viewer of the namespace' do
       sign_in viewer
-      expect(helper.is_namespace_owner?(namespace)).to be false
+      expect(helper.can_manage_namespace?(namespace)).to be false
     end
 
     it 'returns false if current user is a contributor of the namespace' do
       sign_in contributor
-      expect(helper.is_namespace_owner?(namespace)).to be false
+      expect(helper.can_manage_namespace?(namespace)).to be false
+    end
+
+    it 'returns true if current user is an admin even when he is not related with the namespace' do
+      sign_in admin
+      expect(helper.can_manage_namespace?(namespace)).to be true
     end
   end
 

--- a/spec/helpers/teams_helper_spec.rb
+++ b/spec/helpers/teams_helper_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe TeamsHelper, type: :helper do
 
+  let(:admin)       { create(:user, admin: true) }
   let(:owner)       { create(:user) }
   let(:viewer)      { create(:user) }
   let(:contributor) { create(:user) }
@@ -12,20 +13,25 @@ RSpec.describe TeamsHelper, type: :helper do
            viewers: [ viewer ])
   end
 
-  describe 'is_team_owner?' do
+  describe 'can_manage_team?' do
     it 'returns true if current user is an owner of the team' do
       sign_in owner
-      expect(helper.is_team_owner?(team)).to be true
+      expect(helper.can_manage_team?(team)).to be true
     end
 
     it 'returns false if current user is a viewer of the team' do
       sign_in viewer
-      expect(helper.is_team_owner?(team)).to be false
+      expect(helper.can_manage_team?(team)).to be false
     end
 
     it 'returns false if current user is a contributor of the team' do
       sign_in contributor
-      expect(helper.is_team_owner?(team)).to be false
+      expect(helper.can_manage_team?(team)).to be false
+    end
+
+    it 'returns false if current user is an admin even if he is not related with the team' do
+      sign_in admin
+      expect(helper.can_manage_team?(team)).to be true
     end
   end
 

--- a/spec/helpers/teams_helper_spec.rb
+++ b/spec/helpers/teams_helper_spec.rb
@@ -32,7 +32,12 @@ RSpec.describe TeamsHelper, type: :helper do
   describe 'role within team' do
     it 'returns the role of the current user inside of the team' do
       sign_in viewer
-      expect(helper.role_within_team(team)).to eq 'viewer'
+      expect(helper.role_within_team(team)).to eq 'Viewer'
+    end
+
+    it 'returns - for users that are not part of the team' do
+      sign_in create(:user, admin: true)
+      expect(helper.role_within_team(team)).to eq '-'
     end
   end
 end

--- a/spec/policies/namespace_policy_spec.rb
+++ b/spec/policies/namespace_policy_spec.rb
@@ -4,6 +4,7 @@ describe NamespacePolicy do
 
   subject { described_class }
 
+  let(:admin)       { create(:user, admin: true) }
   let(:user)        { create(:user) }
   let(:owner)       { create(:user) }
   let(:viewer)      { create(:user) }
@@ -39,6 +40,10 @@ describe NamespacePolicy do
       expect(subject).to permit(user, namespace)
     end
 
+    it 'allows access to admin users even if they are not part of the team' do
+      expect(subject).to permit(admin, namespace)
+    end
+
   end
 
   permissions :push? do
@@ -57,6 +62,10 @@ describe NamespacePolicy do
 
     it 'disallows access to user who is not part of the team' do
       expect(subject).to_not permit(user, namespace)
+    end
+
+    it 'allows access to admin users even if they are not part of the team' do
+      expect(subject).to permit(admin, namespace)
     end
 
   end

--- a/spec/policies/team_policy_spec.rb
+++ b/spec/policies/team_policy_spec.rb
@@ -4,6 +4,7 @@ describe TeamPolicy do
 
   subject { described_class }
 
+  let(:admin) { create(:user, admin: true) }
   let(:member) { create(:user) }
   let(:team) { create(:team, owners: [ member ]) }
 
@@ -15,6 +16,10 @@ describe TeamPolicy do
 
     it 'allows access to a member of the team' do
       expect(subject).to permit(member, team)
+    end
+
+    it 'allows access to an admin even if he is not part of the team' do
+      expect(subject).to permit(admin, team)
     end
 
   end

--- a/spec/policies/team_user_policy_spec.rb
+++ b/spec/policies/team_user_policy_spec.rb
@@ -4,6 +4,7 @@ describe TeamUserPolicy do
 
   subject { described_class }
 
+  let(:admin)       { create(:user, admin: true) }
   let(:user)        { create(:user) }
   let(:owner)       { create(:user) }
   let(:viewer)      { create(:user) }
@@ -26,13 +27,17 @@ describe TeamUserPolicy do
       expect(subject).to_not permit(contributor, team_user)
     end
 
-    it 'allows access to a member of the team with owner role', bug: true do
+    it 'allows access to a member of the team with owner role' do
       expect(subject).to permit(owner, team_user)
     end
 
     it 'denies access to an owner of another group' do
       create(:team, owners: [user])
       expect(subject).to_not permit(user, team_user)
+    end
+
+    it 'allows access to admin user even if he is not part of the team' do
+      expect(subject).to permit(admin, team_user)
     end
 
   end


### PR DESCRIPTION
This PR adds a simple admin panel that can be used to browse users, namespaces and teams without any limitation.

The teams and namespaces views are simply reusing the traditional ones. The only difference is that now ALL the namespaces and ALL the teams are shown on the index pages. These special index pages live under the "http://<portus>/admin/" namespace.

When an admin user visits the "traditional" team and namespaces index pages the contents are tailored to what a non-admin user would see. To keep it short: the admin does not get bothered with everybody's data when he visits "http://<portus>/(teams|namespaces)"