### PR TITLE
Fixed regression on the authentication of the Portus user when LDAP is enabled

### DIFF
--- a/lib/portus/ldap.rb
+++ b/lib/portus/ldap.rb
@@ -56,7 +56,8 @@ module Portus
 
     # Loads the configuration and authenticates the current user.
     def load_configuration
-      return nil unless ::Portus::LDAP.enabled?
+      # Note that the Portus user needs to authenticate through the DB.
+      return nil if !::Portus::LDAP.enabled? || params[:account] == "portus"
 
       fill_user_params!
       return nil if params[:user].nil?

--- a/spec/lib/portus/ldap_spec.rb
+++ b/spec/lib/portus/ldap_spec.rb
@@ -82,6 +82,18 @@ class LdapMock < Portus::LDAP
   end
 end
 
+class PortusMock < Portus::LDAP
+  attr_reader :params
+
+  def initialize(params)
+    @params = params
+  end
+
+  def load_configuration_test
+    load_configuration
+  end
+end
+
 describe Portus::LDAP do
   let(:ldap_config) do
     {
@@ -125,7 +137,11 @@ describe Portus::LDAP do
     APP_CONFIG["ldap"] = { "enabled" => true }
     expect(lm.load_configuration_test).to be nil
 
+    # The Portus user does not authenticate through LDAP.
     APP_CONFIG["ldap"] = ldap_config
+    lm = PortusMock.new(account: "portus", password: "1234")
+    expect(lm.load_configuration_test).to be nil
+
     lm = LdapMock.new(username: "name", password: "1234")
     cfg = lm.load_configuration_test
 


### PR DESCRIPTION
Thanks to @sotsy for the catch!

Fixes #324

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>