### PR TITLE
Merged the rendering of flashy messages and devise errors

### DIFF
--- a/app/assets/stylesheets/vendor/alerts.css.less
+++ b/app/assets/stylesheets/vendor/alerts.css.less
@@ -2,6 +2,12 @@
   box-shadow: 0px 3px 0px @panel-shadow;
   border-radius: @border-radious;
   border-width: 2px;
+
+  ul {
+    margin: 0px;
+    padding: 0px;
+  }
+
   &.alert-dismissible {
     padding: @alert-padding;
     .close {

--- a/app/helpers/devise_helper.rb
+++ b/app/helpers/devise_helper.rb
@@ -4,7 +4,7 @@ module DeviseHelper
 
     render(
       template: 'shared/_notification.html.slim',
-      layout: nil ,
+      layout: nil,
       locals: {
         alert: 'danger',
         messages: resource.errors.full_messages

--- a/app/helpers/devise_helper.rb
+++ b/app/helpers/devise_helper.rb
@@ -1,0 +1,14 @@
+module DeviseHelper
+  def devise_error_messages!
+    return '' if resource.errors.empty?
+
+    render(
+      template: 'shared/_notification.html.slim',
+      layout: nil ,
+      locals: {
+        alert: 'danger',
+        messages: resource.errors.full_messages
+      }
+    ).to_s.html_safe
+  end
+end

--- a/app/views/shared/_notification.html.slim
+++ b/app/views/shared/_notification.html.slim
@@ -1,0 +1,17 @@
+#alert[class="#{messages && messages.first ? '' : 'collapse'}"]
+  .alert.alert-dismissible.fade.in.text-left[class="alert-#{alert}"]
+    button.close data-dismiss="alert" type="button"
+      span aria-hidden="true" &times;
+      span.sr-only Close
+    .row
+      .col-sm-2.alert-icon
+        i.fa.fa-exclamation-circle.fa-3x
+      .col-sm-9
+        p
+          - if messages.size == 1
+            = messages[0]
+          - else
+            ul
+              - messages.each do |c|
+                li
+                  = c

--- a/app/views/shared/_notifications.html.slim
+++ b/app/views/shared/_notifications.html.slim
@@ -14,26 +14,9 @@
           - else
             p Ask an administrator to complete configuration.
 
-#notice[class="#{flash[:notice] ? '' : 'collapse'}"]
-  .alert.alert-info.alert-dismissible.fade.in.text-left
-    button.close data-dismiss="alert" type="button"
-      span aria-hidden="true" &times;
-      span.sr-only Close
-    .row
-      .col-sm-2.alert-icon
-        i.fa.fa-info-circle.fa-3x
-      .col-sm-9
-        p
-          = flash[:notice]
 
-#alert[class="#{flash[:alert] ? '' : 'collapse'}"]
-  .alert.alert-danger.alert-dismissible.fade.in.text-left
-    button.close data-dismiss="alert" type="button"
-      span aria-hidden="true" &times;
-      span.sr-only Close
-    .row
-      .col-sm-2.alert-icon
-        i.fa.fa-exclamation-circle.fa-3x
-      .col-sm-9
-        p
-          = flash[:alert]
+= render template: 'shared/_notification.html.slim',
+    locals: { messages: [flash[:notice]], alert: 'info' }
+
+= render template: 'shared/_notification.html.slim',
+    locals: { messages: [flash[:alert]], alert: 'danger' }

--- a/spec/features/auth/signup_feature_spec.rb
+++ b/spec/features/auth/signup_feature_spec.rb
@@ -38,7 +38,7 @@ feature 'Signup feature' do
     fill_in 'user_password', with: user.password
     fill_in 'user_password_confirmation', with: user.password
     click_button('Sign Up')
-    expect(page).to have_content('1 error prohibited this user from being saved: Email is invalid')
+    expect(page).to have_content('Email is invalid')
     expect(page).to_not have_content('Create admin')
   end
 


### PR DESCRIPTION
Now flashy messages and devise errors will use the same template to render notifications. For flashy messages this is not very important (except that the `notifications.html.slim` file gets simplified), but for devise errors this is an improvement. This is how devise errors were rendered before:

![master](https://cloud.githubusercontent.com/assets/767943/7669436/99725d9a-fc73-11e4-94ad-d44e97adc4df.png)

And this is how they look now:

![error](https://cloud.githubusercontent.com/assets/767943/7669437/a1ef615c-fc73-11e4-84ba-198463540edc.png)


