### PR TITLE
Always redirect to the signup page if there are no users in the system

### DIFF
--- a/app/controllers/auth/registrations_controller.rb
+++ b/app/controllers/auth/registrations_controller.rb
@@ -5,6 +5,13 @@ class Auth::RegistrationsController < Devise::RegistrationsController
   before_filter :check_admin, only: [ :new, :create ]
   before_filter :configure_sign_up_params, only: [ :create ]
 
+  # Re-implemented so the template has the auxiliary variables regarding if
+  # there are more users on the system or this is the first user to be created.
+  def new
+    @have_users = User.any?
+    super
+  end
+
   def create
     build_resource(sign_up_params)
 

--- a/app/controllers/auth/sessions_controller.rb
+++ b/app/controllers/auth/sessions_controller.rb
@@ -2,6 +2,19 @@ class Auth::SessionsController < Devise::SessionsController
 
   layout 'authentication'
 
+  # Re-implementing. The logic is: if there is already a user that can log in,
+  # work as usual. Otherwise, redirect always to the signup page.
+  def new
+    if User.any?
+      super
+    else
+      # For some reason if we get here from the root path, we'll get a flashy
+      # alert message.
+      flash[:alert] = nil
+      redirect_to new_user_registration_url
+    end
+  end
+
   # Re-implementing both the create and the destroy methods in order to avoid
   # showing the redundant "Signed in/out" flashy messages.
 

--- a/app/views/devise/registrations/new.html.slim
+++ b/app/views/devise/registrations/new.html.slim
@@ -19,5 +19,5 @@ section.sign-up class=(@have_users ? '' : 'first-user')
             | Create account
           - else
             | Create admin
-        - if @admin
+        - if @have_users
           .text-center = link_to 'I already have an account. Login.', new_user_session_url

--- a/app/views/devise/registrations/new.html.slim
+++ b/app/views/devise/registrations/new.html.slim
@@ -1,4 +1,4 @@
-section.sign-up
+section.sign-up class=(@have_users ? '' : 'first-user')
   .center-panel
     .col-md-4.col-sm-2.col-xs-1
     .col-md-4.col-sm-8.col-xs-10.text-center

--- a/spec/features/auth/signup_feature_spec.rb
+++ b/spec/features/auth/signup_feature_spec.rb
@@ -13,12 +13,15 @@ feature 'Signup feature' do
     visit new_user_session_url
     click_link('Create a new account')
     expect(page).to have_field('user_email')
+    expect(page).to_not have_css('section.first-user')
+    expect(page).to_not have_css('#user_admin')
   end
 
-  scenario 'If the admin user has been created, I am not able to create it' do
+  scenario 'The first user to be created is the admin' do
     User.delete_all
     visit new_user_registration_url
     expect(page).to have_content('Create admin')
+    expect(page).to have_css('#user_admin')
   end
 
   scenario 'As a guest I am able to signup' do
@@ -30,6 +33,18 @@ feature 'Signup feature' do
     click_button('Create account')
     expect(page).to have_content('Activities')
     expect(current_url).to eq root_url
+  end
+
+  scenario 'It always redirects to the signup page when there are no users' do
+    User.delete_all
+
+    visit new_user_session_url
+    expect(current_url).to eq new_user_registration_url
+    visit root_url
+    expect(current_url).to eq new_user_registration_url
+
+    expect(page).to have_css('#user_admin')
+    expect(page).to have_css('section.first-user')
   end
 
   scenario 'As a guest I can see error prohibiting my registration to be completed' do

--- a/spec/features/auth/signup_feature_spec.rb
+++ b/spec/features/auth/signup_feature_spec.rb
@@ -47,6 +47,14 @@ feature 'Signup feature' do
     expect(page).to have_css('section.first-user')
   end
 
+  scenario 'It does not exist a link to login if there are no users' do
+    expect(page).to have_content('Login')
+
+    User.delete_all
+    visit new_user_registration_url
+    expect(page).to_not have_content('Login')
+  end
+
   scenario 'As a guest I can see error prohibiting my registration to be completed' do
     fill_in 'user_username', with: user.username
     fill_in 'user_email', with: 'gibberish'


### PR DESCRIPTION
This PR does not address the part of #100 stating that there should be a text explaining why the first user to be created is the admin. Following the logic of #101, this should be put in the docs, and not in the page itself. So I propose to skip the second point of #100.

Fixes #100