### PR TITLE
[packaging] fix hostname apache configuration

### DIFF
--- a/packaging/suse/conf/etc.apache2.vhosts.d.portus.conf
+++ b/packaging/suse/conf/etc.apache2.vhosts.d.portus.conf
@@ -19,7 +19,7 @@
       SetEnv PORTUS_PRODUCTION_DATABASE portus_production
       # Set the __SECRET_KEY__ by running rake secret
       SetEnv PORTUS_SECRET_KEY_BASE __SECRET_KEY__
-      SetEnv PORTUS_MACHINE_FQDN ${HOSTNAME}
+      SetEnv PORTUS_MACHINE_FQDN __HOSTNAME__
       SetEnv PORTUS_KEY_PATH /srv/Portus/config/server.key
       # Set the PORTUS_PASSWORD
       SetEnv PORTUS_PASSWORD __PORTUS_PASSWORD__

--- a/packaging/suse/scripts/configure_apache.sh
+++ b/packaging/suse/scripts/configure_apache.sh
@@ -14,4 +14,5 @@ if [ "$port" == "" ];then
 fi
 
 sed -e "s/<VirtualHost .*/<VirtualHost \*:$port>/g" -i $APACHE_CONF_PATH/portus.conf
+sed -e "s/SetEnv PORTUS_MACHINE_FQDN.*/SetEnv PORTUS_MACHINE_FQDN $HOSTNAME/g" -i $APACHE_CONF_PATH/portus.conf
 


### PR DESCRIPTION
It looks like use ${HOSTNAME} does not work in the apache configuration
for portus. I realized that when trying to login with docker.

Thus, let's set the value within the configure_apache script

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>