### PR TITLE
[compose-setup]: Use the current DOCKER_HOST value if already exists

### DIFF
--- a/compose-setup.sh
+++ b/compose-setup.sh
@@ -44,7 +44,7 @@ clean() {
 }
 
 
-DOCKER_HOST=$(hostname -f)
+DOCKER_HOST=${DOCKER_HOST=$(hostname -f)}
 echo "DOCKER_HOST=${DOCKER_HOST}" > docker/environment
 
 clean


### PR DESCRIPTION
The script is forcing the `DOCKER_HOST` value as the hostname of the current machine, but some people use a custom `DOCKER_HOST`.

This small fix will keep the `DOCKER_HOST` value if already exists or replace with the `hostname -f` if not.