### PR TITLE
Make sure that all the admins own the global namespace

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -12,7 +12,7 @@ class Admin::UsersController < Admin::BaseController
     if user == current_user
       render nothing: true, status: 403
     else
-      user.update_attributes(admin: !(user.admin?))
+      user.toggle_admin!
       render template: 'admin/users/toggle_admin', locals: { user: user }
     end
   end

--- a/app/models/registry.rb
+++ b/app/models/registry.rb
@@ -6,7 +6,7 @@ class Registry < ActiveRecord::Base
   def create_global_namespace!
     team = Team.create(
       name: Namespace.sanitize_name(hostname),
-      owners: [User.find_by(admin: true)],
+      owners: User.where(admin: true),
       hidden: true)
     Namespace.create!(
       name: Namespace.sanitize_name(hostname),

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,4 +40,14 @@ class User < ActiveRecord::Base
     logger.error "Cannot find user #{event['actor']['name']}" if actor.nil?
     actor
   end
+
+  # Toggle the 'admin' attribute for this user. It will also update the
+  # registry accordingly.
+  def toggle_admin!
+    admin = !admin?
+    return unless update_attributes(admin: admin) && Registry.any?
+
+    team = Registry.first.global_namespace.team
+    admin ? team.owners << self : team.owners.delete(self)
+  end
 end

--- a/spec/models/registry_spec.rb
+++ b/spec/models/registry_spec.rb
@@ -3,4 +3,18 @@ require 'rails_helper'
 RSpec.describe Registry, type: :model do
 
   it { should have_many(:namespaces) }
+
+  describe '#create_global_namespace' do
+    it 'adds all existing admins to the global team' do
+      # NOTE: the :registry factory already creates an admin
+      create(:user, admin: true)
+      registry = create(:registry)
+
+      owners = registry.global_namespace.team.owners.order('username ASC')
+      users = User.where(admin: true).order('username ASC')
+
+      expect(owners.count).to be(2)
+      expect(users).to match_array(owners)
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -52,4 +52,29 @@ describe User do
     end
 
   end
+
+  describe '#toggle_admin' do
+    let!(:registry) { create(:registry) }
+    let!(:user) { create(:user) }
+
+    it 'Toggles the admin attribute' do
+      # We have a registry and the admin user is the owner.
+      admin = User.where(admin: true).first
+      owners = registry.global_namespace.team.owners
+      expect(owners.count).to be(1)
+      expect(owners.first.id).to be(admin.id)
+
+      # Now we set the new user as another admin.
+      user.toggle_admin!
+      owners = registry.global_namespace.team.owners
+      expect(user.admin?).to be true
+      expect(owners.count).to be(2)
+
+      # Now we remove it as an admin again
+      user.toggle_admin!
+      owners = registry.global_namespace.team.owners
+      expect(owners.count).to be(1)
+      expect(owners.first.id).to be(admin.id)
+    end
+  end
 end


### PR DESCRIPTION
This is a consistency fix. The idea is that the global namespace should be
owned by all the current admins. This means, that:

1. Whenever we add/remove a new admin, this should be updated.
2. When a registry gets created, all the admins should be added.