### PR TITLE
Only use the gray color for fa-user inside of activities

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -32,6 +32,6 @@
 
 // Overwriting so we fa-user elements are actually shown in the
 // activities list.
-.panel-overview .fa-user {
+.activity .fa-user {
   color: $gray-mid;
 }


### PR DESCRIPTION
This fixes a regression in which suddenly the icon on the users container of
the admin page looked inconsistent with the other icons.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>