### PR TITLE
Show more details on the dashboard about repos

### DIFF
--- a/app/assets/javascripts/dashboard.coffee
+++ b/app/assets/javascripts/dashboard.coffee
@@ -1,0 +1,12 @@
+$(document).on "page:change", ->
+  $('#starred a').on 'click', (event) ->
+    e.preventDefault()
+    $(this).tab('show')
+
+  $('#all a').on 'click', (event) ->
+    e.preventDefault()
+    $(this).tab('show')
+
+  $('#personal a').on 'click', (event) ->
+    e.preventDefault()
+    $(this).tab('show')

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -4,7 +4,12 @@ class DashboardController < ApplicationController
       .limit(20)
       .order("created_at desc")
     @repositories = policy_scope(Repository)
-    @personal_repositories = Namespace.find_by(name: current_user.username).repositories
+
+    # The personal namespace could not exist, that happens when portus
+    # does not have a registry associated yet (right after the initial setup)
+    personal_namespace = Namespace.find_by(name: current_user.username)
+    @personal_repositories = personal_namespace ? personal_namespace.repositories : []
+
     @stars = current_user.stars.order("updated_at desc")
   end
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -3,6 +3,8 @@ class DashboardController < ApplicationController
     @recent_activities = policy_scope(PublicActivity::Activity)
       .limit(20)
       .order("created_at desc")
+    @repositories = policy_scope(Repository)
+    @personal_repositories = Namespace.find_by(name: current_user.username).repositories
     @stars = current_user.stars.order("updated_at desc")
   end
 end

--- a/app/views/dashboard/_repository.html.slim
+++ b/app/views/dashboard/_repository.html.slim
@@ -1,0 +1,5 @@
+tr
+  td
+    = link_to repository.namespace.clean_name, repository.namespace
+    | /
+    = link_to repository.name, repository

--- a/app/views/dashboard/_star.html.slim
+++ b/app/views/dashboard/_star.html.slim
@@ -1,0 +1,8 @@
+tr
+  td
+    = link_to star.repository.namespace.clean_name, star.repository.namespace
+    | /
+    = link_to star.repository.name, star.repository
+  td= star.repository.stars.count
+  td
+    i.fa.fa-star

--- a/app/views/dashboard/index.html.slim
+++ b/app/views/dashboard/index.html.slim
@@ -1,5 +1,4 @@
 h1 Dashboard
-
 .row
   .col-md-8.col-xs-6
     .panel-overview
@@ -11,17 +10,34 @@ h1 Dashboard
   .col-md-4.col-xs-6
     .panel-overview.starred
       .panel-heading
-        h2 Starred repositories
-      .panel-body.starred.table-responsive
-        table.table.table-stripped.table-hover
-          colgroup
-            col.col-80
-            col.col-10
-            col.col-10
-          tbody
-            - @stars.each do |star|
-              tr
-                td= link_to star.repository.name, star.repository
-                td= star.repository.stars.count
-                td
-                  i.fa.fa-star
+        h2 Repositories
+
+        ul.nav.nav-tabs{role="tablist"}
+          li.active{role="presentation"}
+            a{href="#all" aria-controls="all" role="tab" data-toggle="tab"} All
+          li{role="presentation"}
+            a{href="#personal" aria-controls="personal" role="tab" data-toggle="tab"} Personal
+          li{role="presentation"}
+            a{href="#starred" aria-controls="starred" role="tab" data-toggle="tab"} Starred
+      .panel-body.table-responsive
+        .tab-content
+          #all.tab-pane.active{role="tabpanel"}
+            table.table.table-stripped.table-hover
+              tbody
+                - @repositories.each do |repository|
+                  = render partial: 'dashboard/repository', locals: {repository: repository}
+          #starred.tab-pane{role="tabpanel"}
+            table.table.table-stripped.table-hover
+              colgroup
+                col.col-80
+                col.col-10
+                col.col-10
+              tbody
+                - @stars.each do |star|
+                  = render partial: 'dashboard/star', locals: {star: star}
+          #personal.tab-pane{role="tabpanel"}
+            table.table.table-stripped.table-hover.starred
+              tbody
+                - @personal_repositories.each do |repository|
+                  = render partial: 'dashboard/repository', locals: {repository: repository}
+

--- a/spec/features/auth/login_feature_spec.rb
+++ b/spec/features/auth/login_feature_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 feature "Login feature" do
+
+  let!(:registry) { create(:registry) }
   let!(:user) { create(:user) }
 
   before do

--- a/spec/features/auth/login_feature_spec.rb
+++ b/spec/features/auth/login_feature_spec.rb
@@ -22,7 +22,7 @@ feature "Login feature" do
     find("button").click
 
     expect(page).to have_content("Recent activities")
-    expect(page).to have_content("Starred repositories")
+    expect(page).to have_content("Repositories")
     expect(page).to_not have_content("Signed in")
   end
 

--- a/spec/features/auth/logout_feature_spec.rb
+++ b/spec/features/auth/logout_feature_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 feature "Logout feature" do
 
+  let!(:registry) { create(:registry) }
   let!(:user) { create(:user) }
 
   before do

--- a/spec/features/auth/signup_feature_spec.rb
+++ b/spec/features/auth/signup_feature_spec.rb
@@ -7,6 +7,7 @@ feature "Signup feature" do
     visit new_user_registration_url
   end
 
+  let!(:registry) { create(:registry) }
   let(:user) { build(:user) }
 
   scenario "As a guest I am able to signup from login page" do

--- a/spec/features/auth/signup_feature_spec.rb
+++ b/spec/features/auth/signup_feature_spec.rb
@@ -42,7 +42,7 @@ feature "Signup feature" do
     fill_in "user_password_confirmation", with: user.password
     click_button("Create account")
     expect(page).to have_content("Recent activities")
-    expect(page).to have_content("Starred repositories")
+    expect(page).to have_content("Repositories")
     expect(current_url).to eq root_url
   end
 

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+feature "Dashboard page" do
+  let!(:registry) { create(:registry) }
+  let!(:user) { create(:admin) }
+  let!(:team) { create(:team, owners: [user]) }
+  let!(:namespace) { create(:namespace, team: team) }
+  let!(:repository) { create(:repository, namespace: namespace) }
+  let!(:starred_repo) { create(:repository, namespace: namespace) }
+  let!(:star) { create(:star, user: user, repository: starred_repo) }
+  let!(:personal_namespace) { Namespace.find_by(name: user.username) }
+  let!(:personal_repository) { create(:repository, namespace: personal_namespace) }
+
+  let!(:another_user) { create(:admin) }
+  let!(:another_team) { create(:team, owners: [another_user]) }
+  let!(:public_namespace) { create(:namespace, team: another_team, public: true) }
+  let!(:public_repository) { create(:repository, namespace: public_namespace) }
+
+  before do
+    login_as user, scope: :user
+  end
+
+  describe "Repositories sidebar" do
+    scenario "Show all the repositories user has access to", js: true do
+      visit authenticated_root_path
+      expect(page).to have_content("#{personal_namespace.name}/#{personal_repository.name}")
+      expect(page).to have_content("#{namespace.name}/#{repository.name}")
+      expect(page).to have_content("#{namespace.name}/#{starred_repo.name}")
+      expect(page).to have_content("#{public_namespace.name}/#{public_repository.name}")
+    end
+
+    scenario "Show personal repositories", js: true do
+      visit authenticated_root_path
+      click_link("Personal")
+      wait_for_effect_on(".tab-content")
+
+      expect(page).to have_content("#{personal_namespace.name}/#{personal_repository.name}")
+      expect(page).not_to have_content("#{namespace.name}/#{starred_repo.name}")
+      expect(page).not_to have_content("#{namespace.name}/#{repository.name}")
+      expect(page).not_to have_content("#{public_namespace.name}/#{public_repository.name}")
+    end
+
+    scenario "Show personal repositories", js: true do
+      visit authenticated_root_path
+      click_link("Starred")
+      wait_for_effect_on(".tab-content")
+
+      expect(page).to have_content("#{namespace.name}/#{starred_repo.name}")
+      expect(page).not_to have_content("#{personal_namespace.name}/#{personal_repository.name}")
+      expect(page).not_to have_content("#{namespace.name}/#{repository.name}")
+      expect(page).not_to have_content("#{public_namespace.name}/#{public_repository.name}")
+    end
+  end
+end

--- a/spec/features/gravatar_spec.rb
+++ b/spec/features/gravatar_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 feature "Gravatar support" do
 
+  let!(:registry) { create(:registry) }
   let!(:user) { create(:user) }
 
   before do


### PR DESCRIPTION
It is now possible to show all the repositories an user has access to,
the personal repositories and the starred ones.

This fixes issue https://github.com/SUSE/Portus/issues/265

**NOTE WELL:** almost ready to be merged, we have to figure out why some tests are failing. Apparently it's a bug that has always been there, we simply never realized it.

## Mandatory screenshots


### All the repositories
![all](https://cloud.githubusercontent.com/assets/22728/9251629/7d60fd68-41d4-11e5-988f-97f52b8b3c90.png)

### Starred repositories
![starred](https://cloud.githubusercontent.com/assets/22728/9251627/7d4a34a2-41d4-11e5-9ac3-f2316bfabc52.png)

### Personal repositories
![personal](https://cloud.githubusercontent.com/assets/22728/9251628/7d4b081e-41d4-11e5-8530-ff4f31a74188.png)
