### PR TITLE
Run Portus using docker-compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git*
+tmp
+vagrant
+packaging
+log/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM rails:4.2.2
+MAINTAINER Flavio Castelli <fcastelli@suse.com>
+
+RUN mkdir /portus
+WORKDIR /portus
+ADD . /portus
+RUN bundle install
+RUN mv /portus/config/database-docker-compose.yml /portus/config/database.yml
+
+EXPOSE 3000

--- a/README.md
+++ b/README.md
@@ -30,6 +30,55 @@ If Portus is unreachable when a new image is being pushed to the Docker registry
 
 ## Development environment
 
+### Docker
+
+It is possible to use docker-compose to spin up a small development/demo
+environment.
+
+The environment consists of two Docker containers linked together:
+
+  * web: this is the container running Portus. It's based on the
+    [official rails](https://registry.hub.docker.com/_/rails/) Docker image.
+
+  * db: this is the container running the database required by Portus. It's
+    based on the
+    [official mariadb](https://registry.hub.docker.com/_/mariadb/) Docker image.
+
+First of all ensure you have [docker-compose](https://www.docker.com/docker-compose)
+installed. Then do:
+
+```
+docker-compose up
+```
+
+This will:
+  * download the `rails` Docker image from the Docker Hub
+  * build the `web` Docker image
+  * download the `mariadb` docker image from the Docker Hub
+  * start the `db` container and link it against a running insitance of the `web` container.
+
+The next step is to create Portus' database:
+
+```
+docker-compose run web rake db:create
+```
+
+Then populate the database by running Rails' migrations (**note well:** this
+might need to be done from time to time, when new migrations are added):
+
+```
+docker-compose run rake db:migrate
+```
+
+Now everything is ready to be used. Portus' UI will be accessible on
+[http://localhost:3000](http://localhost:3000).
+
+#### Demo
+
+[![asciicast](https://asciinema.org/a/23185.png)](https://asciinema.org/a/23185)
+
+### Vagrant
+
 This project contains a Vagrant based development environment which consists of
 three nodes:
 

--- a/config/database-docker-compose.yml
+++ b/config/database-docker-compose.yml
@@ -1,0 +1,21 @@
+default: &default
+  adapter: mysql2
+  encoding: utf8
+  host: db
+  username: root
+  password: portus
+
+development:
+  <<: *default
+  database: portus_development
+
+# Warning: The database defined as "test" will be erased and
+# re-generated from your development database when you run "rake".
+# Do not set this db to the same as development or production.
+test:
+  <<: *default
+  database: portus_test
+
+production:
+  <<: *default
+  database: portus_production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+db:
+  image: mariadb
+  environment:
+    MYSQL_ROOT_PASSWORD: portus
+web:
+  build: .
+  command: bundle exec rails s -p 3000 -b '0.0.0.0'
+  ports:
+    - "3000:3000"
+  links:
+    - db


### PR DESCRIPTION
This commit adds the possibility to run Portus and its database using docker-compose. This is a different take for issue #81.

I'll add the documentation tomorrow. In the meantime feel free to comment on it.

