### PR TITLE
Show starred repositories on the dashboard

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,6 +12,7 @@
 @import 'layout';
 @import 'buttons';
 @import 'images';
+@import 'dashboard';
 @import 'panels';
 @import 'forms';
 @import 'types';

--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -1,0 +1,5 @@
+.starred {
+  .fa {
+    color: $first-colour !important;
+  }
+}

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -3,5 +3,6 @@ class DashboardController < ApplicationController
     @recent_activities = policy_scope(PublicActivity::Activity)
       .limit(20)
       .order("created_at desc")
+    @stars = current_user.stars.order("updated_at desc")
   end
 end

--- a/app/views/dashboard/index.html.slim
+++ b/app/views/dashboard/index.html.slim
@@ -1,4 +1,27 @@
-h1 Recent activities
+h1 Dashboard
 
-- @recent_activities.each do |activity|
-  = render_activity(activity)
+.row
+  .col-md-8.col-xs-6
+    .panel-overview
+      .panel-heading
+        h2 Recent activities
+      .panel-body
+        - @recent_activities.each do |activity|
+          = render_activity(activity)
+  .col-md-4.col-xs-6
+    .panel-overview.starred
+      .panel-heading
+        h2 Starred repositories
+      .panel-body.starred.table-responsive
+        table.table.table-stripped.table-hover
+          colgroup
+            col.col-80
+            col.col-10
+            col.col-10
+          tbody
+            - @stars.each do |star|
+              tr
+                td= link_to star.repository.name, star.repository
+                td= star.repository.stars.count
+                td
+                  i.fa.fa-star

--- a/app/views/shared/_aside.html.slim
+++ b/app/views/shared/_aside.html.slim
@@ -3,7 +3,7 @@ aside
     li.active
       a[href="#{url_for root_path}"]
         i[class="fa fa-dashboard"]
-        | Activities
+        | Dashboard
       - if current_page?(url_for root_path) || current_page?(root_path)
         .list-selected
     li.active

--- a/spec/features/auth/login_feature_spec.rb
+++ b/spec/features/auth/login_feature_spec.rb
@@ -21,7 +21,8 @@ feature "Login feature" do
     fill_in "user_password", with: user.password
     find("button").click
 
-    expect(page).to have_content("Activities")
+    expect(page).to have_content("Recent activities")
+    expect(page).to have_content("Starred repositories")
     expect(page).to_not have_content("Signed in")
   end
 

--- a/spec/features/auth/signup_feature_spec.rb
+++ b/spec/features/auth/signup_feature_spec.rb
@@ -41,7 +41,8 @@ feature "Signup feature" do
     fill_in "user_password", with: user.password
     fill_in "user_password_confirmation", with: user.password
     click_button("Create account")
-    expect(page).to have_content("Activities")
+    expect(page).to have_content("Recent activities")
+    expect(page).to have_content("Starred repositories")
     expect(current_url).to eq root_url
   end
 


### PR DESCRIPTION
Improve the dashboard to show both the recent activities and the starred repositories.

This addresses https://github.com/SUSE/Portus/issues/243

Mandatory screenshot:

![screenshot-localhost 5000 2015-08-13 12-42-39](https://cloud.githubusercontent.com/assets/22728/9248097/39d52c92-41b9-11e5-9421-6b739e0e1753.png)
