### PR TITLE
[packaging] split create_database

### DIFF
--- a/packaging/suse/scripts/configure_database.sh
+++ b/packaging/suse/scripts/configure_database.sh
@@ -51,24 +51,5 @@ sed -e "s/# SetEnv PORTUS_PRODUCTION_DATABASE/SetEnv PORTUS_PRODUCTION_HOST/g" -
 sed -e "s/SetEnv PORTUS_PRODUCTION_DATABASE.*/SetEnv PORTUS_PRODUCTION_HOST $db_name/g" -i $APACHE_CONF_PATH/portus.conf
 export PORTUS_PRODUCTION_DATABASE=$db_name
 
-bundle="/srv/Portus/vendor/bundle/ruby/2.1.0/bin/bundler.ruby2.1"
-export GEM_PATH=/srv/Portus/vendor/bundle/ruby/2.1.0/
-pushd /srv/Portus
+./create_database.sh
 
-export SKIP_MIGRATION=yes
-export RAILS_ENV=production
-
-echo "Create database"
-$bundle exec rake db:create
-echo "Run migrations"
-$bundle exec rake db:migrate
-
-echo "Seed"
-
-# Set password for portus user
-echo "Set pasword"
-PORTUS_PASSWORD=$(($RANDOM%10))$(($RANDOM%10))$(($RANDOM%10))$(($RANDOM%10))$(($RANDOM%10))$(($RANDOM%10))$(($RANDOM%10))$(($RANDOM%10))
-sed -e "s/SetEnv PORTUS_PASSWORD.*/SetEnv PORTUS_PASSWORD $PORTUS_PASSWORD/g" -i $APACHE_CONF_PATH/portus.conf
-export PORTUS_PASSWORD
-$bundle exec rake db:seed
-popd

--- a/packaging/suse/scripts/create_database.sh
+++ b/packaging/suse/scripts/create_database.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+cd $(dirname $0)
+
+. check_reqs.include
+
+check_reqs
+
+bundle="/srv/Portus/vendor/bundle/ruby/2.1.0/bin/bundler.ruby2.1"
+export GEM_PATH=/srv/Portus/vendor/bundle/ruby/2.1.0/
+pushd /srv/Portus
+
+export SKIP_MIGRATION=yes
+export RAILS_ENV=production
+
+
+echo "Create database"
+$bundle exec rake db:create
+echo "Run migrations"
+$bundle exec rake db:migrate
+
+echo "Seed"
+
+# Set password for portus user
+echo "Set password for user portus"
+PORTUS_PASSWORD=$(($RANDOM%10))$(($RANDOM%10))$(($RANDOM%10))$(($RANDOM%10))$(($RANDOM%10))$(($RANDOM%10))$(($RANDOM%10))$(($RANDOM%10))
+sed -e "s/SetEnv PORTUS_PASSWORD.*/SetEnv PORTUS_PASSWORD $PORTUS_PASSWORD/g" -i $APACHE_CONF_PATH/portus.conf
+export PORTUS_PASSWORD
+$bundle exec rake db:seed
+popd


### PR DESCRIPTION
we need the create_database.sh script because you call it in the
appliance first-boot