### PR TITLE
Review production configuration

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -20,7 +20,15 @@ test:
 
 production:
   <<: *default
-  host:     <%= ENV["PRODUCTION_HOST"] %>
-  username: <%= ENV["PRODUCTION_USERNAME"] %>
-  password: <%= ENV["PRODUCTION_PASSWORD"] %>
-  database: <%= ENV["PRODUCTION_DATABASE"] %>
+  <% if ENV["PORTUS_PRODUCTION_HOST"] %>
+  host:     <%= ENV["PORTUS_PRODUCTION_HOST"] %>
+  <% end %>
+  <% if ENV["PORTUS_PRODUCTION_USERNAME"] %>
+  username: <%= ENV["PORTUS_PRODUCTION_USERNAME"] %>
+  <% end %>
+  <% if ENV["PORTUS_PRODUCTION_PASSWORD"] %>
+  password: <%= ENV["PORTUS_PRODUCTION_PASSWORD"] %>
+  <% end %>
+  <% if ENV["PORTUS_PRODUCTION_DATABASE"] %>
+  database: <%= ENV["PORTUS_PRODUCTION_DATABASE"] %>
+  <% end %>

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -25,7 +25,7 @@ test:
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
 production:
-  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
-  encryption_private_key_path: 'vagrant/conf/ca_bundle/server.key'
-  machine_fqdn: <%= ENV["MACHINE_FQDN"] %>
+  secret_key_base: <%= ENV["PORTUS_SECRET_KEY_BASE"] %>
+  encryption_private_key_path: <%= ENV["PORTUS_KEY_PATH"] %>
+  machine_fqdn: <%= ENV["PORTUS_MACHINE_FQDN"] %>
   portus_password: <%= ENV["PORTUS_PASSWORD"] %>

--- a/packaging/suse/Portus.spec.in
+++ b/packaging/suse/Portus.spec.in
@@ -35,10 +35,6 @@ Group:          System/Management
 Requires:       ruby >= 2.1
 BuildRequires:  fdupes
 BuildRequires:  ruby-macros >= 5
-# We expect apache2 and passenger because we are installing the apache
-# configuration
-BuildRequires:  apache2
-Requires:       apache2
 Requires:       rubygem-passenger-apache2
 Provides:       Portus = %{version}
 # javascript engine to build assets
@@ -96,8 +92,6 @@ fi
 install -d %{buildroot}/%{portusdir}
 
 cp -av . %{buildroot}/%{portusdir}
-install -d %{buildroot}/etc/apache2/vhosts.d/
-cp packaging/suse/conf/etc.apache2.vhosts.d.portus.conf %{buildroot}/etc/apache2/vhosts.d/portus.conf
 
 rm -rf %{buildroot}/%{portusdir}/log
 mkdir %{buildroot}/%{portusdir}/log
@@ -114,7 +108,6 @@ mkdir %{buildroot}/%{portusdir}/tmp
 
 %files
 %defattr(-,root,root)
-%config(noreplace)/etc/apache2/vhosts.d/portus.conf
 %{portusdir}
 %exclude %{portusdir}/spec
 %exclude %{portusdir}/vagrant

--- a/packaging/suse/conf/etc.apache2.vhosts.d.portus.conf
+++ b/packaging/suse/conf/etc.apache2.vhosts.d.portus.conf
@@ -1,11 +1,9 @@
-
-<VirtualHost *:80>
+<VirtualHost *:443>
+   SSLEngine on
+   SSLCertificateFile /etc/registry/ssl.crt/portus.crt
+   SSLCertificateKeyFile /srv/Portus/config/server.key
    # !!! Be sure to point DocumentRoot to 'public'!
-   DocumentRoot /srv/Portus/public    
-   <Directory /srv/>
-      # /srv/Portus is a symlink
-      Options +FollowSymLinks
-   </Directory>
+   DocumentRoot /srv/Portus/public
    <Directory /srv/Portus/public>
       # This relaxes Apache security settings.
       AllowOverride all
@@ -14,6 +12,18 @@
       # Uncomment this if you're on Apache >= 2.4:
       Require all granted
       SetEnv GEM_PATH /srv/Portus/vendor/bundle/ruby/2.1.0
+      # Set database configuration
+      # SetEnv PORTUS_PRODUCTION_USERNAME portus_username
+      # SetEnv PORTUS_PRODUCTION_PASSWORD portus_password
+      # SetEnv PORTUS_PRODUCTION_HOST portus_host
+      SetEnv PORTUS_PRODUCTION_DATABASE portus_production
+      # Set the __SECRET_KEY__ by running rake secret
+      SetEnv PORTUS_SECRET_KEY_BASE __SECRET_KEY__
+      SetEnv PORTUS_MACHINE_FQDN ${HOSTNAME}
+      SetEnv PORTUS_KEY /srv/Portus/config/server.key
+      # Set the PORTUS_PASSWORD
+      SetEnv PORTUS_PASSWORD __PORTUS_PASSWORD__
       PassengerAppEnv production
    </Directory>
 </VirtualHost>
+

--- a/packaging/suse/scripts/configure_portus.sh
+++ b/packaging/suse/scripts/configure_portus.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+bundle="/srv/Portus/vendor/bundle/ruby/2.1.0/bin/bundler.ruby2.1"
+export GEM_PATH=/srv/Portus/vendor/bundle/ruby/2.1.0/
+pushd /srv/Portus
+
+export SKIP_MIGRATION=yes
+export RAILS_ENV=production
+cp /srv/Portus/packaging/suse/conf/apache2/vhosts.d/portus.conf.in /etc/apache2/vhosts.d/portus.conf
+echo "Generating secrets"
+SECRET=$($bundle exec rake secret)
+sed -e "s/__SECRET_KEY__/$SECRET/g" -i /etc/apache2/vhosts.d/portus.conf
+
+echo "Create database"
+$bundle exec rake db:create
+
+echo "Set pasword"
+PP=$(echo $RANDOM)
+sed -e "s/__PORTUS_PASSWORD__/$PP/g" -i /etc/apache2/vhosts.d/portus.conf
+
+popd
+

--- a/packaging/suse/scripts/configure_portus.sh
+++ b/packaging/suse/scripts/configure_portus.sh
@@ -11,9 +11,6 @@ echo "Generating secrets"
 SECRET=$($bundle exec rake secret)
 sed -e "s/__SECRET_KEY__/$SECRET/g" -i /etc/apache2/vhosts.d/portus.conf
 
-echo "Create database"
-$bundle exec rake db:create
-
 echo "Set pasword"
 PP=$(echo $RANDOM)
 sed -e "s/__PORTUS_PASSWORD__/$PP/g" -i /etc/apache2/vhosts.d/portus.conf

--- a/packaging/suse/scripts/configure_registry.sh
+++ b/packaging/suse/scripts/configure_registry.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+echo "Configuring registry ..."
+HOSTNAME=$(cat /etc/HOSTNAME)
+sed -e "s/__HOSTNAME__/$HOSTNAME/g" /srv/Portus/packaging/suse/conf/registry/config.yml.in > /etc/registry/config.yml
+

--- a/packaging/suse/scripts/configure_ssl.sh
+++ b/packaging/suse/scripts/configure_ssl.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+echo "Configuring ssl ..."
+
+HOSTNAME=$(cat /etc/HOSTNAME)
+
+if [ ! -f /etc/apache2/ssl.key/$HOSTNAME-server.key ];then
+  echo "Generating private key and certificate"
+  gensslcert -C "$HOSTNAME" -o "SUSE Linux GmbH" -u "SUSE Portus example" -n "$HOSTNAME" -e kontakt-de@novell.com -c DE -l Nuremberg -s Bayern
+fi
+
+if [ ! -d /etc/registry/ssl.crt ];then
+  mkdir -p /etc/registry/ssl.crt
+fi
+
+chgrp www /etc/apache2/ssl.key/$HOSTNAME-server.key
+chmod 440 /etc/apache2/ssl.key/$HOSTNAME-server.key 
+cd /srv/Portus/config
+ln -sf //etc/apache2/ssl.key/$HOSTNAME-server.key server.key
+chgrp www /etc/apache2/ssl.key
+chmod 750 /etc/apache2/ssl.key/
+cd /etc/registry/ssl.crt/
+ln -sf /etc/apache2/ssl.crt/$HOSTNAME-server.crt portus.crt
+cp /etc/apache2/ssl.crt/$HOSTNAME-ca.crt /srv/www/htdocs/
+cp /etc/apache2/ssl.crt/$HOSTNAME-ca.crt /etc/pki/trust/anchors/
+update-ca-certificates
+chmod 755 /srv/www/htdocs/$HOSTNAME-ca.crt
+

--- a/packaging/suse/scripts/create_db.sh
+++ b/packaging/suse/scripts/create_db.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+bundle="/srv/Portus/vendor/bundle/ruby/2.1.0/bin/bundler.ruby2.1"
+export GEM_PATH=/srv/Portus/vendor/bundle/ruby/2.1.0/
+pushd /srv/Portus
+
+export SKIP_MIGRATION=yes
+export RAILS_ENV=production
+
+echo "Create database"
+$bundle exec rake db:create
+
+popd
+


### PR DESCRIPTION
This is required for creating an RPM that can be supported.

In order to simplify the configuration when installing from an RPM, I've moved the configuration to:

* environment variables for Portus configuration for production
* scripts for generating registry, ssl, apache and db configuration
* the environment variables for Portus will be set in the apache configuration

This way, the Portus configuration for production can be reused when deploying with other ways other than the RPM. However, if you deploy with the RPM, you can set up those variables in the apache configuration.

Also, external dependencies like registry, ssl, db, apache, can be easily configured by running some scripts. These scripts will provide default configurations, thus, the user can decide not to run them. For example, if the user has an external registry, or wants to use something else other than apache2, or apache2 is running on another fronted, or has his own ssl keys (which is recommended)...