### PR TITLE
review Gemfile for packaging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,35 +25,45 @@ gem 'rails-observers'
 #TODO remove as soon as we migrate to PostgreSQL
 gem 'sqlite3'
 
-group :development do
-  gem 'quiet_assets'
-  gem 'pry-rails'
-  gem 'git-review', require: false
-  gem 'rack-mini-profiler', require: false
-end
+# In order to create the Gemfile.lock required for packaging
+# meaning that it should contain only the production packages
+# run:
+#
+# PACKAGING=yes bundle list
 
-group :development, :test do
-  gem 'byebug'
-  gem 'web-console', '~> 2.0.0.beta4'
-  gem 'thin'
-  gem 'awesome_print'
-  gem 'hirb'
-  gem 'wirb'
-  gem 'wirble'
-  gem 'sqlite3'
-  gem 'factory_girl_rails'
-  gem 'ffaker'
-  gem 'rubocop', '~> 0.27.1', require: false
-end
+unless ENV['PACKAGING'] && ENV['PACKAGING'] == "yes"
 
-group :test do
-  gem 'shoulda'
-  gem 'rspec-rails'
-  gem 'vcr'
-  gem 'webmock', require: false
-  gem 'simplecov', require: false
-  gem 'capybara'
-  gem 'poltergeist', require: false
-  gem 'database_cleaner'
-  gem 'json-schema'
+  group :development do
+    gem 'quiet_assets'
+    gem 'pry-rails'
+    gem 'git-review', require: false
+    gem 'rack-mini-profiler', require: false
+  end
+
+  group :development, :test do
+    gem 'byebug'
+    gem 'web-console', '~> 2.0.0.beta4'
+    gem 'thin'
+    gem 'awesome_print'
+    gem 'hirb'
+    gem 'wirb'
+    gem 'wirble'
+    gem 'sqlite3'
+    gem 'factory_girl_rails'
+    gem 'ffaker'
+    gem 'rubocop', '~> 0.27.1', require: false
+  end
+
+  group :test do
+    gem 'shoulda'
+    gem 'rspec-rails'
+    gem 'vcr'
+    gem 'webmock', require: false
+    gem 'simplecov', require: false
+    gem 'capybara'
+    gem 'poltergeist', require: false
+    gem 'database_cleaner'
+    gem 'json-schema'
+  end
+
 end


### PR DESCRIPTION
When packaging this application as for example an RPM, we need to know
which gems are needed, which means we don't want to have devel or test
gems.

While you can run "bundle install --without development test", this
does not update the Gemfile.lock, meaning the develoment and test gems
are still in Gemfile.lock.

If you infere the gem dependencies from the Gemfile.lock, you would get
the development and test gems, unless you exclude them inside the
Gemfile file.

This commits adds a "unless ENV['PACKAGING'] == 'yes'" that excludes the
gems in the Gemfile thus, if you run

PACKAGING=yes bundle list

you will get the Gemfile.lock that you need without the test and
development dependencies and thus you can use that for infering which
gems you will need in production and thus set the package requirements.