### PR TITLE
Take advantage of the Catalog API

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,3 +46,4 @@ AllCops:
     - bin/*
     - vendor/**/*
     - tmp/**/*
+    - config/cronotab.rb

--- a/Gemfile
+++ b/Gemfile
@@ -21,9 +21,8 @@ gem "public_activity"
 gem "active_record_union"
 gem "mysql2"
 gem "search_cop"
-
-# Pagination
 gem "kaminari"
+gem "crono"
 
 # In order to create the Gemfile.lock required for packaging
 # meaning that it should contain only the production packages

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,9 @@ GEM
     columnize (0.9.0)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
+    crono (0.9.0)
+      activerecord (~> 4.0)
+      activesupport (~> 4.0)
     daemons (1.2.2)
     database_cleaner (1.4.1)
     debug_inspector (0.0.2)
@@ -322,6 +325,7 @@ DEPENDENCIES
   capybara
   codeclimate-test-reporter
   coffee-rails
+  crono
   database_cleaner
   devise
   factory_girl_rails
@@ -360,6 +364,3 @@ DEPENDENCIES
   webmock
   wirb
   wirble
-
-BUNDLED WITH
-   1.10.5

--- a/README.md
+++ b/README.md
@@ -22,11 +22,21 @@ described by the new version of the Docker registry. This can be used to have fu
 
 Portus provides quick access to all the images available on your private instance of Docker registry. User's privileges are taken into account to make sure private images (the ones requiring special rights also for `docker pull`) are not shown to unauthorized personnel.
 
-## Current limitations
+### Synchronization between the database and the registry
 
-Portus' knowledge of the images available on the private instance of a Docker registry is built using the [notifications](https://github.com/docker/distribution/blob/master/docs/notifications.md) sent by the Docker registry itself.
+Portus' knowledge of the images available on the private instance of a Docker
+registry is built in two ways:
 
-If Portus is unreachable when a new image is being pushed to the Docker registry, Portus won't be aware of it. This issue is going to be solved by next versions of Portus.
+1. Using the [notifications](https://github.com/docker/distribution/blob/master/docs/notifications.md)
+sent by the Docker registry itself.
+2. Using the [Catalog API endpoint](https://github.com/docker/distribution/blob/master/docs/spec/api.md#listing-repositories).
+
+The two methods complement each other. The first method is used to retrieve
+updates on the registry in real time, and the second one is used to
+double-check the consistency of the database with the registry. To read more on
+this topic, don't hesistate to check the [wiki
+page](https://github.com/SUSE/Portus/wiki/Synchronizing-the-Registry-and-Portus)
+about it.
 
 ## Contributing
 

--- a/app/jobs/catalog_job.rb
+++ b/app/jobs/catalog_job.rb
@@ -1,0 +1,45 @@
+# CatalogJob is a job that synchronizes the contents of the database with the
+# contents of the Registry. This is done by using the Catalog API.
+class CatalogJob < ActiveJob::Base
+  # This method will be called on each tic of the cron. It basically gets the
+  # contents from the registry and calls `update_registry!`. Any error is
+  # logged.
+  def perform
+    # TODO: (mssola) change this once more than one registry can be configured
+    # at the same time.
+    registry = Registry.first
+    return if registry.nil?
+
+    pass = Rails.application.secrets.portus_password
+    client = RegistryClient.new(registry.hostname, false, "portus", pass)
+
+    begin
+      cat = client.catalog
+
+      # Update the registry in a transaction, since we don't want to leave the DB
+      # in an unknown state because of an update failure.
+      ActiveRecord::Base.transaction { update_registry!(cat) }
+    rescue StandardError => e
+      Rails.logger.warn "Exception: #{e.message}"
+    end
+  end
+
+  protected
+
+  # This method updates the database of this application with the given
+  # registry contents.
+  def update_registry!(catalog)
+    dangling_repos = Repository.all.pluck(:id)
+
+    # In this loop we will create/update all the repos from the catalog.
+    # Created/updated repos will be removed from the "repos" array.
+    catalog.each do |r|
+      cou   = Repository.create_or_update!(r)
+      dangling_repos = dangling_repos.delete_if { |re| re == cou.id }
+    end
+
+    # At this point, the remaining items in the "repos" array are repos that
+    # exist in the DB but not in the catalog. Remove all of them.
+    Repository.where(id: dangling_repos).delete_all
+  end
+end

--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -11,6 +11,20 @@ class Namespace < ActiveRecord::Base
     name.downcase.gsub(/\s+/, "_").gsub(/[^#{NAME_ALLOWED_CHARS}]/, "")
   end
 
+  # From the given repository name that can be prefix by the name of the
+  # namespace, returns two values:
+  #   1. The namespace where the given repository belongs to.
+  #   2. The name of the repository itself.
+  def self.get_from_name(name)
+    if name.include?("/")
+      namespace, name = name.split("/", 2)
+      namespace = Namespace.find_by(name: namespace)
+    else
+      namespace = Namespace.find_by(global: true)
+    end
+    [namespace, name]
+  end
+
   # Returns a String containing the cleaned name for this namespace. The
   # cleaned name will be the registry's hostname if this is a global namespace,
   # or the name of the namespace itself otherwise.

--- a/config/config.yml
+++ b/config/config.yml
@@ -4,4 +4,3 @@
 
 settings:
   gravatar: true
-

--- a/config/cronotab.rb
+++ b/config/cronotab.rb
@@ -1,0 +1,2 @@
+env = ENV["CATALOG_CRON"] || "10.minutes"
+Crono.perform(CatalogJob).every eval(env)

--- a/db/migrate/20150805130722_create_crono_jobs.rb
+++ b/db/migrate/20150805130722_create_crono_jobs.rb
@@ -1,0 +1,16 @@
+class CreateCronoJobs < ActiveRecord::Migration
+  def self.up
+    create_table :crono_jobs do |t|
+      t.string    :job_id, null: false
+      t.text      :log
+      t.datetime  :last_performed_at
+      t.boolean   :healthy
+      t.timestamps null: false
+    end
+    add_index :crono_jobs, [:job_id], unique: true
+  end
+
+  def self.down
+    drop_table :crono_jobs
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150729153854) do
+ActiveRecord::Schema.define(version: 20150805130722) do
 
   create_table "activities", force: :cascade do |t|
     t.integer  "trackable_id",   limit: 4
@@ -30,6 +30,17 @@ ActiveRecord::Schema.define(version: 20150729153854) do
   add_index "activities", ["owner_id", "owner_type"], name: "index_activities_on_owner_id_and_owner_type", using: :btree
   add_index "activities", ["recipient_id", "recipient_type"], name: "index_activities_on_recipient_id_and_recipient_type", using: :btree
   add_index "activities", ["trackable_id", "trackable_type"], name: "index_activities_on_trackable_id_and_trackable_type", using: :btree
+
+  create_table "crono_jobs", force: :cascade do |t|
+    t.string   "job_id",            limit: 255,   null: false
+    t.text     "log",               limit: 65535
+    t.datetime "last_performed_at"
+    t.boolean  "healthy",           limit: 1
+    t.datetime "created_at",                      null: false
+    t.datetime "updated_at",                      null: false
+  end
+
+  add_index "crono_jobs", ["job_id"], name: "index_crono_jobs_on_job_id", unique: true, using: :btree
 
   create_table "namespaces", force: :cascade do |t|
     t.string   "name",        limit: 255

--- a/spec/classes/registry_client_spec.rb
+++ b/spec/classes/registry_client_spec.rb
@@ -199,7 +199,8 @@ describe RegistryClient do
 
         catalog = registry.catalog
         expect(catalog.length).to be 1
-        expect(catalog[0]["busybox"]).to match_array(["latest"])
+        expect(catalog[0]["name"]).to eq "busybox"
+        expect(catalog[0]["tags"]).to match_array(["latest"])
       end
     end
 

--- a/spec/models/namespace_spec.rb
+++ b/spec/models/namespace_spec.rb
@@ -50,4 +50,24 @@ describe Namespace do
     end
   end
 
+  describe "get_from_name" do
+    let!(:registry)    { create(:registry) }
+    let!(:owner)       { create(:user) }
+    let!(:team)        { create(:team, owners: [owner]) }
+    let!(:namespace)   { create(:namespace, team: team) }
+    let!(:repo)        { create(:repository, namespace: namespace) }
+
+    it "works for global namespaces" do
+      ns = Namespace.find_by(global: true)
+      namespace, name = Namespace.get_from_name(repo.name)
+      expect(namespace.id).to eq ns.id
+      expect(name).to eq repo.name
+    end
+
+    it "works for user namespaces" do
+      ns, name = Namespace.get_from_name("#{namespace.name}/#{repo.name}")
+      expect(ns.id).to eq namespace.id
+      expect(name).to eq repo.name
+    end
+  end
 end

--- a/spec/vcr_cassettes/registry/get_registry_catalog.yml
+++ b/spec/vcr_cassettes/registry/get_registry_catalog.yml
@@ -158,7 +158,7 @@ http_interactions:
       - Mon, 10 Aug 2015 16:06:08 GMT
     body:
       string: |
-        {"busybox":["latest"]}
+        {"name": "busybox", "tags":["latest"]}
     http_version:
   recorded_at: Mon, 10 Aug 2015 16:06:08 GMT
 recorded_with: VCR 2.9.3


### PR DESCRIPTION
In recent commits, the RegistryClient not only was fixed, but it also
introduced the `catalog` method. With this commit we take advantage of this new
method by calling it in a new crono job.

For managing and launching this new job we use the `crono` gem as suggested by
@lsamayoa.

Fixes #199