### PR TITLE
ldap: fixed LDAP tests

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -243,7 +243,13 @@ Devise.setup do |config|
   #   manager.intercept_401 = false
   #   manager.default_strategies(scope: :user).unshift :some_external_strategy
   # end
-  if Portus::LDAP.enabled?
+  #
+  # The LDAP authenticatable strategy is enabled by default on tests. This is
+  # to avoid some trouble with tests actually requiring LDAP support to be
+  # enabled. By default, the test suite mocks the Portus::LDAP class to make
+  # the authenticate! method to fail directly. See the `spec/rails_helper.rb`
+  # file.
+  if Portus::LDAP.enabled? || Rails.env.test?
     config.warden do |manager|
       # Let's put LDAP in front of every other strategy.
       manager.default_strategies(scope: :user).unshift :ldap_authenticatable

--- a/spec/api/v2/token_spec.rb
+++ b/spec/api/v2/token_spec.rb
@@ -90,6 +90,7 @@ describe "/v2/token" do
     context "as LDAP user I can authenticate from Docker CLI" do
       before :each do
         APP_CONFIG["ldap"] = { "enabled" => true, "base" => "" }
+        allow_any_instance_of(Portus::LDAP).to receive(:authenticate!).and_call_original
         allow_any_instance_of(Net::LDAP).to receive(:bind_as).and_return(true)
         allow_any_instance_of(NamespacePolicy).to receive(:push?).and_return(true)
         allow_any_instance_of(NamespacePolicy).to receive(:pull?).and_return(true)

--- a/spec/lib/portus/ldap_spec.rb
+++ b/spec/lib/portus/ldap_spec.rb
@@ -92,6 +92,10 @@ describe Portus::LDAP do
     }
   end
 
+  before :each do
+    allow_any_instance_of(Portus::LDAP).to receive(:authenticate!).and_call_original
+  end
+
   it "sets self.enabled? accordingly" do
     expect(Portus::LDAP.enabled?).to be_falsey
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -16,6 +16,22 @@ ActiveRecord::Migration.maintain_test_schema!
 # been pushed into individual files inside the `spec/support` directory.
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 
+# To avoid problems, the LDAP authenticatable is enabled always. Since this
+# means trouble for regular logins, we mock Portus::LDAP to implement a fake
+# authenticate method. This method will be used by everyone. Tests that really
+# want to interface with the real LDAP support, have to call the following in a
+# before(:each) block:
+#
+#   allow_any_instance_of(Portus::LDAP).to receive(:authenticate!).and_call_original
+#
+Portus::LDAP.class_eval do
+  def fake_authenticate!
+    # rubocop:disable Style/SignalException
+    fail(:invalid_login)
+    # rubocop:enable Style/SignalException
+  end
+end
+
 RSpec.configure do |config|
   # If we want Capybara + DatabaseCleaner + Poltergeist to work correctly, we
   # have to just set this to false.
@@ -24,4 +40,9 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.include FactoryGirl::Syntax::Methods
   config.infer_base_class_for_anonymous_controllers = true
+
+  # By default, LDAP will be faked away.
+  config.before :each do
+    allow_any_instance_of(Portus::LDAP).to receive(:authenticate!).and_return(:fake_authenticate!)
+  end
 end


### PR DESCRIPTION
There were some issues with tests requiring LDAP to be enabled. To fix that,
LDAP will be enabled always for the test suite. However, the test suite mocks
away the Portus::LDAP class so the `authenticate!` method fails gracefully for
regular tests. Tests that require the legit version of the `authenticate!`
method have to call the following inside the `before(:each)` block:

```ruby
allow_any_instance_of(Portus::LDAP).to receive(:authenticate!).and_call_original
```

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>