### PR TITLE
travis: add ruby 2.2 and ruby-head

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: ruby
 rvm:
   - 2.1.3
+  - 2.2
+  - ruby-head
+matrix:
+  allow_failures:
+    - rvm: ruby-head
 before_install:
   - |
     bash -c " # Install MariaDB


### PR DESCRIPTION
The ruby-head version is allowed to fail