### PR TITLE
Introducing the special 'portus' user

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'gravatar_image_tag'
 gem 'rails-observers'
 gem 'public_activity'
 gem 'active_record_union'
+gem 'rotp'
 
 #TODO remove as soon as we migrate to PostgreSQL
 gem 'sqlite3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,6 +205,7 @@ GEM
     ref (1.0.5)
     responders (2.1.0)
       railties (>= 4.2.0, < 5)
+    rotp (2.1.0)
     rspec-core (3.2.3)
       rspec-support (~> 3.2.0)
     rspec-expectations (3.2.1)
@@ -342,6 +343,7 @@ DEPENDENCIES
   rack-mini-profiler
   rails (~> 4.2.1)
   rails-observers
+  rotp
   rspec-rails
   rubocop (~> 0.27.1)
   sass-rails

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,6 +1,7 @@
 class Api::BaseController < ActionController::Base
   class ScopeNotHandled < StandardError; end
   class RegistryNotHandled < StandardError; end
+  class WrongPortusOTP < StandardError; end
 
   include Pundit
 
@@ -10,6 +11,7 @@ class Api::BaseController < ActionController::Base
   rescue_from Pundit::NotAuthorizedError, with: :deny_access
   rescue_from ScopeNotHandled, with: :deny_access
   rescue_from RegistryNotHandled, with: :deny_access
+  rescue_from WrongPortusOTP, with: :deny_access
 
   protected
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,9 @@ class User < ActiveRecord::Base
 
   validates :username, presence: true, uniqueness: true,
                        format: { with: /\A[a-z0-9]{4,30}\Z/,
-                                 message: 'Accepted format: "\A[a-z0-9]{4,30}\Z"' }
+                                 message: 'Accepted format: "\A[a-z0-9]{4,30}\Z"' },
+                       exclusion: { in: %w(portus),
+                                    message: '%{value} is reserved.' }
 
   has_many :team_users
   has_many :teams, through: :team_users

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,5 +24,7 @@ module Portus
     config.active_record.raise_in_transactional_callbacks = true
 
     config.active_record.observers = :user_observer, :team_observer
+
+    config.otp_secret = ROTP::Base32.random_base32
   end
 end

--- a/spec/controllers/auth/registrations_controller_spec.rb
+++ b/spec/controllers/auth/registrations_controller_spec.rb
@@ -12,35 +12,35 @@ describe Auth::RegistrationsController do
 
     it 'defaults admin to false when omitted' do
       post :create, user: {
-        'username' => 'portus',
-        'email' => 'portus@test.com',
+        'username' => 'administrator',
+        'email' => 'administrator@test.com',
         'password' => '12341234',
         'password_confirmation' => '12341234'
       }
-      expect(User.find_by!(username: 'portus')).not_to be_admin
+      expect(User.find_by!(username: 'administrator')).not_to be_admin
     end
 
     it 'handles the admin column properly' do
       post :create, user: {
-        'username' => 'portus',
-        'email' =>  'portus@test.com',
+        'username' => 'administrator',
+        'email' =>  'administrator@test.com',
         'password' =>  '12341234',
         'password_confirmation' => '12341234',
         'admin' => true
       }
-      expect(User.find_by!(username: 'portus')).to be_admin
+      expect(User.find_by!(username: 'administrator')).to be_admin
     end
 
     it 'omits the value of admin if there is already another admin' do
       create(:user, admin: true)
       post :create, user: {
-        'username'=> 'portus',
-        'email' => 'portus@test.com',
+        'username'=> 'wonnabeadministrator',
+        'email' => 'wonnabeadministrator@test.com',
         'password' => '12341234',
         'password_confirmation' => '12341234',
         'admin' => true
       }
-      expect(User.find_by!(username: 'portus')).not_to be_admin
+      expect(User.find_by!(username: 'wonnabeadministrator')).not_to be_admin
     end
 
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,7 +7,7 @@ describe User do
   it { should validate_uniqueness_of(:email) }
   it { should validate_uniqueness_of(:username) }
   it { should allow_value('test1', '1test').for(:username) }
-  it { should_not allow_value('foo', '1Test', 'another_test').for(:username) }
+  it { should_not allow_value('portus', 'foo', '1Test', 'another_test').for(:username) }
 
 
   describe '#create_personal_team!' do


### PR DESCRIPTION
Soon we are going to fetch informations from the registry itself (like
repositories' manifests). When doing that we have to authenticate
against the registry like all normal clients. Basically Portus is going to
authenticate against itself. :)

The client library used to interact with the registry is already merged
in master (see `app/models/registry_client.rb`). However we still have
to provide a username and password. Hence we need to send the password
as a client, and then verify itself inside of the token controller.

We are going to authenticate as 'portus' user providing a time based one
time only password (aka TOTP).
The TOTP is generated using a secret that changes every time the Rails process
starts (see `config/application.rb`).

The policy checks inside of the token controller have been disabled for the
'portus' user because he can access to everything.s

I've also reserved 'portus' as username to avoid misuses from the users.