### PR TITLE
registry: fixed webhooks for distribution v2.1

### DIFF
--- a/spec/vcr_cassettes/registry/get_image_manifest_another_webhook.yml
+++ b/spec/vcr_cassettes/registry/get_image_manifest_another_webhook.yml
@@ -1,0 +1,36 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://registry.test.lan/v2/portus/busybox/manifests/digest
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - registry.test.lan
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Docker-Distribution-Api-Version:
+      - registry/2.0
+      Date:
+      - Mon, 20 Apr 2015 10:06:19 GMT
+      Content-Length:
+      - '170'
+    body:
+      encoding: UTF-8
+      string: |
+        {"tag": "latest" }
+    http_version:
+  recorded_at: Mon, 20 Apr 2015 10:06:19 GMT

--- a/spec/vcr_cassettes/registry/get_image_manifest_namespaced_webhook.yml
+++ b/spec/vcr_cassettes/registry/get_image_manifest_namespaced_webhook.yml
@@ -1,0 +1,36 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://registry.test.lan/v2/suse/busybox/manifests/digest
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - registry.test.lan
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Docker-Distribution-Api-Version:
+      - registry/2.0
+      Date:
+      - Mon, 20 Apr 2015 10:06:19 GMT
+      Content-Length:
+      - '170'
+    body:
+      encoding: UTF-8
+      string: |
+        {"tag": "latest" }
+    http_version:
+  recorded_at: Mon, 20 Apr 2015 10:06:19 GMT

--- a/spec/vcr_cassettes/registry/get_image_manifest_webhook.yml
+++ b/spec/vcr_cassettes/registry/get_image_manifest_webhook.yml
@@ -1,0 +1,36 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://registry.test.lan/v2/busybox/manifests/digest
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - registry.test.lan
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Docker-Distribution-Api-Version:
+      - registry/2.0
+      Date:
+      - Mon, 20 Apr 2015 10:06:19 GMT
+      Content-Length:
+      - '170'
+    body:
+      encoding: UTF-8
+      string: |
+        {"tag": "latest" }
+    http_version:
+  recorded_at: Mon, 20 Apr 2015 10:06:19 GMT


### PR DESCRIPTION
Distribution changed the format of event notifications. In particular, the tag
is no longer provided inside the URL. This is a good move since it's safer to
point by digest. However it affected us because we retrieved tags from this
URL. From now on, we'll take advantage of this digest to call the Manifest API
and fetch the tag.

I've also submitted an issue on Docker Distribution about providing a better
solution for this (so we don't have to call the Manifest API everytime).

See docker/distribution#966

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>