### PR TITLE
Remove explicit provides

### DIFF
--- a/packaging/suse/Portus.spec.in
+++ b/packaging/suse/Portus.spec.in
@@ -51,8 +51,6 @@ BuildRequires:  %{rubygem bundler} >= 1.3.0
 
 __RUBYGEMS_BUILD_REQUIRES__
 
-__RUBYGEMS_PROVIDES__
-
 
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -51,7 +51,7 @@ pushd build/Portus-$branch/
     gem_version=$(echo $gem | cut -d "(" -f2 | cut -d ")" -f1)
     build_requires="$build_requires\nBuildRequires: %{rubygem $gem_name} = $gem_version"
     build_requires="$build_requires\n$(additional_native_build_requirements $gem_name)"
-    provides="$provides\nProvides: embedded-rubygem-$gem_name = $gem_version"
+    provides="$provides\nProvides: bundled(rubygem-$gem_name) = $gem_version"
   done
 popd
 

--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -45,13 +45,11 @@ pushd build/Portus-$branch/
   echo "get requirements from Gemfile.lock"
   IFS=$'\n' # do not split on spaces
   build_requires=""
-  provides=""
   for gem in $(cat Gemfile.lock | grep "    "  | grep "     " -v | sort | uniq);do
     gem_name=$(echo $gem | cut -d" " -f5)
     gem_version=$(echo $gem | cut -d "(" -f2 | cut -d ")" -f1)
     build_requires="$build_requires\nBuildRequires: %{rubygem $gem_name} = $gem_version"
     build_requires="$build_requires\n$(additional_native_build_requirements $gem_name)"
-    provides="$provides\nProvides: bundled(rubygem-$gem_name) = $gem_version"
   done
 popd
 
@@ -59,7 +57,6 @@ echo "create Portus.spec based on Portus.spec.in"
 cp Portus.spec.in Portus.spec
 sed -e "s/__BRANCH__/$branch/g" -i Portus.spec
 sed -e "s/__RUBYGEMS_BUILD_REQUIRES__/$build_requires/g" -i Portus.spec
-sed -e "s/__RUBYGEMS_PROVIDES__/$provides/g" -i Portus.spec
 sed -e "s/__DATE__/$date/g" -i Portus.spec
 sed -e "s/__COMMIT__/$commit/g" -i Portus.spec
 sed -e "s/__VERSION__/$version/g" -i Portus.spec


### PR DESCRIPTION
We are not using the provides for tracking the bundled gems, so we better don't have it because it creates noise.

I did it on a way that if we decide to get it back, we can revert the latest commit and we will have what we will probably need, that is "Provides: bundled(rubygem-foo) = XXX"

