### PR TITLE
Show the cleaned name of the namespace in the repositories#show page

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,12 +2,4 @@ module ApplicationHelper
   def can_manage_namespace?(namespace)
     current_user.admin? || namespace.team.owners.exists?(current_user.id)
   end
-
-  def namespace_clean_name(namespace)
-    if namespace.global?
-      namespace.registry.hostname
-    else
-      namespace.name
-    end
-  end
 end

--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -10,4 +10,11 @@ class Namespace < ActiveRecord::Base
   def self.sanitize_name(name)
     name.downcase.gsub(/\s+/, '_').gsub(/[^#{NAME_ALLOWED_CHARS}]/, '')
   end
+
+  # Returns a String containing the cleaned name for this namespace. The
+  # cleaned name will be the registry's hostname if this is a global namespace,
+  # or the name of the namespace itself otherwise.
+  def clean_name
+    global? ? registry.hostname : name
+  end
 end

--- a/app/views/namespaces/_namespace.html.slim
+++ b/app/views/namespaces/_namespace.html.slim
@@ -1,5 +1,5 @@
 tr[id="namespace_#{namespace.id}"]
-  td= link_to namespace_clean_name(namespace), namespace
+  td= link_to namespace.clean_name, namespace
   td= namespace.repositories.count
   td
     - if can_manage_namespace?(namespace) && !namespace.global

--- a/app/views/namespaces/show.html.slim
+++ b/app/views/namespaces/show.html.slim
@@ -3,7 +3,7 @@
     h5
       'Namespace:
       strong
-        = namespace_clean_name(@namespace)
+        = @namespace.clean_name
   .panel-body
     .table-responsive
       table[class="table table-stripped table-hover"]

--- a/app/views/public_activity/repository/_push.html.slim
+++ b/app/views/public_activity/repository/_push.html.slim
@@ -8,6 +8,6 @@
       .clearfix
         .details
           = "#{activity.owner.username} pushed "
-          = link_to namespace_clean_name(activity.trackable.namespace), activity.trackable.namespace
+          = link_to activity.trackable.namespace.clean_name, activity.trackable.namespace
           | /
           = link_to "#{activity.trackable.name}:#{activity.recipient.name}", activity.trackable

--- a/app/views/repositories/index.html.slim
+++ b/app/views/repositories/index.html.slim
@@ -11,5 +11,5 @@
         tbody
           - @repositories.each do |repository|
             tr
-              td= link_to namespace_clean_name(repository.namespace), repository.namespace
+              td= link_to repository.namespace.clean_name, repository.namespace
               td= link_to repository.name, repository

--- a/app/views/repositories/show.html.slim
+++ b/app/views/repositories/show.html.slim
@@ -1,7 +1,7 @@
 .[class="panel panel-default"]
   .panel-heading
     h1
-      = link_to @repository.namespace.name, @repository.namespace
+      = link_to @repository.namespace.clean_name, @repository.namespace
       | /
       = @repository.name
   .panel-body

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -37,19 +37,4 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
-  describe 'namespace_clean_name' do
-    context 'non global namespace' do
-      it 'returns the name of the namespace' do
-        expect(helper.namespace_clean_name(namespace)).to eq(namespace.name)
-      end
-    end
-
-    context 'global namespace' do
-      it 'returns the name of the namespace' do
-        global_namespace = create(:namespace, global: true, public: true, registry: registry)
-        expect(helper.namespace_clean_name(global_namespace)).to eq(registry.hostname)
-      end
-    end
-  end
-
 end

--- a/spec/models/namespace_spec.rb
+++ b/spec/models/namespace_spec.rb
@@ -30,4 +30,24 @@ describe Namespace do
     end
   end
 
+  describe 'namespace_clean_name' do
+    let(:registry)    { create(:registry) }
+    let(:owner)       { create(:user) }
+    let(:team)        { create(:team, owners: [owner]) }
+    let(:namespace)   { create(:namespace, team: team) }
+
+    context 'non global namespace' do
+      it 'returns the name of the namespace' do
+        expect(namespace.clean_name).to eq(namespace.name)
+      end
+    end
+
+    context 'global namespace' do
+      it 'returns the name of the namespace' do
+        global_namespace = create(:namespace, global: true, public: true, registry: registry)
+        expect(global_namespace.clean_name).to eq(registry.hostname)
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
I've also moved the `namespace_clean_name` method into the Namespace model,
since it makes more sense.