### PR TITLE
Disabling the `fulltext` option for the repository model for now

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -10,11 +10,11 @@ class Repository < ActiveRecord::Base
     attributes :name
     attributes namespace_name: 'namespace.name'
 
-    # TODO (mssola): we are experiencing some issues with MariaDB's fulltext
+    # TODO: (mssola): we are experiencing some issues with MariaDB's fulltext
     # support. Because of that, the following two options have been disabled
     # until we find a solution for it.
-    #options :name, type: :fulltext
-    #options :namespace_name, type: :fulltext
+    # options :name, type: :fulltext
+    # options :namespace_name, type: :fulltext
   end
 
   # Handle a push event from the registry.

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -10,8 +10,11 @@ class Repository < ActiveRecord::Base
     attributes :name
     attributes namespace_name: 'namespace.name'
 
-    options :name, type: :fulltext
-    options :namespace_name, type: :fulltext
+    # TODO (mssola): we are experiencing some issues with MariaDB's fulltext
+    # support. Because of that, the following two options have been disabled
+    # until we find a solution for it.
+    #options :name, type: :fulltext
+    #options :namespace_name, type: :fulltext
   end
 
   # Handle a push event from the registry.

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe SearchController, type: :controller do
-
   let(:registry)    { create(:registry) }
   let(:user)        { create(:user) }
   let(:team)        { create(:team, owners: [user]) }
@@ -17,13 +16,6 @@ RSpec.describe SearchController, type: :controller do
     it 'returns http success' do
       get :index, search: @repository.name
       expect(response).to have_http_status(:success)
-
-      # NOTE: we cannot test the contents of @repositories because
-      # MariaDB does not update the fulltext indexes until the transaction
-      # is commited. All the data created by the tests is wrapped inside of a
-      # transaction by rails, so we cannot search for it.
-      # http://dev.mysql.com/doc/refman/5.6/en/fulltext-restrictions.html
     end
   end
-
 end

--- a/spec/policies/repository_policy_spec.rb
+++ b/spec/policies/repository_policy_spec.rb
@@ -40,7 +40,7 @@ describe RepositoryPolicy do
       namespace = create(:namespace, team: team, name: 'mssola')
       create(:repository, namespace: namespace, name: 'repository')
 
-      %w{repository rep epo}.each do |name|
+      %w(repository rep epo).each do |name|
         repo = Pundit.policy_scope(user, Repository).search(name)
         expect(repo.name).to eql 'Repository'
       end

--- a/spec/policies/repository_policy_spec.rb
+++ b/spec/policies/repository_policy_spec.rb
@@ -11,7 +11,6 @@ describe RepositoryPolicy do
   let(:team2)       { create(:team, owners: [user2]) }
 
   describe 'scope' do
-
     before :each do
       public_namespace = create(:namespace, team: team2, public: true, registry: registry)
       @public_repository = create(:repository, namespace: public_namespace)
@@ -34,7 +33,17 @@ describe RepositoryPolicy do
     it 'never shows repositories inside of private namespaces' do
       expect(Pundit.policy_scope(user, Repository).to_a).not_to include(@private_repository)
     end
-
   end
 
+  describe 'search' do
+    it 'finds the same repository regardless to how it has been written'  do
+      namespace = create(:namespace, team: team, name: 'mssola')
+      create(:repository, namespace: namespace, name: 'repository')
+
+      %w{repository rep epo}.each do |name|
+        repo = Pundit.policy_scope(user, Repository).search(name)
+        expect(repo.name).to eql 'Repository'
+      end
+    end
+  end
 end


### PR DESCRIPTION
This works around a regression in the search feature. Basically, MariaDB seems
to fail at some searches when the `fulltext` option has been enabled. We are
still investigating about this.