### PR TITLE
Fix firstboot

### DIFF
--- a/packaging/suse/scripts/portus-firstboot
+++ b/packaging/suse/scripts/portus-firstboot
@@ -46,7 +46,7 @@ systemctl start registry
 systemctl enable portus_crono
 systemctl start portus_crono
 
-echo "Disabling firstboot"
-
-mv /portus-firstboot /portus-firstboot.disabled
-
+if [ -e /portus-firstboot ]; then
+  echo "Disabling firstboot"
+  mv /portus-firstboot /portus-firstboot.disabled
+fi


### PR DESCRIPTION
Check for the presence of /first-boot before trying to move it. Usually the file is not there, hence the script exits with an error
