### PR TITLE
rubocop: added cops for rails

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -457,6 +457,7 @@ Style/DotPosition:
   Enabled: true
 
 AllCops:
+  RunRailsCops: true
   Include:
     - Rakefile
     - config.ru

--- a/app/controllers/api/v2/tokens_controller.rb
+++ b/app/controllers/api/v2/tokens_controller.rb
@@ -1,6 +1,6 @@
 class Api::V2::TokensController < Api::BaseController
 
-  before_filter :authenticate
+  before_action :authenticate
 
   def authenticate
     if params['account'] == 'portus'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
-  before_filter :authenticate_user!
+  before_action :authenticate_user!
   protect_from_forgery with: :exception
 
   include Pundit

--- a/app/controllers/auth/registrations_controller.rb
+++ b/app/controllers/auth/registrations_controller.rb
@@ -2,8 +2,8 @@ class Auth::RegistrationsController < Devise::RegistrationsController
 
   layout 'authentication', except: :edit
 
-  before_filter :check_admin, only: [ :new, :create ]
-  before_filter :configure_sign_up_params, only: [ :create ]
+  before_action :check_admin, only: [ :new, :create ]
+  before_action :configure_sign_up_params, only: [ :create ]
 
   # Re-implemented so the template has the auxiliary variables regarding if
   # there are more users on the system or this is the first user to be created.

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,7 @@
 if ENV['INTEGRATION_TESTS']
-  puts 'Adding user username31'
+  Rails.logger.info 'Adding user username31'
   if (User.find_by_username('username31'))
-    puts 'User already exists. Please drop the database first'
+    Rails.logger.fatal 'User already exists. Please drop the database first'
     exit -1
   end
   User.create(
@@ -11,7 +11,7 @@ if ENV['INTEGRATION_TESTS']
     admin: true
   )
 
-  puts 'Adding registry portus.suse.example.com:5000'
+  Rails.logger.info 'Adding registry portus.suse.example.com:5000'
   Registry.create(
     name: 'portus.suse.example.com:5000',
     hostname: 'portus.suse.example.com:5000'


### PR DESCRIPTION
The reported issues have been:

- Since 4.2 *_filter methods are discouraged, in favor of *_action methods.
- We should use Rails.logger instead of puts.