### PR TITLE
Adapted the style of the profile page and fixed some bugs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -355,3 +355,6 @@ DEPENDENCIES
   webmock
   wirb
   wirble
+
+BUNDLED WITH
+   1.10.2

--- a/app/assets/javascripts/profile.js.coffee
+++ b/app/assets/javascripts/profile.js.coffee
@@ -1,10 +1,7 @@
 
 jQuery ->
   email = $('#user_email').val()
-  console.log email
   $('#user_email').keyup ->
-    console.log $('#user_email').val()
-    console.log email
     if $('#user_email').val() == email
       $('#edit_user.profile .btn').attr('disabled', 'disabled')
     else

--- a/app/assets/javascripts/profile.js.coffee
+++ b/app/assets/javascripts/profile.js.coffee
@@ -1,0 +1,21 @@
+
+jQuery ->
+  email = $('#user_email').val()
+  console.log email
+  $('#user_email').keyup ->
+    console.log $('#user_email').val()
+    console.log email
+    if $('#user_email').val() == email
+      $('#edit_user.profile .btn').attr('disabled', 'disabled')
+    else
+      $('#edit_user.profile .btn').removeAttr('disabled')
+
+  $('#edit_user.password .form-control').keyup ->
+    current = $('#user_current_password').val()
+    password = $('#user_password').val()
+    confirm = $('#user_password_confirmation').val()
+
+    if current != '' && password != '' && confirm != '' && password == confirm
+      $('#edit_user.password .btn').removeAttr('disabled')
+    else
+      $('#edit_user.password .btn').attr('disabled', 'disabled')

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -28,3 +28,7 @@
 .table > tfoot > tr > td {
   vertical-align: middle;
 }
+
+#profile .panel {
+  max-width: 700px;
+}

--- a/app/controllers/auth/registrations_controller.rb
+++ b/app/controllers/auth/registrations_controller.rb
@@ -1,9 +1,28 @@
 class Auth::RegistrationsController < Devise::RegistrationsController
 
-  layout 'authentication'
+  layout 'authentication', except: :edit
 
   before_filter :check_admin, only: [ :new, :create ]
   before_filter :configure_sign_up_params, only: [ :create ]
+
+  def update
+    success =
+    if password_update?
+      current_user.update_with_password(params.require(:user).permit(
+        :password, :password_confirmation, :current_password
+      ))
+    else
+      current_user.update_without_password(params.require(:user).permit(:email))
+    end
+
+    if success
+      redirect_to edit_user_registration_url,
+        notice: 'Profile updated successfully!'
+    else
+      redirect_to edit_user_registration_url,
+        alert: resource.errors.full_messages[0]
+    end
+  end
 
   def check_admin
     @admin = User.exists?(admin: true)
@@ -14,6 +33,16 @@ class Auth::RegistrationsController < Devise::RegistrationsController
     unless User.exists?(admin: true)
       devise_parameter_sanitizer.for(:sign_up) << :admin
     end
+  end
+
+  protected
+
+  # Returns true if the contents of the `params` hash contains the needed keys
+  # to update the password of the user.
+  def password_update?
+    user = params[:user]
+    !user[:current_password].blank? || !user[:password].blank? ||
+      !user[:password_confirmation].blank?
   end
 
 end

--- a/app/views/devise/registrations/edit.html.slim
+++ b/app/views/devise/registrations/edit.html.slim
@@ -1,31 +1,50 @@
-h2 Edit #{resource_name.to_s.humanize}s
-= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
-  = devise_error_messages!
-  .field
-    = f.label :email
-    br
-    = f.email_field :email, autofocus: true
-  - if devise_mapping.confirmable? && resource.pending_reconfirmation?
-    div
-      Currently waiting confirmation for: #{resource.unconfirmed_email}
-  .field
-    = f.label :password
-    i
-      | (leave blank if you don't want to change it)
-    br
-    = f.password_field :password, autocomplete: 'off'
-  .field
-    = f.label :password_confirmation
-    br
-    = f.password_field :password_confirmation, autocomplete: 'off'
-  .field
-    = f.label :current_password
-    i
-      | (we need your current password to confirm your changes)
-    br
-    = f.password_field :current_password, autocomplete: 'off'
-  .actions
-    = f.submit 'Update'
-  h3 Cancel my account
-  p Unhappy? #{button_to 'Cancel my account', registration_path(resource_name), data: { confirm: 'Are you sure?' }, method: :delete }
-  = link_to 'Back', :back
+
+#profile
+
+  .[class="panel panel-default"]
+    .panel-heading
+      h2[class='panel-title panel-heading'] Public Profile
+    .panel-body
+      = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: 'profile' }) do |f|
+        .form-group
+          .field
+            = f.label :email
+            = f.text_field(:email, class: 'form-control', required: true)
+        .form-group
+          .actions
+            = f.submit('Update', class: 'btn btn-primary', disabled: true)
+
+  .[class="panel panel-default"]
+    .panel-heading
+      h2[class='panel-title panel-heading'] Change Password
+    .panel-body
+      = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: 'password' }) do |f|
+        - if devise_mapping.confirmable? && resource.pending_reconfirmation?
+          div
+            Currently waiting confirmation for: #{resource.unconfirmed_email}
+        .form-group
+          .field
+            = f.label :current_password, class: 'control-label'
+            = f.password_field :current_password, autocomplete: 'off', class: 'form-control'
+            br
+          .field
+            = f.label :password, class: 'control-label'
+            = f.password_field :password, autocomplete: 'off', class: 'form-control'
+            br
+          .field
+            = f.label :password_confirmation, class: 'control-label'
+            = f.password_field :password_confirmation, autocomplete: 'off', class: 'form-control'
+        .form-group
+          .actions
+            = f.submit('Change', class: 'btn btn-primary', disabled: true)
+
+
+  .[class="panel panel-default"]
+    .panel-heading
+      h2[class='panel-title panel-heading'] Cancel account
+    .panel-body
+      = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :delete }, data: { confirm: 'Are you sure?' }) do |f|
+        p
+          | Don't make any rush decissions, once you cancel your account there is no going back.
+        .actions
+          = f.submit('Cancel your account', class: 'btn btn-danger')


### PR DESCRIPTION
As described in the issue #80, the profile page was quite broken. This PR fixes this situation. In order to do this, the `update` method from `devise` has to be re-implemented, otherwise we will face some issues regarding password fields. That being said, I've tried to use as many `devise` methods inside this new `update` method as possible, so it is as consistent as possible. The mandatory screenshot:
![snapshot2](https://cloud.githubusercontent.com/assets/767943/7960078/10cd3846-09fe-11e5-8fd9-a4828f6dbdbb.png)
As you can see, I don't allow panels to fill the width, because personally I think that it looks ugly then. Moreover, I've also added some coffeescript to enable/disable buttons as needed.