### PR TITLE
Allow the user to disable Gravatar support.

### DIFF
--- a/app/assets/javascripts/profile.js.coffee
+++ b/app/assets/javascripts/profile.js.coffee
@@ -7,6 +7,14 @@ jQuery ->
     else
       $('#edit_user.profile .btn').removeAttr('disabled')
 
+  gravatar = $('#user_gravatar').is(':checked')
+  $('#user_gravatar').click ->
+    if $('#user_gravatar').is(':checked') == gravatar
+      $('#edit_user.profile .btn').attr('disabled', 'disabled')
+    else
+      $('#edit_user.profile .btn').removeAttr('disabled')
+
+
   $('#edit_user.password .form-control').keyup ->
     current = $('#user_current_password').val()
     password = $('#user_password').val()

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -32,3 +32,16 @@
 #profile .panel {
   max-width: 700px;
 }
+
+#profile .gravatar label {
+  font-weight: normal;
+
+  input {
+    padding: 0;
+    margin:0;
+    vertical-align: middle;
+    margin-right: 5px;
+    position: relative;
+    top: -1px;
+  }
+}

--- a/app/controllers/auth/registrations_controller.rb
+++ b/app/controllers/auth/registrations_controller.rb
@@ -12,7 +12,9 @@ class Auth::RegistrationsController < Devise::RegistrationsController
         :password, :password_confirmation, :current_password
       ))
     else
-      current_user.update_without_password(params.require(:user).permit(:email))
+      current_user.update_without_password(params.require(:user).permit(
+        :email, :gravatar
+      ))
     end
 
     if success

--- a/app/views/devise/registrations/edit.html.slim
+++ b/app/views/devise/registrations/edit.html.slim
@@ -10,6 +10,11 @@
           .field
             = f.label :email
             = f.text_field(:email, class: 'form-control', required: true)
+            br
+          .field.gravatar
+            = f.label :gravatar
+              = f.check_box(:gravatar)
+              | Get the profile picture from Gravatar.
         .form-group
           .actions
             = f.submit('Update', class: 'btn btn-primary', disabled: true)

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -11,7 +11,10 @@
 .pull-right.user-header.hidden-xs
 
   .hidden-xs
-    = gravatar_image_tag(current_user.email)
+    - if current_user.gravatar?
+      = gravatar_image_tag(current_user.email)
+    - else
+      i.fa.fa-user.fa-1x
     = link_to edit_user_registration_url, class: 'nav-a' do
       span.username = current_user.username
   = link_to destroy_user_session_url, method: :delete, class: 'btn btn-default', id: 'logout' do

--- a/db/migrate/20150603132325_add_gravatar_to_users.rb
+++ b/db/migrate/20150603132325_add_gravatar_to_users.rb
@@ -1,0 +1,5 @@
+class AddGravatarToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :gravatar, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150522144027) do
+ActiveRecord::Schema.define(version: 20150603132325) do
 
   create_table "activities", force: :cascade do |t|
     t.integer  "trackable_id",   limit: 4
@@ -114,6 +114,7 @@ ActiveRecord::Schema.define(version: 20150522144027) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean  "admin",                  limit: 1,   default: false
+    t.boolean  "gravatar",               limit: 1,   default: true
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/spec/controllers/auth/registrations_controller_spec.rb
+++ b/spec/controllers/auth/registrations_controller_spec.rb
@@ -62,6 +62,14 @@ describe Auth::RegistrationsController do
       expect(User.find(user.id).email).to eq('valid@example.com')
     end
 
+    it 'changes the Gravatar settings accordingly', focus: true do
+      expect(User.find(user.id).gravatar?).to be true
+      put :update, user: { 'gravatar' => 0 }
+      expect(User.find(user.id).gravatar?).to be false
+      put :update, user: { 'gravatar' => 1 }
+      expect(User.find(user.id).gravatar?).to be true
+    end
+
     # NOTE: since the tests on passwords also have to take care that even if
     # there are other parameters (e.g. emails), they are ignored when there are
     # password parameters, these tests will always have an extra parameter.

--- a/spec/controllers/auth/registrations_controller_spec.rb
+++ b/spec/controllers/auth/registrations_controller_spec.rb
@@ -62,7 +62,7 @@ describe Auth::RegistrationsController do
       expect(User.find(user.id).email).to eq('valid@example.com')
     end
 
-    it 'changes the Gravatar settings accordingly', focus: true do
+    it 'changes the Gravatar settings accordingly' do
       expect(User.find(user.id).gravatar?).to be true
       put :update, user: { 'gravatar' => 0 }
       expect(User.find(user.id).gravatar?).to be false


### PR DESCRIPTION
If the user disables gravatar support, then a default image is shown. It looks like this:
![snapshot3](https://cloud.githubusercontent.com/assets/767943/7962932/8258d38c-0a10-11e5-850f-a7ccd65c1e11.png)
I considered using a larger image, but then it's to big :)

Fixes #76 