### PR TITLE
Respect the "gravatar" configurable value everywhere

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -366,6 +366,3 @@ DEPENDENCIES
   webmock
   wirb
   wirble
-
-BUNDLED WITH
-   1.10.6

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -29,3 +29,9 @@
 #profile .panel {
   max-width: 700px;
 }
+
+// Overwriting so we fa-user elements are actually shown in the
+// activities list.
+.panel-overview .fa-user {
+  color: $gray-mid;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,4 +2,13 @@ module ApplicationHelper
   def can_manage_namespace?(namespace)
     current_user.admin? || namespace.team.owners.exists?(current_user.id)
   end
+
+  # Render the user profile picture depending on the gravatar configuration.
+  def user_image_tag(email, size = 1)
+    if APP_CONFIG.enabled?("gravatar")
+      gravatar_image_tag(email)
+    else
+      render html: "<i class=\"fa fa-user fa-#{size}x\"></i>".html_safe
+    end
+  end
 end

--- a/app/views/public_activity/namespace/_create.html.slim
+++ b/app/views/public_activity/namespace/_create.html.slim
@@ -1,7 +1,7 @@
 .alert.alert-info.activity
   .row
     .col-xs-1
-      = gravatar_image_tag(activity.owner.email)
+      = user_image_tag(activity.owner.email)
     .col-xs-11
       .pull-right
         = time_ago_in_words(activity.created_at)

--- a/app/views/public_activity/namespace/_private.html.slim
+++ b/app/views/public_activity/namespace/_private.html.slim
@@ -1,7 +1,7 @@
 .alert.alert-info.activity
   .row
     .col-xs-1
-      = gravatar_image_tag(activity.owner.email)
+      = user_image_tag(activity.owner.email)
     .col-xs-11
       .pull-right
         = time_ago_in_words(activity.created_at)

--- a/app/views/public_activity/namespace/_public.html.slim
+++ b/app/views/public_activity/namespace/_public.html.slim
@@ -1,7 +1,7 @@
 .alert.alert-info.activity
   .row
     .col-xs-1
-      = gravatar_image_tag(activity.owner.email)
+      = user_image_tag(activity.owner.email)
     .col-xs-11
       .pull-right
         = time_ago_in_words(activity.created_at)

--- a/app/views/public_activity/repository/_push.html.slim
+++ b/app/views/public_activity/repository/_push.html.slim
@@ -1,7 +1,7 @@
 .alert.alert-info.activity
   .row
     .col-xs-1
-      = gravatar_image_tag(activity.owner.email)
+      = user_image_tag(activity.owner.email)
     .col-xs-11
       .pull-right
         = time_ago_in_words(activity.created_at)

--- a/app/views/public_activity/team/_add_member.html.slim
+++ b/app/views/public_activity/team/_add_member.html.slim
@@ -1,7 +1,7 @@
 .alert.alert-info.activity
   .row
     .col-xs-1
-      = gravatar_image_tag(activity.owner.email)
+      = user_image_tag(activity.owner.email)
     .col-xs-11
       .pull-right
         = time_ago_in_words(activity.created_at)

--- a/app/views/public_activity/team/_change_member_role.html.slim
+++ b/app/views/public_activity/team/_change_member_role.html.slim
@@ -1,7 +1,7 @@
 .alert.alert-info.activity
   .row
     .col-xs-1
-      = gravatar_image_tag(activity.owner.email)
+      = user_image_tag(activity.owner.email)
     .col-xs-11
       .pull-right
         = time_ago_in_words(activity.created_at)

--- a/app/views/public_activity/team/_create.html.slim
+++ b/app/views/public_activity/team/_create.html.slim
@@ -1,7 +1,7 @@
 .alert.alert-info.activity
   .row
     .col-xs-1
-      = gravatar_image_tag(activity.owner.email)
+      = user_image_tag(activity.owner.email)
     .col-xs-11
       .pull-right
         = time_ago_in_words(activity.created_at)

--- a/app/views/public_activity/team/_remove_member.html.slim
+++ b/app/views/public_activity/team/_remove_member.html.slim
@@ -1,7 +1,7 @@
 .alert.alert-info.activity
   .row
     .col-xs-1
-      = gravatar_image_tag(activity.owner.email)
+      = user_image_tag(activity.owner.email)
     .col-xs-11
       .pull-right
         = time_ago_in_words(activity.created_at)

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -14,7 +14,7 @@
   .username-logout
     .hidden-xs
       - if APP_CONFIG.enabled?("gravatar")
-        = gravatar_image_tag(current_user.email)
+        = user_image_tag(current_user.email)
       - else
         i.fa.fa-user.fa-1x
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -37,4 +37,20 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
+  describe "#user_image_tag" do
+    # Mocking the gravatar_image_tag
+    def gravatar_image_tag(email)
+      email
+    end
+
+    it "uses the gravatar image tag if enabled" do
+      APP_CONFIG["gravatar"] = { "enabled" => true }
+      expect(user_image_tag("user@example.com")).to eq "user@example.com"
+    end
+
+    it "uses the fa icon if gravatar support is disabled" do
+      APP_CONFIG["gravatar"] = { "enabled" => false }
+      expect(user_image_tag("user@example.com")).to eq "<i class=\"fa fa-user fa-1x\"></i>"
+    end
+  end
 end

--- a/spec/lib/portus/config_spec.rb
+++ b/spec/lib/portus/config_spec.rb
@@ -5,7 +5,7 @@ def get_config(default, local)
   Portus::Config.new(default, local)
 end
 
-describe Portus::Config, focus: true do
+describe Portus::Config do
   it "returns an empty config if neither the global nor the local were found" do
     cfg = get_config("", "").fetch
 


### PR DESCRIPTION
I realized that in the public activities we use `gravatar_image_tag` directly,
without caring whether the current Portus instance has gravatar support enabled
or not. Therefore, I'm introducing a helper method that abstracts this away,
and I've replaced all the wrong uses of the `gravatar_image_tag` with this new
helper method.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>