### PR TITLE
search: Support the `repo:tag` syntax

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,5 +1,6 @@
 class SearchController < ApplicationController
   def index
-    @repositories = policy_scope(Repository).search(params[:search])
+    search = params[:search].split(':').first
+    @repositories = policy_scope(Repository).search(search)
   end
 end

--- a/spec/policies/repository_policy_spec.rb
+++ b/spec/policies/repository_policy_spec.rb
@@ -36,11 +36,19 @@ describe RepositoryPolicy do
   end
 
   describe 'search' do
-    it 'finds the same repository regardless to how it has been written'  do
-      namespace = create(:namespace, team: team, name: 'mssola')
-      create(:repository, namespace: namespace, name: 'repository')
+    let!(:namespace)  { create(:namespace, team: team, name: 'mssola') }
+    let!(:repository) { create(:repository, namespace: namespace, name: 'repository') }
 
+    it 'finds the same repository regardless to how it has been written'  do
       %w(repository rep epo).each do |name|
+        repo = Pundit.policy_scope(user, Repository).search(name)
+        expect(repo.name).to eql 'Repository'
+      end
+    end
+
+    it 'finds repos with the `repo:tag` syntax' do
+      %w(repository rep epo).each do |name|
+        name = "#{name}:tag"
         repo = Pundit.policy_scope(user, Repository).search(name)
         expect(repo.name).to eql 'Repository'
       end


### PR DESCRIPTION
Right now the tag is ignored, but at least it looks for the given repo instead
of failing. This, of course, could be improved in the future.

Fixes #221