### PR TITLE
[packaging] fix Portus.spec

### DIFF
--- a/packaging/suse/Portus.spec.in
+++ b/packaging/suse/Portus.spec.in
@@ -38,6 +38,7 @@ BuildRequires: systemd-rpm-macros
 %endif
 BuildRequires:  fdupes
 BuildRequires:  ruby-macros >= 5
+BuildRequires:  apache2
 Requires:       rubygem-passenger-apache2
 %{?systemd_requires}
 Provides:       Portus = %{version}


### PR DESCRIPTION
add apache2 as BuildRequires because we need it for installing
/etc/apache2/vhosts.d/portus.conf.sample