### PR TITLE
Support auth protocol introduced by docker 1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ PR [#212](https://github.com/SUSE/Portus/pull/212).
 - Added the appliance tests. See PR [#208](https://github.com/SUSE/Portus/pull/208).
 - Star/Unstar repositories. See PR [#230](https://github.com/SUSE/Portus/pull/230).
 - Now users can be disabled. See PR [#240](https://github.com/SUSE/Portus/pull/240).
+- Fixed the authentication process for Docker 1.8. See PR
+[#282](https://github.com/SUSE/Portus/pull/282).
 - And some minor fixes here and there.
 
 ## 1.0.1

--- a/app/controllers/api/v2/tokens_controller.rb
+++ b/app/controllers/api/v2/tokens_controller.rb
@@ -41,7 +41,7 @@ class Api::V2::TokensController < Api::BaseController
         raise ScopeNotHandled, "Cannot handle scope #{scope}"
       rescue Pundit::NotAuthorizedError
         logger.debug "scope #{scope} not authorized, removing from actions"
-        auth_scope.actions.delete_if{|a| a == scope}
+        auth_scope.actions.delete_if { |a| a == scope }
       end
     end
 
@@ -64,6 +64,6 @@ class Api::V2::TokensController < Api::BaseController
       raise ScopeNotHandled
     end
 
-    [auth_scope, auth_scope.scopes]
+    [auth_scope, auth_scope.scopes.dup]
   end
 end

--- a/app/controllers/api/v2/tokens_controller.rb
+++ b/app/controllers/api/v2/tokens_controller.rb
@@ -30,10 +30,21 @@ class Api::V2::TokensController < Api::BaseController
   def authorize_scopes(registry)
     return unless params[:scope]
 
+    # First try to fetch the requested scopes and the handler. If no scopes
+    # were successfully given, respond with a 401.
     auth_scope, scopes = scope_handler(registry, params[:scope])
     raise Pundit::NotAuthorizedError, "No scopes to handle" if scopes.empty?
 
     scopes.each do |scope|
+      # It will try to check if the current user is authorized to access the
+      # scope given in this iteration. If everything is fine, then nothing will
+      # happen, otherwise there are two possible exceptions that can be raised:
+      #
+      #   - NoMethodError: the targeted resource does not handle the scope that
+      #     is being checked. It will raise a ScopeNotHandled.
+      #   - Pundit::NotAuthorizedError: the targeted resource unauthorized the
+      #     given user for the scope that is being checked. In this case this
+      #     scope gets removed from `auth_scope.actions`.
       begin
         authorize auth_scope.resource, "#{scope}?".to_sym
       rescue NoMethodError
@@ -45,6 +56,10 @@ class Api::V2::TokensController < Api::BaseController
       end
     end
 
+    # If auth_scope.actions is empty, it means that the previous loop
+    # unauthorized all the requested scopes for the current user. Therefore
+    # respond with a 401. Otherwise, return the resulting auth_scope.
+    raise Pundit::NotAuthorizedError if auth_scope.actions.empty?
     auth_scope
   end
 

--- a/app/controllers/api/v2/tokens_controller.rb
+++ b/app/controllers/api/v2/tokens_controller.rb
@@ -39,6 +39,9 @@ class Api::V2::TokensController < Api::BaseController
       rescue NoMethodError
         logger.warn "Cannot handle scope #{scope}"
         raise ScopeNotHandled, "Cannot handle scope #{scope}"
+      rescue Pundit::NotAuthorizedError
+        logger.debug "scope #{scope} not authorized, removing from actions"
+        auth_scope.actions.delete_if{|a| a == scope}
       end
     end
 

--- a/spec/api/v2/token_spec.rb
+++ b/spec/api/v2/token_spec.rb
@@ -52,6 +52,26 @@ describe "/v2/token" do
       end
     end
 
+    context "as another user" do
+      let(:another) { create(:user, password: password) }
+
+      it "does not allow to pull a private namespace from another team" do
+        # It works for the regular user
+        get v2_token_url,
+          { service: registry.hostname, account: user.username, scope: "repository:#{user.username}/busybox:push,pull" },
+          "HTTP_AUTHORIZATION" => auth_mech.encode_credentials(user.username, password)
+
+        expect(response.status).to eq 200
+
+        # But not for another
+        get v2_token_url,
+          { service: registry.hostname, account: another.username, scope: "repository:#{user.username}/busybox:push,pull" },
+          "HTTP_AUTHORIZATION" => auth_mech.encode_credentials(another.username, password)
+
+        expect(response.status).to eq 401
+      end
+    end
+
     context "as valid user" do
       let(:valid_request) do
         {
@@ -110,7 +130,7 @@ describe "/v2/token" do
         end
       end
 
-      context "reposity scope" do
+      context "repository scope" do
         it "delegates authentication to the Namespace policy" do
           personal_namespace = Namespace.find_by(name: user.username)
           expect_any_instance_of(Api::V2::TokensController).to receive(:authorize)
@@ -121,6 +141,24 @@ describe "/v2/token" do
           get v2_token_url,
             { service: registry.hostname, account: user.username, scope: "repository:#{user.username}/busybox:push,pull" },
             valid_auth_header
+        end
+
+        it "allows to pull an image in which this user is just a viewer"  do
+          # Quick way to force a "viewer" policy.
+          allow_any_instance_of(NamespacePolicy).to receive(:push?).and_return(false)
+          allow_any_instance_of(NamespacePolicy).to receive(:pull?).and_return(true)
+
+          get v2_token_url,
+            { service: registry.hostname, account: user.username, scope: "repository:#{user.username}/busybox:push,pull" },
+            valid_auth_header
+
+          expect(response.status).to eq 200
+
+          # And check that the only authorized scope is "pull"
+          token = JSON.parse(response.body)["token"]
+          payload = JWT.decode(token, nil, false, leeway: 2)[0]
+          expect(payload["access"][0]["name"]).to eq "#{user.username}/busybox"
+          expect(payload["access"][0]["actions"]).to match_array ["pull"]
         end
       end
 


### PR DESCRIPTION
**NOTE WELL:** This is some preliminary work to fix issue 276. I'm about to leave for my vacation. @mssola please take a look at the code and vet it. I can fix the broken tests once I'm back on the 1st of September (unless you really want to take care of that once you are back from your vacation). 

## The issue

The authorization protocol changed with Docker 1.8:
  * client does pull or push or whatever
  * daemon does ping to registry i.e. https://registry.ip/v2/
  * registry returns 401 along with realm and service, but not scope
  * daemon asks for a token from the auth server, with
    service=<registry>&scope=repository:namespace/image:push,pull

In other words, the daemon always asks for push,pull, even if you are
just doing a pull. The auth server is supposed to respond in the
following fashion:

  * If unauthenticated access is not allowed, return a 401 requiring
user to authentictae
  * If unauthenticated access is allowed to that repo, return a web
token

When user tries the token path against the auth server with credentials:

  * If invalid credentials, return 401
  * If valid credentials, always return a 200 with a JWT that has the
    maximum credentials allowed this user on this repository in this service
    that is a subset of the scope provided.

The daemon will always ask for push,pull, and - as long as I am validly
authenticated - the auth server should always return 200 with a valid
Web token. The Web token will list the max I am allowed.

  * If I am not allowed push or pull, then return a token with no access
  * If I am allowed pull but not push, then return a token with pull
    access only
  * If I am allowed pull and push, then return a token with push and
    pull access