### PR TITLE
Add the 'timezone' requirement to the Portus rpm

### DIFF
--- a/packaging/suse/Portus.spec.in
+++ b/packaging/suse/Portus.spec.in
@@ -33,6 +33,7 @@ Group:          System/Management
 %define portusdir /srv/Portus
 
 Requires:       ruby >= 2.1
+Requires:       timezone
 %if 0%{?suse_version} >= 1210
 BuildRequires: systemd-rpm-macros
 %endif


### PR DESCRIPTION
On a really minimal system (e.g. a Docker image) the timezone package
is usually missing, that would cause some rubygem to fail.