### PR TITLE
Global namespaces support, plus better handling of teams

### DIFF
--- a/app/controllers/admin/namespaces_controller.rb
+++ b/app/controllers/admin/namespaces_controller.rb
@@ -1,6 +1,6 @@
 class Admin::NamespacesController < Admin::BaseController
   def index
-    @namespaces = Namespace.all
-    render template: 'namespaces/index'
+    @special_namespaces = Namespace.where(global: true)
+    @namespaces = Namespace.where(global: false)
   end
 end

--- a/app/controllers/admin/teams_controller.rb
+++ b/app/controllers/admin/teams_controller.rb
@@ -2,7 +2,6 @@ class Admin::TeamsController < Admin::BaseController
 
   def index
     @teams = Team.all
-    render template: 'teams/index'
   end
 
 end

--- a/app/controllers/namespaces_controller.rb
+++ b/app/controllers/namespaces_controller.rb
@@ -8,6 +8,8 @@ class NamespacesController < ApplicationController
   # GET /namespaces
   # GET /namespaces.json
   def index
+    @special_namespaces = Namespace.where(
+      'global = ? OR namespaces.name = ?', true, current_user.username)
     @namespaces = policy_scope(Namespace)
 
     respond_with(@namespaces)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,4 +4,12 @@ module ApplicationHelper
     current_user.admin? || namespace.team.owners.exists?(current_user.id)
   end
 
+  def namespace_clean_name(namespace)
+    if namespace.global?
+      'Global namespace'
+    else
+      namespace.name
+    end
+  end
+
 end

--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -11,7 +11,7 @@ class Namespace < ActiveRecord::Base
             format: {
               with: /\A[#{NAME_ALLOWED_CHARS}]+\Z/,
               message: 'Only allowed letters: [a-z0-9-_]' }
-  validates :public, inclusion: { in: [true]}, if: :global?
+  validates :public, inclusion: { in: [true] }, if: :global?
 
   def self.sanitize_name(name)
     name.downcase.gsub(/\s+/, '_').gsub(/[^#{NAME_ALLOWED_CHARS}]/, '')

--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -11,6 +11,7 @@ class Namespace < ActiveRecord::Base
             format: {
               with: /\A[#{NAME_ALLOWED_CHARS}]+\Z/,
               message: 'Only allowed letters: [a-z0-9-_]' }
+  validates :public, inclusion: { in: [true]}, if: :global?
 
   def self.sanitize_name(name)
     name.downcase.gsub(/\s+/, '_').gsub(/[^#{NAME_ALLOWED_CHARS}]/, '')

--- a/app/models/registry.rb
+++ b/app/models/registry.rb
@@ -11,7 +11,7 @@ class Registry < ActiveRecord::Base
     team.namespaces.last.update_attributes({
       registry: self,
       public: true,
-      global: true})
+      global: true })
   end
 
   def global_namespace

--- a/app/models/registry.rb
+++ b/app/models/registry.rb
@@ -6,7 +6,8 @@ class Registry < ActiveRecord::Base
   def create_global_namespace!
     team = Team.create(
       name: Namespace.sanitize_name(hostname),
-      owners: [User.where(admin: true).first])
+      owners: [User.where(admin: true).first],
+      hidden: true)
     team.namespaces.last.update_attributes({
       registry: self,
       public: true,

--- a/app/models/registry.rb
+++ b/app/models/registry.rb
@@ -2,4 +2,18 @@ class Registry < ActiveRecord::Base
   has_many :namespaces
   validates :name, presence: true, uniqueness: true
   validates :hostname, presence: true, uniqueness: true
+
+  def create_global_namespace!
+    team = Team.create(
+      name: Namespace.sanitize_name(hostname),
+      owners: [User.where(admin: true).first])
+    team.namespaces.last.update_attributes({
+      registry: self,
+      public: true,
+      global: true})
+  end
+
+  def global_namespace
+    Namespace.find_by(registry: self, global: true)
+  end
 end

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -27,7 +27,12 @@ class Repository < ActiveRecord::Base
       return
     end
 
-    namespace = registry.namespaces.find_by(name: namespace_name)
+    if namespace_name
+      namespace = registry.namespaces.find_by(name: namespace_name)
+    else
+      namespace = registry.global_namespace
+    end
+
     if namespace.nil?
       logger.error "Cannot find namespace #{namespace_name} under registry #{registry.hostname}"
       return

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,7 +14,8 @@ class User < ActiveRecord::Base
 
   def create_personal_team!
     if Team.find_by(name: username).nil?
-      Team.create!(name: username, owners: [self])
+      Team.create!(name: username, owners: [self], hidden: true)
     end
   end
+
 end

--- a/app/observers/registry_observer.rb
+++ b/app/observers/registry_observer.rb
@@ -1,0 +1,7 @@
+class RegistryObserver < ActiveRecord::Observer
+
+  def after_create(registry)
+    registry.create_global_namespace!
+  end
+
+end

--- a/app/policies/namespace_policy.rb
+++ b/app/policies/namespace_policy.rb
@@ -10,7 +10,8 @@ class NamespacePolicy
   def pull?
     # All the members of the team have READ access or anyone if
     # the namespace is public
-    user.admin? || namespace.public? || namespace.team.users.exists?(user.id)
+    # Everybody can pull from the global namespace
+    namespace.global? || user.admin? || namespace.public? || namespace.team.users.exists?(user.id)
   end
 
   def push?

--- a/app/policies/team_policy.rb
+++ b/app/policies/team_policy.rb
@@ -22,7 +22,7 @@ class TeamPolicy
     end
 
     def resolve
-      user.teams
+      user.teams.where(hidden: false)
     end
   end
 

--- a/app/views/admin/namespaces/index.html.slim
+++ b/app/views/admin/namespaces/index.html.slim
@@ -1,0 +1,38 @@
+h1 Namespaces
+
+.[class="panel panel-default"]
+  .panel-heading
+    h2[class='panel-title panel-heading'] Special namespaces
+  .panel-body
+    .table-responsive
+      table[class="table table-stripped table-hover"]
+        col.col-50
+        col.col-40
+        col.col-10
+        thead
+          tr
+            th Name
+            th Repositories
+            th Public
+        tbody
+          - @special_namespaces.each do |namespace|
+            = render partial: 'namespaces/namespace', locals: {namespace: namespace}
+
+
+.[class="panel panel-default"]
+  .panel-heading
+    h2[class='panel-title panel-heading'] Other namespaces
+  .panel-body
+    .table-responsive
+      table[class="table table-stripped table-hover"]
+        col.col-50
+        col.col-40
+        col.col-10
+        thead
+          tr
+            th Name
+            th Repositories
+            th Public
+        tbody
+          - @namespaces.each do |namespace|
+            = render partial: 'namespaces/namespace', locals: {namespace: namespace}

--- a/app/views/admin/teams/index.html.slim
+++ b/app/views/admin/teams/index.html.slim
@@ -1,0 +1,22 @@
+.[class="panel panel-default"]
+  .[class="panel-heading clearfix"]
+    h2[class="panel-title pull-left"]Teams
+  .panel-body
+    .table-responsive
+      table[class="table table-striped table-hover"]
+        colgroup
+          col[class="col-30"]
+          col[class="col-30"]
+          col[class="col-10"]
+          col[class="col-15"]
+          col[class="col-15"]
+        thead
+          tr
+            th Team
+            th Role
+            th Hidden
+            th Number of members
+            th Number of namespaces
+        tbody#teams
+          - @teams.each do |team|
+            = render partial: 'teams/team', locals: { team: team }

--- a/app/views/namespaces/_namespace.html.slim
+++ b/app/views/namespaces/_namespace.html.slim
@@ -1,8 +1,8 @@
 tr[id="namespace_#{namespace.id}"]
-  td= link_to namespace.name, namespace
+  td= link_to namespace_clean_name(namespace), namespace
   td= namespace.repositories.count
   td
-    - if can_manage_namespace?(namespace)
+    - if can_manage_namespace?(namespace) && !namespace.global
       a[class="btn btn-default"
           data-remote="true"
           data-method="put"

--- a/app/views/namespaces/index.html.slim
+++ b/app/views/namespaces/index.html.slim
@@ -4,6 +4,25 @@ p A namespace groups a series of repositories.
 
 .[class="panel panel-default"]
   .panel-heading
+    h2[class='panel-title panel-heading'] Special namespaces
+  .panel-body
+    .table-responsive
+      table[class="table table-stripped table-hover"]
+        col.col-50
+        col.col-40
+        col.col-10
+        thead
+          tr
+            th Name
+            th Repositories
+            th Public
+        tbody
+          - @special_namespaces.each do |namespace|
+            = render partial: 'namespaces/namespace', locals: {namespace: namespace}
+
+
+.[class="panel panel-default"]
+  .panel-heading
     h2[class='panel-title panel-heading'] Namespaces you have access to
   .panel-body
     .table-responsive

--- a/app/views/namespaces/show.html.slim
+++ b/app/views/namespaces/show.html.slim
@@ -1,6 +1,6 @@
 .[class="panel panel-default"]
   .panel-heading
-    h1= "Namespace #{@namespace.name}"
+    h1= namespace_clean_name(@namespace)
   .panel-body
     .table-responsive
       table[class="table table-stripped table-hover"]

--- a/app/views/teams/_team.html.slim
+++ b/app/views/teams/_team.html.slim
@@ -1,5 +1,8 @@
 tr
   td= link_to team.name, team
   td= role_within_team(team)
+  - if current_page?(url_for admin_teams_path)
+    td
+      i[class="fa fa-toggle-#{team.hidden? ? 'on': 'off'} fa-lg"]
   td= team.users.count
   td= team.namespaces.count

--- a/app/views/teams/index.html.slim
+++ b/app/views/teams/index.html.slim
@@ -16,10 +16,7 @@
 
 .[class="panel panel-default"]
   .[class="panel-heading clearfix"]
-    - if current_page?(url_for admin_teams_path)
-      h2[class="panel-title pull-left"]Teams
-    - else
-      h2[class="panel-title pull-left"]Teams you are member of
+    h2[class="panel-title pull-left"]Teams you are member of
   .panel-body
     .table-responsive
       table[class="table table-striped table-hover"]
@@ -36,6 +33,4 @@
             th Number of namespaces
         tbody#teams
           - @teams.each do |team|
-            = render partial: 'teams/team', locals: { team: team }
-
-
+            = render team

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,7 +23,7 @@ module Portus
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
 
-    config.active_record.observers = :user_observer, :team_observer
+    config.active_record.observers = :user_observer, :team_observer, :registry_observer
 
     config.otp_secret = ROTP::Base32.random_base32
   end

--- a/db/migrate/20150515114145_add_global_flag_to_namespaces.rb
+++ b/db/migrate/20150515114145_add_global_flag_to_namespaces.rb
@@ -1,0 +1,5 @@
+class AddGlobalFlagToNamespaces < ActiveRecord::Migration
+  def change
+    add_column :namespaces, :global, :boolean, default: false
+  end
+end

--- a/db/migrate/20150518142223_add_hidden_to_teams.rb
+++ b/db/migrate/20150518142223_add_hidden_to_teams.rb
@@ -1,0 +1,5 @@
+class AddHiddenToTeams < ActiveRecord::Migration
+  def change
+    add_column :teams, :hidden, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150515114145) do
+ActiveRecord::Schema.define(version: 20150518142223) do
 
   create_table "activities", force: :cascade do |t|
     t.integer  "trackable_id"
@@ -89,8 +89,9 @@ ActiveRecord::Schema.define(version: 20150515114145) do
 
   create_table "teams", force: :cascade do |t|
     t.string   "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+    t.boolean  "hidden",     default: false
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150515111638) do
+ActiveRecord::Schema.define(version: 20150515114145) do
 
   create_table "activities", force: :cascade do |t|
     t.integer  "trackable_id"
@@ -38,6 +38,7 @@ ActiveRecord::Schema.define(version: 20150515111638) do
     t.integer  "team_id"
     t.boolean  "public",      default: false
     t.integer  "registry_id"
+    t.boolean  "global",      default: false
   end
 
   add_index "namespaces", ["name"], name: "index_namespaces_on_name", unique: true

--- a/spec/controllers/namespaces_controller_spec.rb
+++ b/spec/controllers/namespaces_controller_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 describe NamespacesController do
 
   let(:valid_session) { {} }
+  let(:registry) { create(:registry) }
   let(:user) { create(:user) }
   let(:viewer) { create(:user) }
   let(:contributor) { create(:user) }
@@ -13,9 +14,11 @@ describe NamespacesController do
            viewers: [ user, viewer ],
            contributors: [ contributor ])
   end
-  let(:namespace) { create(:namespace, team: team) }
+  let(:namespace) { create(:namespace, team: team, registry: registry) }
 
   before :each do
+    # trigger creation of registry
+    registry
     sign_in user
   end
 
@@ -23,7 +26,9 @@ describe NamespacesController do
 
     it 'assigns all namespaces as @namespaces' do
       get :index, {}, valid_session
-      expect(assigns(:namespaces).ids).to match_array(Namespace.all.ids)
+      expect(assigns(:special_namespaces)).to match_array(
+        [Namespace.find_by(name: user.username), Namespace.find_by(global: true)])
+      expect(assigns(:namespaces).ids).to be_empty
     end
 
   end

--- a/spec/controllers/teams_controller_spec.rb
+++ b/spec/controllers/teams_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe TeamsController, type: :controller do
         create(:team)
 
         get :index
-        expect(assigns(:teams)).to match_array(owner.teams)
+        expect(assigns(:teams)).to be_empty
       end
     end
 

--- a/spec/factories/registries.rb
+++ b/spec/factories/registries.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :registry do
+    before(:create) { create(:user, admin: true) }
     sequence :hostname do |n|
       "registry hostname #{n}"
     end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -36,4 +36,19 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
+  describe 'namespace_clean_name' do
+    context 'non global namespace' do
+      it 'returns the name of the namespace' do
+        expect(helper.namespace_clean_name(namespace)).to eq(namespace.name)
+      end
+    end
+
+    context 'global namespace' do
+      it 'returns the name of the namespace' do
+        global_namespace = create(:namespace, global: true, public: true)
+        expect(helper.namespace_clean_name(global_namespace)).to eq('Global namespace')
+      end
+    end
+  end
+
 end

--- a/spec/models/namespace_spec.rb
+++ b/spec/models/namespace_spec.rb
@@ -22,4 +22,12 @@ describe Namespace do
     end
   end
 
+  context 'global namespace' do
+    it 'must be public' do
+      namespace = create(:namespace, global: true, public: true)
+      namespace.public = false
+      expect(namespace.save).to be false
+    end
+  end
+
 end

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -39,9 +39,6 @@ describe Repository do
         @event['target']['url'] = "http://registry.test.lan/v2/#{repository_name}/manifests/#{tag_name}"
         @event['request']['host'] = 'unknown-registry.test.lan'
         @event['actor']['name'] = user.username
-
-        @global_namespace = Namespace.new(name: nil, registry: registry)
-        @global_namespace.save(validate: false)
       end
 
       it 'sends event to logger' do
@@ -59,9 +56,6 @@ describe Repository do
         @event['target']['url'] = "http://registry.test.lan/v2/#{repository_name}/manifests/#{tag_name}"
         @event['request']['host'] = registry.hostname
         @event['actor']['name'] = 'a_ghost'
-
-        @global_namespace = Namespace.new(name: nil, registry: registry)
-        @global_namespace.save(validate: false)
       end
 
       it 'sends event to logger' do
@@ -80,9 +74,6 @@ describe Repository do
         @event['target']['url'] = "http://registry.test.lan/v2/#{repository_name}/manifests/#{tag_name}"
         @event['request']['host'] = registry.hostname
         @event['actor']['name'] = user.username
-
-        @global_namespace = Namespace.new(name: nil, registry: registry)
-        @global_namespace.save(validate: false)
       end
 
       context 'when the repository is not known by Portus' do
@@ -96,7 +87,7 @@ describe Repository do
           expect(Repository.count).to eq 1
           expect(Tag.count).to eq 1
 
-          expect(repository.namespace).to eq(@global_namespace)
+          expect(repository.namespace).to eq(registry.global_namespace)
           expect(repository.name).to eq(repository_name)
           expect(repository.tags.count).to eq 1
           expect(repository.tags.first.name).to eq tag_name
@@ -131,11 +122,10 @@ describe Repository do
           end.to change(Namespace, :count).by(0)
 
           expect(repository).not_to be_nil
-          expect(Namespace.count).to eq 2
           expect(Repository.count).to eq 1
           expect(Tag.count).to eq 2
 
-          expect(repository.namespace).to eq(@global_namespace)
+          expect(repository.namespace).to eq(registry.global_namespace)
           expect(repository.name).to eq(repository_name)
           expect(repository.tags.count).to eq 2
           expect(repository.tags.map(&:name)).to include('1.0.0', tag_name)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -18,6 +18,7 @@ describe User do
       Namespace.find_by!(name: subject.username)
       TeamUser.find_by!(user: subject, team: team)
       expect(team.owners).to include(subject)
+      expect(team).to be_hidden
     end
 
   end

--- a/spec/policies/namespace_policy_spec.rb
+++ b/spec/policies/namespace_policy_spec.rb
@@ -100,7 +100,7 @@ describe NamespacePolicy do
     end
 
     context 'global namespace' do
-      let(:namespace) { create(:namespace, global:true, public: true) }
+      let(:namespace) { create(:namespace, global: true, public: true) }
 
       it 'disallow access to everybody' do
         expect(subject).to_not permit(admin, namespace)

--- a/spec/policies/namespace_policy_spec.rb
+++ b/spec/policies/namespace_policy_spec.rb
@@ -4,6 +4,7 @@ describe NamespacePolicy do
 
   subject { described_class }
 
+  let(:registry)    { create(:registry) }
   let(:admin)       { create(:user, admin: true) }
   let(:user)        { create(:user) }
   let(:owner)       { create(:user) }
@@ -44,6 +45,10 @@ describe NamespacePolicy do
       expect(subject).to permit(admin, namespace)
     end
 
+    it 'always allows access to a global namespace' do
+      expect(subject).to permit(create(:user), registry.global_namespace)
+    end
+
   end
 
   permissions :push? do
@@ -64,8 +69,14 @@ describe NamespacePolicy do
       expect(subject).to_not permit(user, namespace)
     end
 
-    it 'allows access to admin users even if they are not part of the team' do
-      expect(subject).to permit(admin, namespace)
+    context 'global namespace' do
+      it 'allows access to administrators' do
+        expect(subject).to permit(admin, registry.global_namespace)
+      end
+
+      it 'denies access to other users' do
+        expect(subject).not_to permit(user, registry.global_namespace)
+      end
     end
 
   end

--- a/spec/policies/namespace_policy_spec.rb
+++ b/spec/policies/namespace_policy_spec.rb
@@ -81,4 +81,56 @@ describe NamespacePolicy do
 
   end
 
+  permissions :toggle_public? do
+
+    it 'allows admin to change it' do
+      expect(subject).to permit(admin, namespace)
+    end
+
+    it 'disallows access to user who is not part of the team' do
+      expect(subject).to_not permit(user, namespace)
+    end
+
+    it 'disallow access to user with viewer role' do
+      expect(subject).to_not permit(viewer, namespace)
+    end
+
+    it 'disallow access to user with contributor role' do
+      expect(subject).to_not permit(contributor, namespace)
+    end
+
+    context 'global namespace' do
+      let(:namespace) { create(:namespace, global:true, public: true) }
+
+      it 'disallow access to everybody' do
+        expect(subject).to_not permit(admin, namespace)
+      end
+    end
+
+  end
+
+  describe 'scope' do
+
+    it 'shows namespaces controlled by teams the user is member of' do
+      expected = team.namespaces
+      expect(Pundit.policy_scope(viewer, Namespace).to_a).to match_array(expected)
+
+      expect(Pundit.policy_scope(create(:user), Namespace).to_a).to be_empty
+    end
+
+    it 'always shows public namespaces' do
+      n = create(:namespace, public: true)
+      create(:team, namespaces: [n], owners: [owner])
+      expect(Pundit.policy_scope(create(:user), Namespace).to_a).to match_array([n])
+    end
+
+    it 'never shows public or personal namespaces' do
+      user = create(:user)
+      expect(Namespace.find_by(name: user.username)).not_to be_nil
+      create(:namespace, global: true, public: true)
+      expect(Pundit.policy_scope(create(:user), Namespace).to_a).to be_empty
+    end
+
+  end
+
 end

--- a/spec/policies/team_policy_spec.rb
+++ b/spec/policies/team_policy_spec.rb
@@ -28,7 +28,15 @@ describe TeamPolicy do
     it 'returns only teams having the user as a memeber' do
       # Another team not related with 'owner'
       create(:team, owners: [ create(:user) ])
-      expect(Pundit.policy_scope(member, Team).to_a).to match_array(member.teams)
+
+      expected_list = [team]
+      expect(Pundit.policy_scope(member, Team).to_a).to match_array(expected_list)
+    end
+
+    it 'never shows the team associated with personal repository' do
+      user = create(:user)
+      expect(user.teams).not_to be_empty
+      expect(Pundit.policy_scope(user, Team).to_a).to be_empty
     end
   end
 


### PR DESCRIPTION
This PR introduces the concept of global namespace.

## Global namespaces

A global namespace is identified by a boolean flag and it's associated with a Registry instance. Global namespaces are **always** public, meaning everybody can pull from them. Only admin users can push to them. As usual there's a team behind the global namespace, so an admin user could add contributors to it to have more people with pull rights.

## Hidden teams

The team model now has a new boolean attribute: hidden. This is used to hide certain teams like: the one associated to a global namespace and the one associated with a personal user namespace.

## UI changes

### Namespaces index

The namespaces page now has to sections: special namespaces and normal ones. The special section contains the global namespaces plus the personal namespace of the user (this addresses some of the points of issue #54).

![namespaces index](https://cloud.githubusercontent.com/assets/22728/7684946/6405224c-fd8a-11e4-88cb-60c92295a01a.png)

### Teams index

The team page hides all the teams that have `hidden` set to `true`. This fixes some of the points of issue #54.

![team index](https://cloud.githubusercontent.com/assets/22728/7684986/c2cbe572-fd8a-11e4-9bca-4b317294ab81.png)

In the above screenshot the user is part of 0 teams as opposed to before when the team of the personal namespace would have been shown.
