### PR TITLE
fixed a warning tips.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ registry:
     file: docker/compose-common.yml
     service: registry
   volumes:
-    - docker/registry:/registry
+    - ./docker/registry:/registry
   entrypoint: /registry/entry.sh
   env_file: docker/environment
   links:


### PR DESCRIPTION
Warning: the mapping "docker/registry:/registry" in the volumes config for service "registry" is ambiguous. In a future version of Docker, it will designate a "named" volume (see https://github.com/docker/docker/pull/14242).