### PR TITLE
Replaced `alerts` for Bootstrap's popover element

### DIFF
--- a/app/assets/javascripts/lifeitup_layout.js
+++ b/app/assets/javascripts/lifeitup_layout.js
@@ -61,7 +61,10 @@ function layout_resizer () {
 // init popovers
 
 $(function () {
-  $('[data-toggle="popover"]').popover()
+  $('body').popover({
+    selector: '[data-toggle="popover"]',
+    trigger: 'focus'
+  })
   // to destroy the popovers that are hidden
   $('[data-toggle="popover"]').on('hidden.bs.popover', function () {
     var popover = $('.popover').not('.in');

--- a/app/views/namespaces/index.html.slim
+++ b/app/views/namespaces/index.html.slim
@@ -1,7 +1,7 @@
 h1
   ' Namespaces
   small
-    a[data-placement="right" data-toggle="popover" data-container="h1" data-trigger="focus" data-content="A namespace groups a series of repositories." data-original-title="What's this?" tabindex="0"]
+    a[data-placement="right" data-toggle="popover" data-container="h1" data-content="A namespace groups a series of repositories." data-original-title="What's this?" tabindex="0"]
       i.fa.fa-info-circle
 
 .[class="panel panel-default"]

--- a/app/views/team_users/_team_user.html.slim
+++ b/app/views/team_users/_team_user.html.slim
@@ -16,10 +16,11 @@ tr[id="team_user_#{team_user.id}"]
         i[class="fa fa-pencil fa-lg"]
     td
       a[class="btn btn-default"
-        data-method="delete"
-        rel="nofollow"
-        data-remote="true"
-        data-confirm="Are you sure?"
-        href=url_for(team_user)
+        data-placement="left"
+        data-toggle="popover"
+        data-content='<p>Are you sure?</p><a class="btn btn-default" data-method="delete" rel="nofollow" data-remote="true" href="#{url_for(team_user)}">Yes</a>'
+        data-html="true"
+        tabindex="0"
+        role="button"
         ]
         i[class="fa fa-trash fa-lg"]

--- a/app/views/teams/show.html.slim
+++ b/app/views/teams/show.html.slim
@@ -21,7 +21,7 @@
       strong
         '#{@team.name}
       small
-        a[data-placement="right" data-toggle="popover" data-container=".panel-heading" data-trigger="focus" data-content="<p>There are three types of users inside of a team:<br><strong>Viewer:</strong> has read only access. Only pull operations are permitted.<br/><strong>Contributor:</strong> has read and write access. Both pull and push operations are permitted.<br/><strong>Owner:</strong> like 'contributor', but can also manage the team.</p>" data-original-title="What's this?" tabindex="0" data-html="true"]
+        a[data-placement="right" data-toggle="popover" data-container=".panel-heading" data-content="<p>There are three types of users inside of a team:<br><strong>Viewer:</strong> has read only access. Only pull operations are permitted.<br/><strong>Contributor:</strong> has read and write access. Both pull and push operations are permitted.<br/><strong>Owner:</strong> like 'contributor', but can also manage the team.</p>" data-original-title="What's this?" tabindex="0" data-html="true"]
           i.fa.fa-info-circle
 
       - if can_manage_team?(@team)
@@ -73,7 +73,7 @@
       strong
         '#{@team.name}
       small
-        a[data-placement="right" data-toggle="popover" data-container=".panel-heading" data-trigger="focus" data-content='<p>A team can own one or more namespaces. By default all the namespaces can be accessed only by the members of the team.</p><p>It is possible to add read only (pull) access to all Portus users by toggling the "public" flag.</p>' data-original-title="What's this?" tabindex="0" data-html="true"]
+        a[data-placement="right" data-toggle="popover" data-container=".panel-heading" data-content='<p>A team can own one or more namespaces. By default all the namespaces can be accessed only by the members of the team.</p><p>It is possible to add read only (pull) access to all Portus users by toggling the "public" flag.</p>' data-original-title="What's this?" tabindex="0" data-html="true"]
           i.fa.fa-info-circle
       - if can_manage_team?(@team)
         .pull-right


### PR DESCRIPTION
Moreover, since these popovers have to appear for dynamically-generated
content, then we have to change the lifeitup code that handled popovers in
order to take this into account. Finally, I've moved all the "data-trigger"
attributes to the JS config.

Fixes #106