### PR TITLE
get rid of rubygem-bundler as run-time requirement

### DIFF
--- a/packaging/suse/Portus.spec.in
+++ b/packaging/suse/Portus.spec.in
@@ -40,8 +40,6 @@ BuildRequires:  ruby-macros >= 5
 BuildRequires:  apache2
 Requires:       apache2
 Requires:       rubygem-passenger-apache2
-# We require bundler to start the rails app with passenger
-Requires:       %{rubygem bundler}
 Provides:       Portus = %{version}
 # javascript engine to build assets
 BuildRequires:  nodejs
@@ -81,6 +79,10 @@ APPLICATION_CSS=$(find . -name application-*.css 2>/dev/null)
 cp $APPLICATION_CSS public/landing.css
 
 bundle install --retry=3 --local --deployment
+
+# install bundler
+gem install --install-dir vendor/bundle/ruby/%{rb_ver}/ vendor/cache/bundler-*.gem
+
 rm -rf vendor/cache
 
 if [ -f config/secrets.yml ];then


### PR DESCRIPTION
If we install bundler gem under vendor/bundle/ruby/2.1.0 directory,
and since we had that directory as GEM_PATH in the vhost configuration,
we don't need rubygem-bundler rpm as a runtime requirement.

Bundler does not install itself if you add it at the Gemfile, thus we
need to install it with "gem install --install-dir ..."