### PR TITLE
remove nodejs as a requirement for production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,11 +31,11 @@ gem "crono"
 #
 # IGNORE_ASSETS=yes bundle list
 unless ENV["IGNORE_ASSETS"] && ENV["IGNORE_ASSETS"] == "yes"
-    gem "coffee-rails"
-    gem "bootstrap-sass", "~> 3.3.4"
-    gem "uglifier"
-    gem "jquery-turbolinks"
-    gem "turbolinks"
+  gem "coffee-rails"
+  gem "bootstrap-sass", "~> 3.3.4"
+  gem "uglifier"
+  gem "jquery-turbolinks"
+  gem "turbolinks"
 end
 
 # In order to create the Gemfile.lock required for packaging

--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem "crono"
 # run:
 #
 # IGNORE_ASSETS=yes bundle list
-unless ENV["IGNORE_ASSETS"] && ENV["IGNORE_ASSETS"] == "yes"
+unless ENV["IGNORE_ASSETS"] == "yes"
   gem "coffee-rails"
   gem "bootstrap-sass", "~> 3.3.4"
   gem "uglifier"

--- a/Gemfile
+++ b/Gemfile
@@ -2,19 +2,14 @@ source "https://rubygems.org"
 
 gem "rails", "~> 4.2.2"
 gem "jquery-rails", "~> 4.0.4"
-gem "turbolinks"
-gem "slim"
-gem "coffee-rails"
-gem "bootstrap-sass", "~> 3.3.4"
 gem "sass-rails", ">= 3.2"
-gem "uglifier"
+gem "slim"
 gem "pundit"
 gem "sprockets", "~> 2.12.3"
 gem "jwt"
 gem "base32"
 gem "active_model_serializers"
 gem "devise"
-gem "jquery-turbolinks"
 gem "gravatar_image_tag"
 gem "rails-observers"
 gem "public_activity"
@@ -23,6 +18,25 @@ gem "mysql2"
 gem "search_cop"
 gem "kaminari"
 gem "crono"
+
+# Assets group.
+#
+# Do not set it or set it to no when precompiling the assets.
+#
+# IGNORE_ASSETS="no" RAILS_ENV=production bundle exec rake assets:precompile
+#
+# Set IGNORE_ASSETS to YES when creating the Gemfile.lock for
+# production after having precompiled the assets
+# run:
+#
+# IGNORE_ASSETS=yes bundle list
+unless ENV["IGNORE_ASSETS"] && ENV["IGNORE_ASSETS"] == "yes"
+    gem "coffee-rails"
+    gem "bootstrap-sass", "~> 3.3.4"
+    gem "uglifier"
+    gem "jquery-turbolinks"
+    gem "turbolinks"
+end
 
 # In order to create the Gemfile.lock required for packaging
 # meaning that it should contain only the production packages

--- a/packaging/suse/Portus.spec.in
+++ b/packaging/suse/Portus.spec.in
@@ -45,8 +45,6 @@ Requires:       %{rubygem bundler}
 Provides:       Portus = %{version}
 # javascript engine to build assets
 BuildRequires:  nodejs
-# We require nodejs at runtime because Rails4 removed the assets group from the Gemfile.
-Requires:       nodejs
 
 %define rb_build_versions %{rb_default_ruby}
 BuildRequires:  %{rubydevel}
@@ -74,12 +72,18 @@ install -d vendor/cache
 cp %{_libdir}/ruby/gems/%{rb_ver}/cache/*.gem vendor/cache
 export NOKOGIRI_USE_SYSTEM_LIBRARIES=1
 export PACKAGING=yes
+export IGNORE_ASSETS=no
 SKIP_MIGRATION="yes" SECRET_KEY_BASE="assets_precompilation" RAILS_ENV=production bundle exec rake assets:precompile
+export IGNORE_ASSETS=yes
 
 # patch landing_page
 APPLICATION_CSS=$(find . -name application-*.css 2>/dev/null)
 cp $APPLICATION_CSS public/landing.css
 
+# run bundle list to redo the Gemfile.lock
+bundle list
+
+# deploy gems
 bundle install --retry=3 --local --deployment
 rm -rf vendor/cache
 

--- a/packaging/suse/Portus.spec.in
+++ b/packaging/suse/Portus.spec.in
@@ -72,7 +72,6 @@ install -d vendor/cache
 cp %{_libdir}/ruby/gems/%{rb_ver}/cache/*.gem vendor/cache
 export NOKOGIRI_USE_SYSTEM_LIBRARIES=1
 export PACKAGING=yes
-export IGNORE_ASSETS=no
 SKIP_MIGRATION="yes" SECRET_KEY_BASE="assets_precompilation" RAILS_ENV=production bundle exec rake assets:precompile
 export IGNORE_ASSETS=yes
 


### PR DESCRIPTION
Assets are not being recompiled in production for Rails 4

http://guides.rubyonrails.org/asset_pipeline.html

Thus, we don't need any javascript engine in production (nor the gems
that requires that)

Let's remove nodejs and the gems that require that from production
(=assets gems)

However, we do need nodejs and these gems for precompiling the assets,
thus we use an env variable for enabling/disabling them.

This way we can do:

For precompiling assets in the spec file:

PACKAGING=yes IGNORE_ASSETS=no RAILS_ENV=production bundle exec rake
assets:precompile

and then, for bundling the gems:

PACKAGING=yes IGNORE_ASSETS=yes bundle install