### PR TITLE
update uglifier gem for fixing a security issue (OSVDB-126747)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,7 @@ GEM
     docile (1.1.5)
     erubis (2.7.0)
     eventmachine (1.0.7)
-    execjs (2.5.2)
+    execjs (2.6.0)
     factory_girl (4.5.0)
       activesupport (>= 3.0.0)
     factory_girl_rails (4.5.0)
@@ -287,7 +287,7 @@ GEM
       coffee-rails
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    uglifier (2.7.1)
+    uglifier (2.7.2)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
     uri_template (0.5.3)
@@ -364,3 +364,6 @@ DEPENDENCIES
   webmock
   wirb
   wirble
+
+BUNDLED WITH
+   1.10.6


### PR DESCRIPTION
It was discovered that the upstream library for uglifier Gem for Ruby,
UglifyJS, versions 2.4.23 and earlier, was affected by a vulnerability
which allows a specially crafted JavaScript file to have altered
functionality after minification. This bug was demonstrated to allow
potentially malicious code to be hidden within secure code, activated
by minification.

References:

https://github.com/mishoo/UglifyJS2/issues/751
https://zyan.scripts.mit.edu/blog/backdooring-js/