### PR TITLE
Don't allocate automatically a namespace upon team creation

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -23,7 +23,6 @@ class TeamsController < ApplicationController
 
     if @team.save
       @team.create_activity :create, owner: current_user
-      @team.namespaces.first.create_activity :create, owner: current_user
       respond_with(@team)
     else
       respond_with @team.errors, status: :unprocessable_entity

--- a/app/models/registry.rb
+++ b/app/models/registry.rb
@@ -8,10 +8,12 @@ class Registry < ActiveRecord::Base
       name: Namespace.sanitize_name(hostname),
       owners: [User.where(admin: true).first],
       hidden: true)
-    team.namespaces.last.update_attributes({
+    Namespace.create!(
+      name: Namespace.sanitize_name(hostname),
       registry: self,
       public: true,
-      global: true })
+      global: true,
+      team: team)
   end
 
   def global_namespace

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -16,14 +16,6 @@ class Team < ActiveRecord::Base
 
   before_create :downcase?
 
-  def create_team_namespace!
-    # TODO: change once we allow more registries to be handled by portus
-    registry = Registry.first
-    Namespace.find_or_create_by!(team: self,
-                                 name: Namespace.sanitize_name(name),
-                                 registry: registry)
-  end
-
   private
 
   def downcase?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,10 +20,20 @@ class User < ActiveRecord::Base
     end
   end
 
-  def create_personal_team!
-    if Team.find_by(name: username).nil?
-      Team.create!(name: username, owners: [self], hidden: true)
+  def create_personal_namespace!
+    # the registry is not configured yet, we cannot create the namespace
+    return unless Registry.any?
+
+    team = Team.find_by(name: username)
+    if team.nil?
+      team = Team.create!(name: username, owners: [self], hidden: true)
     end
+
+    Namespace.find_or_create_by!(
+      team: team,
+      name: username,
+      registry: Registry.last # TODO: fix once we handle more registries
+    )
   end
 
 end

--- a/app/observers/registry_observer.rb
+++ b/app/observers/registry_observer.rb
@@ -2,6 +2,12 @@ class RegistryObserver < ActiveRecord::Observer
 
   def after_create(registry)
     registry.create_global_namespace!
+
+    # Now it is possible to create the private namespaces
+    # of all the users that signed into portus _before_
+    # the 1st registry was created
+    # TODO: change code once we support multiple registries
+    User.all.each(&:create_personal_namespace!)
   end
 
 end

--- a/app/observers/team_observer.rb
+++ b/app/observers/team_observer.rb
@@ -1,7 +1,0 @@
-class TeamObserver < ActiveRecord::Observer
-
-  def after_create(team)
-    team.create_team_namespace!
-  end
-
-end

--- a/app/observers/user_observer.rb
+++ b/app/observers/user_observer.rb
@@ -1,7 +1,7 @@
 class UserObserver < ActiveRecord::Observer
 
   def after_create(user)
-    user.create_personal_team!
+    user.create_personal_namespace!
   end
 
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,7 +23,7 @@ module Portus
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
 
-    config.active_record.observers = :user_observer, :team_observer, :registry_observer
+    config.active_record.observers = :user_observer, :registry_observer
 
     config.otp_secret = ROTP::Base32.random_base32
   end

--- a/spec/controllers/teams_controller_spec.rb
+++ b/spec/controllers/teams_controller_spec.rb
@@ -82,16 +82,12 @@ RSpec.describe TeamsController, type: :controller do
     it 'creation of new teams' do
       expect do
         post :create, { team: valid_attributes, format: :js }
-      end.to change(PublicActivity::Activity, :count).by(2)
+      end.to change(PublicActivity::Activity, :count).by(1)
 
       team = Team.last
       team_creation_activity = PublicActivity::Activity.find_by(key: 'team.create')
       expect(team_creation_activity.owner).to eq(owner)
       expect(team_creation_activity.trackable).to eq(team)
-
-      namespace_creation_activity = PublicActivity::Activity.find_by(key: 'namespace.create')
-      expect(namespace_creation_activity.owner).to eq(owner)
-      expect(namespace_creation_activity.trackable).to eq(team.namespaces.first)
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,9 +4,6 @@ describe User do
 
   subject { create(:user) }
 
-  let(:registry) { create(:registry) }
-  let(:team) { create(:team, owners: [ subject ]) }
-
   it { should validate_uniqueness_of(:email) }
   it { should validate_uniqueness_of(:username) }
   it { should allow_value('test1', '1test').for(:username) }
@@ -14,6 +11,7 @@ describe User do
 
   it 'should block user creation when the private namespace is not available' do
     name = 'coolname'
+    team = create(:team, owners: [ subject ])
     create(:namespace, team: team, name: name)
     user = build(:user, username: name)
     expect(user.save).to be false
@@ -21,17 +19,37 @@ describe User do
     expect(user.errors.first).to match_array([:username, 'cannot be used as name for private namespace'])
   end
 
-  describe '#create_personal_team!' do
+  describe '#create_personal_namespace!' do
 
-    it 'creates a team and a namespace with the name of username' do
-      subject.create_personal_team!
-      team = Team.find_by!(name: subject.username)
-      Namespace.find_by!(name: subject.username)
-      TeamUser.find_by!(user: subject, team: team)
-      expect(team.owners).to include(subject)
-      expect(team).to be_hidden
+    context 'no registry defined yet' do
+      before :each do
+        expect(Registry.count).to be(0)
+      end
+
+      it 'does nothing' do
+        subject.create_personal_namespace!
+
+        expect(Team.find_by(name: subject.username)).to be(nil)
+        expect(Namespace.find_by(name: subject.username)).to be(nil)
+      end
+
+    end
+
+    context 'registry defined' do
+      before :each do
+        create(:user, admin: true)
+        create(:registry)
+      end
+
+      it 'creates a team and a namespace with the name of username' do
+        subject.create_personal_namespace!
+        team = Team.find_by!(name: subject.username)
+        Namespace.find_by!(name: subject.username)
+        TeamUser.find_by!(user: subject, team: team)
+        expect(team.owners).to include(subject)
+        expect(team).to be_hidden
+      end
     end
 
   end
-
 end

--- a/spec/observers/registry_observer_spec.rb
+++ b/spec/observers/registry_observer_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe RegistryObserver do
+
+  before :each do
+    @admin = create(:user, admin: true)
+    @user  = create(:user)
+
+    expect(Namespace.count).to be(0)
+  end
+
+  describe 'after_create' do
+
+    before :each do
+      create(:registry)
+    end
+
+    it 'all users have a personal namespace' do
+      User.all.each do |user|
+        expect(Namespace.find_by(name: user.username)).not_to be(nil)
+      end
+    end
+
+  end
+end

--- a/spec/observers/user_observer_spec.rb
+++ b/spec/observers/user_observer_spec.rb
@@ -7,7 +7,7 @@ describe UserObserver do
   describe 'after_create' do
 
     it 'calls create_personal_team! on a user' do
-      expect(user).to receive(:create_personal_team!)
+      expect(user).to receive(:create_personal_namespace!)
       described_class.instance.after_create(user)
     end
 

--- a/spec/policies/namespace_policy_spec.rb
+++ b/spec/policies/namespace_policy_spec.rb
@@ -4,8 +4,6 @@ describe NamespacePolicy do
 
   subject { described_class }
 
-  let(:registry)    { create(:registry) }
-  let(:admin)       { create(:user, admin: true) }
   let(:user)        { create(:user) }
   let(:owner)       { create(:user) }
   let(:viewer)      { create(:user) }
@@ -16,7 +14,12 @@ describe NamespacePolicy do
            contributors: [ contributor ],
            viewers: [ viewer ])
   end
-  let(:namespace) { team.namespaces.first }
+  let(:namespace) { create(:namespace, registry: @registry, team: team) }
+
+  before :each do
+    @admin = create(:user, admin: true)
+    @registry = create(:registry)
+  end
 
   permissions :pull? do
 
@@ -42,11 +45,11 @@ describe NamespacePolicy do
     end
 
     it 'allows access to admin users even if they are not part of the team' do
-      expect(subject).to permit(admin, namespace)
+      expect(subject).to permit(@admin, namespace)
     end
 
     it 'always allows access to a global namespace' do
-      expect(subject).to permit(create(:user), registry.global_namespace)
+      expect(subject).to permit(create(:user), @registry.global_namespace)
     end
 
   end
@@ -71,11 +74,11 @@ describe NamespacePolicy do
 
     context 'global namespace' do
       it 'allows access to administrators' do
-        expect(subject).to permit(admin, registry.global_namespace)
+        expect(subject).to permit(@admin, @registry.global_namespace)
       end
 
       it 'denies access to other users' do
-        expect(subject).not_to permit(user, registry.global_namespace)
+        expect(subject).not_to permit(user, @registry.global_namespace)
       end
     end
 
@@ -84,7 +87,7 @@ describe NamespacePolicy do
   permissions :toggle_public? do
 
     it 'allows admin to change it' do
-      expect(subject).to permit(admin, namespace)
+      expect(subject).to permit(@admin, namespace)
     end
 
     it 'disallows access to user who is not part of the team' do
@@ -103,7 +106,7 @@ describe NamespacePolicy do
       let(:namespace) { create(:namespace, global: true, public: true) }
 
       it 'disallow access to everybody' do
-        expect(subject).to_not permit(admin, namespace)
+        expect(subject).to_not permit(@admin, namespace)
       end
     end
 

--- a/spec/policies/team_policy_spec.rb
+++ b/spec/policies/team_policy_spec.rb
@@ -4,9 +4,13 @@ describe TeamPolicy do
 
   subject { described_class }
 
-  let(:admin) { create(:user, admin: true) }
   let(:member) { create(:user) }
   let(:team) { create(:team, owners: [ member ]) }
+
+  before :each do
+    @admin = create(:user, admin: true)
+    create(:registry)
+  end
 
   permissions :is_member? do
 
@@ -19,7 +23,7 @@ describe TeamPolicy do
     end
 
     it 'allows access to an admin even if he is not part of the team' do
-      expect(subject).to permit(admin, team)
+      expect(subject).to permit(@admin, team)
     end
 
   end


### PR DESCRIPTION
When creating a new team no namespace will be automatically created.
This implments what discussed inside of #73. It also fixes #72 and
makes #53 useless.