### PR TITLE
Ensure User#username and Namespace#name are always valid

### DIFF
--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -1,8 +1,18 @@
 class Namespace < ActiveRecord::Base
 
+  NAME_ALLOWED_CHARS = 'a-z0-9\-_'
+
   has_many :repositories
   belongs_to :registry
   belongs_to :team
-  validates :name, presence: true
+  validates :name,
+            presence: true,
+            format: {
+              with: /\A[#{NAME_ALLOWED_CHARS}]+\Z/,
+              message: 'Only allowed letters: [a-z0-9-_]' }
+
+  def self.sanitize_name(name)
+    name.downcase.gsub(/\s+/, '_').gsub(/[^#{NAME_ALLOWED_CHARS}]/, '')
+  end
 
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -18,7 +18,9 @@ class Team < ActiveRecord::Base
   def create_team_namespace!
     # TODO: change once we allow more registries to be handled by portus
     registry = Registry.first
-    Namespace.find_or_create_by!(team: self, name: name, registry: registry)
+    Namespace.find_or_create_by!(team: self,
+                                 name: Namespace.sanitize_name(name),
+                                 registry: registry)
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,9 @@ class User < ActiveRecord::Base
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable, authentication_keys: [ :username ]
 
-  validates :username, presence: true, uniqueness: true
+  validates :username, presence: true, uniqueness: true,
+                       format: { with: /\A[a-z0-9]{4,30}\Z/,
+                                 message: 'Accepted format: "\A[a-z0-9]{4,30}\Z"' }
 
   has_many :team_users
   has_many :teams, through: :team_users

--- a/spec/controllers/namespaces_controller_spec.rb
+++ b/spec/controllers/namespaces_controller_spec.rb
@@ -67,7 +67,7 @@ describe NamespacesController do
     let(:valid_attributes) do
       {
         team: team.name,
-        namespace: 'qa team namespace'
+        namespace: 'qa_team_namespace'
       }
     end
 

--- a/spec/factories/teams_factory.rb
+++ b/spec/factories/teams_factory.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
 
   factory :team do
-    name   { FFaker::NatoAlphabet.code.downcase }
+    sequence(:name) {|n| "team_name#{n}" }
     owners {|t| [t.association(:user)] }
   end
 

--- a/spec/factories/users_factory.rb
+++ b/spec/factories/users_factory.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
   factory :user do
     sequence(:email) {|n| "test#{n}@localhost.test.lan" }
     password 'test-password'
-    sequence(:username) {|n| "#{FFaker::Internet.user_name}#{n}" }
+    sequence(:username) {|n| "username#{n}" }
   end
 
 end

--- a/spec/models/namespace_spec.rb
+++ b/spec/models/namespace_spec.rb
@@ -5,5 +5,21 @@ describe Namespace do
   it { should have_many(:repositories) }
   it { should belong_to(:team) }
   it { should validate_presence_of(:name) }
+  it { should allow_value('test1', '1test', 'another-test').for(:name) }
+  it { should_not allow_value('TesT1', '1Test', 'another_test!').for(:name) }
+
+  context 'sanitize name' do
+    it 'replaces white spaces with underscores' do
+      expect(Namespace.sanitize_name('the qa team')).to eq('the_qa_team')
+    end
+
+    it 'downcase all letters' do
+      expect(Namespace.sanitize_name('QA')).to eq('qa')
+    end
+
+    it 'remove unsupported chars' do
+      expect(Namespace.sanitize_name('qa, developers & others')).to eq('qa_developers__others')
+    end
+  end
 
 end

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -77,7 +77,7 @@ describe Repository do
     end
 
     context 'when the repository is inside of namespace' do
-      let(:namespace_name) { 'SUSE' }
+      let(:namespace_name) { 'suse' }
       let(:event) do
         {
           'target' => {
@@ -89,7 +89,7 @@ describe Repository do
 
       context 'when the namespaceis not known by Portus' do
         it 'should create a namespace with a tagged repository' do
-          create(:namespace, name: 'openSUSE')
+          create(:namespace, name: 'opensuse')
 
           repository = Repository.handle_push_event(event)
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,6 +6,9 @@ describe User do
 
   it { should validate_uniqueness_of(:email) }
   it { should validate_uniqueness_of(:username) }
+  it { should allow_value('test1', '1test').for(:username) }
+  it { should_not allow_value('foo', '1Test', 'another_test').for(:username) }
+
 
   describe '#create_personal_team!' do
 


### PR DESCRIPTION
The Docker daemon performs some validations for the User's username and
also for the Namespace's name. We have to apply the same policies
inside of Portus.

Fixes #42 and #44