### PR TITLE
Ported flashy messages from #notice to #alert

### DIFF
--- a/app/views/admin/users/toggle_admin.js.erb
+++ b/app/views/admin/users/toggle_admin.js.erb
@@ -1,5 +1,5 @@
 $('#user_<%= user.id %> .admin-btn a i').addClass("fa-toggle-<%= user.admin? ? 'on' : 'off' %>");
 $('#user_<%= user.id %> .admin-btn a i').removeClass("fa-toggle-<%= user.admin? ? 'off' : 'on' %>");
 
-$('#notice p').html("User '<%= user.username %>' is <%= user.admin? ? 'now' : 'no longer' %> an admin");
-$('#notice').fadeIn();
+$('#alert p').html("User '<%= user.username %>' is <%= user.admin? ? 'now' : 'no longer' %> an admin");
+$('#alert').fadeIn();

--- a/app/views/namespaces/create.js.erb
+++ b/app/views/namespaces/create.js.erb
@@ -5,8 +5,8 @@
   $('#alert p').html("<%= escape_javascript(@namespace.errors.full_messages.join('<br/>')) %>");
   $('#alert').fadeIn();
 <% else %>
-  $('#notice p').html("New namespace created");
-  $('#notice').fadeIn();
+  $('#alert p').html("New namespace created");
+  $('#alert').fadeIn();
 
   $('#add_namespace_form').fadeOut();
   $('#add_namespace_btn i').addClass("fa-chevron-down")

--- a/app/views/namespaces/toggle_public.js.erb
+++ b/app/views/namespaces/toggle_public.js.erb
@@ -1,5 +1,5 @@
 $('#namespace_<%= namespace.id %> td a i').addClass("fa-toggle-<%= namespace.public? ? 'on' : 'off' %>");
 $('#namespace_<%= namespace.id %> td a i').removeClass("fa-toggle-<%= namespace.public? ? 'off' : 'on' %>");
 
-$('#notice p').html("Namespace '<%= namespace.name %>' is now <%= namespace.public? ? 'public' : 'private' %>");
-$('#notice').fadeIn();
+$('#alert p').html("Namespace '<%= namespace.name %>' is now <%= namespace.public? ? 'public' : 'private' %>");
+$('#alert').fadeIn();

--- a/app/views/team_users/create.js.erb
+++ b/app/views/team_users/create.js.erb
@@ -3,8 +3,8 @@
   $('#alert').fadeIn();
 <% else %>
   $("<%= escape_javascript(render @team_user) %>").appendTo("#team_users");
-  $('#notice p').html("New user added to the team");
-  $('#notice').fadeIn();
+  $('#alert p').html("New user added to the team");
+  $('#alert').fadeIn();
   $('#add_team_user_form').fadeOut();
   $('#add_team_user_btn i').addClass("fa-chevron-down")
   $('#add_team_user_btn i').removeClass("fa-chevron-up")

--- a/app/views/team_users/destroy.js.erb
+++ b/app/views/team_users/destroy.js.erb
@@ -3,6 +3,6 @@
   $('#alert').fadeIn();
 <% else %>
   $("#team_user_<%= team_user_id %>").remove();
-  $('#notice p').html("User removed from the team");
-  $('#notice').fadeIn();
+  $('#alert p').html("User removed from the team");
+  $('#alert').fadeIn();
 <% end %>

--- a/app/views/teams/create.js.erb
+++ b/app/views/teams/create.js.erb
@@ -3,8 +3,8 @@
   $('#alert').fadeIn();
 <% else %>
   $("<%= escape_javascript(render @team) %>").appendTo("#teams");
-  $('#notice p').html("The team '<%= @team.name %>' was created successfully");
-  $('#notice').fadeIn();
+  $('#alert p').html("The team '<%= @team.name %>' was created successfully");
+  $('#alert').fadeIn();
   $('#add_team_form').fadeOut();
   $('#add_team_btn i').addClass("fa-plus-circle")
   $('#add_team_btn i').removeClass("fa-minus-circle")

--- a/spec/features/admin/users_spec.rb
+++ b/spec/features/admin/users_spec.rb
@@ -6,7 +6,7 @@ feature "Admin - Users panel" do
   let!(:user) { create(:user) }
 
   before do
-    login_as admin, scope: :user
+    login_as admin
     visit admin_users_path
   end
 
@@ -20,6 +20,35 @@ feature "Admin - Users panel" do
       expect(page).to_not have_css("#user_#{user.id}")
       wait_for_effect_on("#alert")
       expect(page).to have_content("User '#{user.username}' has been disabled.")
+    end
+  end
+
+  describe "toggle admin" do
+    scenario "allows the admin to toggle a regular user into becoming an admin", js: true do
+      expect(page).to have_css("#user_#{user.id}")
+      expect(page).to have_css("#user_#{user.id} .admin-btn .fa-toggle-off")
+      find("#user_#{user.id} .admin-btn").click
+
+      wait_for_effect_on("#alert")
+
+      expect(page).to_not have_css("#user_#{user.id} .admin-btn .fa-toggle-off")
+      expect(page).to have_css("#user_#{user.id} .admin-btn .fa-toggle-on")
+      expect(page).to have_content("User '#{user.username}' is now an admin")
+    end
+
+    scenario "allows the admin to remove another admin", js: true do
+      user.update_attributes(admin: true)
+      visit admin_users_path
+
+      expect(page).to have_css("#user_#{user.id}")
+      expect(page).to have_css("#user_#{user.id} .admin-btn .fa-toggle-on")
+      find("#user_#{user.id} .admin-btn").click
+
+      wait_for_effect_on("#alert")
+
+      expect(page).to_not have_css("#user_#{user.id} .admin-btn .fa-toggle-on")
+      expect(page).to have_css("#user_#{user.id} .admin-btn .fa-toggle-off")
+      expect(page).to have_content("User '#{user.username}' is no longer an admin")
     end
   end
 end

--- a/spec/features/namespaces_spec.rb
+++ b/spec/features/namespaces_spec.rb
@@ -78,6 +78,9 @@ feature "Namespaces support" do
       expect(current_path).to eql namespaces_path
       expect(page).to have_content("valid-namespace")
 
+      wait_for_effect_on("#alert")
+      expect(page).to have_content("New namespace created")
+
       # Check that it created a link to it and that it's accessible.
       click_link "valid-namespace"
       namespace = Namespace.find_by(name: "valid-namespace")
@@ -115,6 +118,9 @@ feature "Namespaces support" do
       expect(page).to have_css("#namespace_#{id} .fa-toggle-on")
       namespace = Namespace.find(id)
       expect(namespace.public?).to be true
+
+      wait_for_effect_on("#alert")
+      expect(page).to have_content("Namespace '#{namespace.name}' is now public")
     end
   end
 end

--- a/spec/features/teams_spec.rb
+++ b/spec/features/teams_spec.rb
@@ -116,7 +116,7 @@ feature "Teams support" do
     scenario "An user can be added as a team member", js: true do
       find("#add_team_user_btn").click
       wait_for_effect_on("#add_team_user_form")
-      find("#team_user_role").select 'Contributor'
+      find("#team_user_role").select "Contributor"
       find("#team_user_user").set another.username
       find("#add_team_user_form .btn").click
 
@@ -130,7 +130,7 @@ feature "Teams support" do
     scenario "New team members have to exist on the system", js: true do
       find("#add_team_user_btn").click
       wait_for_effect_on("#add_team_user_form")
-      find("#team_user_role").select 'Contributor'
+      find("#team_user_role").select "Contributor"
       find("#team_user_user").set "grumpy"
       find("#add_team_user_form .btn").click
 
@@ -141,7 +141,7 @@ feature "Teams support" do
     end
 
     scenario "A team member can be kicked out from a team", js: true do
-      tu = TeamUser.create!(team: team, user: another, role: TeamUser.roles['viewer' ])
+      tu = TeamUser.create!(team: team, user: another, role: TeamUser.roles["viewer"])
       visit team_path(team)
 
       find("#team_user_#{tu.id} a.btn").click


### PR DESCRIPTION
A ton of JS expected the #notice element to exist but that was never the case.
Instead, the element to target for flashy messages is the #alert one. This must
be some leftover from a refactoring.

Moreover, I've added some acceptance tests that were missing (e.g. Team
members), since some of the alert messages referenced this features anyways.