### PR TITLE
registrations: don't show "Create Admin" on signup error if there is an admin

### DIFF
--- a/app/controllers/auth/registrations_controller.rb
+++ b/app/controllers/auth/registrations_controller.rb
@@ -2,11 +2,11 @@ class Auth::RegistrationsController < Devise::RegistrationsController
 
   layout 'authentication'
 
+  before_filter :check_admin, only: [ :new, :create ]
   before_filter :configure_sign_up_params, only: [ :create ]
 
-  def new
+  def check_admin
     @admin = User.exists?(admin: true)
-    super
   end
 
   def configure_sign_up_params

--- a/spec/features/auth/signup_feature_spec.rb
+++ b/spec/features/auth/signup_feature_spec.rb
@@ -39,6 +39,7 @@ feature 'Signup feature' do
     fill_in 'user_password_confirmation', with: user.password
     click_button('Sign Up')
     expect(page).to have_content('1 error prohibited this user from being saved: Email is invalid')
+    expect(page).to_not have_content('Create admin')
   end
 
 end


### PR DESCRIPTION
Devise does not redirect to the 'new' page on signup error, but it renders it.
This means that on signup error the `@admin` view variable will be nil, thus
showing the "Create Admin" button. In this commit a before_filter has been
added for both the 'new' and the 'create' actions, so this case is always
handled consistently.

Signed-off-by: Miquel Sabaté <mikisabate@gmail.com>