### PR TITLE
Allow configurable values to be overwritten by environment variables

### DIFF
--- a/lib/portus/config.rb
+++ b/lib/portus/config.rb
@@ -14,19 +14,22 @@ module Portus
       cfg = {}
       cfg = YAML.load_file(@default) if File.file?(@default)
 
+      local = {}
       if File.file?(@local)
         # Check for bad user input in the local config.yml file.
         local = YAML.load_file(@local)
         unless local.is_a?(Hash)
           raise StandardError, "Wrong format for the config-local file!"
         end
-        cfg = cfg.deep_merge(local)
       end
 
-      add_enabled(cfg)
+      hsh = strict_merge_with_env(cfg, local)
+      add_enabled(hsh)
     end
 
     protected
+
+    include ::Portus::HashUtils
 
     # Add the `enabled?` method to the given object. The `enabled?` method is
     # a convenient method that checks whether a specific feature is enabled or

--- a/lib/portus/hash_utils.rb
+++ b/lib/portus/hash_utils.rb
@@ -1,0 +1,67 @@
+module Portus
+  # The HashUtils modules include some helper methods that can be useful for
+  # some hashes (e.g. the ones that deal with configuration management).
+  module HashUtils
+    # Applies a deep merge while respecting the values from environment
+    # variables. A deep merge consists of a merge of all the nested elements of
+    # the two given hashes `cfg` and `local`. The `cfg` hash is supposed to
+    # contain all the accepted keys, and the `local` hash is a subset of it.
+    #
+    # Moreover, let's say that we have the following hash:
+    # { "ldap" => { "enabled" => true } }. An environment variable that can
+    # modify the value of the previous hash has to be named
+    # `PORTUS_LDAP_ENABLED`. The `prefix` argument specifies how all the
+    # environment variables have to start. It defaults to "PORTUS".
+    #
+    # Returns the merged hash, where the precedence of the merge is as follows:
+    #   1. The value of the related environment variable if set.
+    #   2. The value from the `local` hash.
+    #   3. The value from the `cfg` hash.
+    def strict_merge_with_env(cfg, local, prefix = "portus")
+      hsh = {}
+
+      cfg.each do |k, v|
+        # The corresponding environment variable. If it's not the final value,
+        # then this just contains the partial prefix of the env. variable.
+        env = "#{prefix}_#{k}"
+
+        # If the current value is a hash, then go deeper to perform a deep
+        # merge, otherwise we merge the final value by respecting the order as
+        # specified in the documentation.
+        if v.is_a?(Hash)
+          l = local[k] || {}
+          hsh[k] = strict_merge_with_env(cfg[k], l, env)
+        else
+          hsh[k] = first_non_nil(get_env(env), local[k], v)
+        end
+      end
+      hsh
+    end
+
+    private
+
+    # Get the typed value of the specified environment variable. If it doesn't
+    # exist, it will return nil. Otherwise, it will try to cast the fetched
+    # value into the proper type and return it.
+    def get_env(key)
+      env = ENV[key.upcase]
+      return nil if env.nil?
+
+      # Try to convert it into a boolean value.
+      return true if env.downcase == "true"
+      return false if env.downcase == "false"
+
+      # Try to convert it into an integer. Otherwise just keep the string.
+      begin
+        Integer(env)
+      rescue ArgumentError
+        env
+      end
+    end
+
+    # Returns the first value that is not nil from the given argument list.
+    def first_non_nil(*values)
+      values.each { |v| return v unless v.nil? }
+    end
+  end
+end

--- a/spec/fixtures/local.yml
+++ b/spec/fixtures/local.yml
@@ -3,3 +3,5 @@ ldap:
   hostname: "ldap.example.com"
   port: 389
   base: "ou=users,dc=example,dc=com"
+unknown:
+  enabled: true

--- a/spec/lib/portus/config_spec.rb
+++ b/spec/lib/portus/config_spec.rb
@@ -5,7 +5,22 @@ def get_config(default, local)
   Portus::Config.new(default, local)
 end
 
+class ConfigMock < Portus::Config
+  def initialize
+  end
+
+  def strict_merge_with_env(cfg, local, prefix = "portus")
+    super(cfg, local, prefix)
+  end
+end
+
 describe Portus::Config do
+  after :each do
+    ["PORTUS_LDAP_COUNT", "PORTUS_ANOTHER_ENABLED", "PORTUS_LDAP_STRING"].each do |key|
+      ENV[key] = nil
+    end
+  end
+
   it "returns an empty config if neither the global nor the local were found" do
     cfg = get_config("", "").fetch
 
@@ -28,10 +43,39 @@ describe Portus::Config do
     expect(cfg["ldap"]["hostname"]).to eq "ldap.example.com"
     expect(cfg["ldap"]["port"]).to eq 389
     expect(cfg["ldap"]["base"]).to eq "ou=users,dc=example,dc=com"
+    expect(cfg["unknown"]).to be nil
   end
 
   it "raises an error when the local file is badly formatted" do
     bad   = get_config("config.yml", "bad.yml")
     expect { bad.fetch }.to raise_error(StandardError, "Wrong format for the config-local file!")
+  end
+
+  it "merges hashes in a strict manner while evaluating env variables first" do
+    default = {
+      "gravatar" => { "enabled" => true },
+      "another"  => { "enabled" => true },
+      "ldap"     => {
+        "enabled" => false,
+        "count"   => 0,
+        "string"  => ""
+      }
+    }
+    local = {
+      "ldap"     => {
+        "enabled" => true,
+        "count"   => 1
+      }
+    }
+    ENV["PORTUS_LDAP_COUNT"] = "2"
+    ENV["PORTUS_ANOTHER_ENABLED"] = "false"
+    ENV["PORTUS_LDAP_STRING"] = "string"
+
+    cfg = ConfigMock.new.strict_merge_with_env(default, local)
+    expect(cfg["gravatar"]["enabled"]).to be true # default
+    expect(cfg["another"]["enabled"]).to be false # env
+    expect(cfg["ldap"]["enabled"]).to be true     # local
+    expect(cfg["ldap"]["count"]).to eq 2          # env
+    expect(cfg["ldap"]["string"]).to eq "string"  # env
   end
 end


### PR DESCRIPTION
If we have the following configuration:

```yaml
ldap:
  enabled: true
```

Now there is another way to change that besides using a `config-local.yml`
file. That's by using the proper environment variable. For the previous case,
the environment variable would be `PORTUS_LDAP_ENABLED`. Therefore, all these
environment variables start with "PORTUS", and then they follow the keys.

Moreover, now the accepted configurable values are tied to the `config.yml`
file. Therefore, any other value set by either the `config-local.yml` file or
an environment variable will be properly ignored.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>