### PR TITLE
Fix db constraints

### DIFF
--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -8,6 +8,7 @@ class Namespace < ActiveRecord::Base
   belongs_to :team
   validates :name,
             presence: true,
+            uniqueness: { scope: 'registry_id' },
             format: {
               with: /\A[#{NAME_ALLOWED_CHARS}]+\Z/,
               message: 'Only allowed letters: [a-z0-9-_]' }

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -2,8 +2,17 @@ class Repository < ActiveRecord::Base
   include PublicActivity::Common
   include SearchCop
 
+  NAME_ALLOWED_CHARS = 'a-z0-9\-_'
+
   belongs_to :namespace
   has_many :tags
+
+  validates :name,
+            presence: true,
+            uniqueness: { scope: 'namespace_id' },
+            format: {
+              with: /\A[#{NAME_ALLOWED_CHARS}]+\Z/,
+              message: 'Only allowed letters: [a-z0-9-_]' }
 
   search_scope :search do
     attributes :name

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -3,4 +3,11 @@ class Tag < ActiveRecord::Base
   belongs_to :repository
   belongs_to :author, class_name: 'User', foreign_key: 'user_id'
 
+  validates :name,
+            presence: true,
+            uniqueness: { scope: 'repository_id' },
+            format: {
+              with: /\A[A-Za-z0-9_\.\-]{1,128}\Z/,
+              message: 'Only allowed letters: [A-Za-z0-9_.-]{1,128}' }
+
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,8 +1,8 @@
 class Team < ActiveRecord::Base
   include PublicActivity::Common
 
-  validates :name, :owners, presence: true
-
+  validates :name, presence: true, uniqueness: true
+  validates :owners, presence: true
   has_many :namespaces
 
   has_many :team_users

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,8 +9,16 @@ class User < ActiveRecord::Base
                        exclusion: { in: %w(portus),
                                     message: '%{value} is reserved.' }
 
+  validate :private_namespace_available, on: :create
+
   has_many :team_users
   has_many :teams, through: :team_users
+
+  def private_namespace_available
+    if Namespace.exists?(name: username)
+      errors.add(:username, 'cannot be used as name for private namespace')
+    end
+  end
 
   def create_personal_team!
     if Team.find_by(name: username).nil?

--- a/db/migrate/20150522140822_add_index_name_on_teams.rb
+++ b/db/migrate/20150522140822_add_index_name_on_teams.rb
@@ -1,0 +1,5 @@
+class AddIndexNameOnTeams < ActiveRecord::Migration
+  def change
+    add_index :teams, :name, unique: true
+  end
+end

--- a/db/migrate/20150522141052_fix_index_name_on_repositories.rb
+++ b/db/migrate/20150522141052_fix_index_name_on_repositories.rb
@@ -1,0 +1,6 @@
+class FixIndexNameOnRepositories < ActiveRecord::Migration
+  def change
+    remove_index :repositories, column: :name
+    add_index :repositories, [:name, :namespace_id], unique: true
+  end
+end

--- a/db/migrate/20150522141547_fix_index_name_on_namespaces.rb
+++ b/db/migrate/20150522141547_fix_index_name_on_namespaces.rb
@@ -1,0 +1,6 @@
+class FixIndexNameOnNamespaces < ActiveRecord::Migration
+  def change
+    remove_index :namespaces, column: :name
+    add_index :namespaces, [:name, :registry_id], unique: true
+  end
+end

--- a/db/migrate/20150522144027_add_index_on_tag_name_repository_id.rb
+++ b/db/migrate/20150522144027_add_index_on_tag_name_repository_id.rb
@@ -1,0 +1,5 @@
+class AddIndexOnTagNameRepositoryId < ActiveRecord::Migration
+  def change
+    add_index :tags, [:name, :repository_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150521145620) do
+ActiveRecord::Schema.define(version: 20150522144027) do
 
   create_table "activities", force: :cascade do |t|
     t.integer  "trackable_id",   limit: 4
@@ -41,8 +41,8 @@ ActiveRecord::Schema.define(version: 20150521145620) do
     t.boolean  "global",      limit: 1,   default: false
   end
 
+  add_index "namespaces", ["name", "registry_id"], name: "index_namespaces_on_name_and_registry_id", unique: true, using: :btree
   add_index "namespaces", ["name"], name: "fulltext_index_namespaces_on_name", type: :fulltext
-  add_index "namespaces", ["name"], name: "index_namespaces_on_name", unique: true, using: :btree
   add_index "namespaces", ["registry_id"], name: "index_namespaces_on_registry_id", using: :btree
   add_index "namespaces", ["team_id"], name: "index_namespaces_on_team_id", using: :btree
 
@@ -63,8 +63,8 @@ ActiveRecord::Schema.define(version: 20150521145620) do
     t.datetime "updated_at",                            null: false
   end
 
+  add_index "repositories", ["name", "namespace_id"], name: "index_repositories_on_name_and_namespace_id", unique: true, using: :btree
   add_index "repositories", ["name"], name: "fulltext_index_repositories_on_name", type: :fulltext
-  add_index "repositories", ["name"], name: "index_repositories_on_name", unique: true, using: :btree
   add_index "repositories", ["namespace_id"], name: "index_repositories_on_namespace_id", using: :btree
 
   create_table "tags", force: :cascade do |t|
@@ -75,6 +75,7 @@ ActiveRecord::Schema.define(version: 20150521145620) do
     t.integer  "user_id",       limit: 4
   end
 
+  add_index "tags", ["name", "repository_id"], name: "index_tags_on_name_and_repository_id", unique: true, using: :btree
   add_index "tags", ["repository_id"], name: "index_tags_on_repository_id", using: :btree
   add_index "tags", ["user_id"], name: "index_tags_on_user_id", using: :btree
 
@@ -95,6 +96,8 @@ ActiveRecord::Schema.define(version: 20150521145620) do
     t.datetime "updated_at",                             null: false
     t.boolean  "hidden",     limit: 1,   default: false
   end
+
+  add_index "teams", ["name"], name: "index_teams_on_name", unique: true, using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "username",               limit: 255, default: "",    null: false

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,11 +4,22 @@ describe User do
 
   subject { create(:user) }
 
+  let(:registry) { create(:registry) }
+  let(:team) { create(:team, owners: [ subject ]) }
+
   it { should validate_uniqueness_of(:email) }
   it { should validate_uniqueness_of(:username) }
   it { should allow_value('test1', '1test').for(:username) }
   it { should_not allow_value('portus', 'foo', '1Test', 'another_test').for(:username) }
 
+  it 'should block user creation when the private namespace is not available' do
+    name = 'coolname'
+    create(:namespace, team: team, name: name)
+    user = build(:user, username: name)
+    expect(user.save).to be false
+    expect(user.errors.size).to eq(1)
+    expect(user.errors.first).to match_array([:username, 'cannot be used as name for private namespace'])
+  end
 
   describe '#create_personal_team!' do
 


### PR DESCRIPTION
Ensure:
  * a user cannot be created when there's already a namespace with the
    same name
  * namespace names must be unique relatively to the registry they
    belong to
  * repositories names must be unique relatively to the namespace they
    belong to
  * tags names must be unique relatively to the repository they belong
    to
  * team name must be unique

We are now verifying the format of the name used by repositories and
tags. As usual we follow docker's directives.

This fixes issue #74 and issue #68