### PR TITLE
Set log level for production env

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  # config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   # config.log_tags = [:subdomain, :uuid]


### PR DESCRIPTION
This is required to get rid of a deprecation warning:

> DEPRECATION WARNING: You did not specify a `log_level` in
> `production.rb`. Currently, the default value for `log_level` is
> `:info` for the production environment and `:debug` in all other
> environments. In Rails 5 the default value will be unified to `:debug`
> across all environments. To preserve the current setting, add the
> following line to your `production.rb`: