### PR TITLE
check secrets and ssl in production

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
+  before_action :check_requirements
   before_action :authenticate_user!
   protect_from_forgery with: :exception
 
@@ -18,6 +19,21 @@ class ApplicationController < ActionController::Base
   end
 
   protected
+
+  # Check whether certain requirements are met, like ssl configuration
+  # for production or having setup secrets.
+  # If they are not met, render a page with status 500
+  def check_requirements
+    fix_secrets = true if Rails.application.secrets.secret_key_base == "CHANGE_ME"
+    fix_ssl = true if Rails.env.production? && !request.ssl?
+    return unless fix_secrets || fix_ssl
+    text = "Please review the following configurations"
+    text += "<ul>"
+    text += "<li>ssl</li>" if fix_ssl
+    text += "<li>secrets</li>" if fix_secrets
+    text += "</ul>"
+    render text: text, status: 500
+  end
 
   def deny_access
     render text: "Access Denied", status: :unauthorized

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -25,7 +25,11 @@ test:
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
 production:
+  <% if ENV["PORTUS_SECRET_KEY_BASE"] %>
   secret_key_base: <%= ENV["PORTUS_SECRET_KEY_BASE"] %>
+  <% else %>
+  secret_key_base: CHANGE_ME
+  <% end %>
   encryption_private_key_path: <%= ENV["PORTUS_KEY_PATH"] %>
   machine_fqdn: <%= ENV["PORTUS_MACHINE_FQDN"] %>
   portus_password: <%= ENV["PORTUS_PASSWORD"] %>


### PR DESCRIPTION
If secrets have not been set or ssl, render an error page. This will
prevent running unsafely in production but also provides with a
running application.

The message needs to be rewritten. I'll do that on a separate commit.