### PR TITLE
Make it possible to disable ssl checks on production

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,7 +25,7 @@ class ApplicationController < ActionController::Base
   def fixes
     secrets = Rails.application.secrets
     {}.tap do |fix|
-      fix[:ssl]                                = Rails.env.production? && !request.ssl?
+      fix[:ssl]                                = Rails.env.production? && !request.ssl? && APP_CONFIG.enabled?("check_ssl_usage")
       fix[:secret_key_base]                    = secrets.secret_key_base == "CHANGE_ME"
       fix[:secret_machine_fqdn]                = secrets.machine_fqdn.nil?
       fix[:secret_encryption_private_key_path] = secrets.encryption_private_key_path.nil?

--- a/config/config.yml
+++ b/config/config.yml
@@ -59,3 +59,7 @@ ldap:
 # in order to set the admin user
 first_user_admin:
   enabled: true
+
+# By default require ssl to be enabled when running on production
+check_ssl_usage:
+  enabled: true

--- a/spec/controllers/errors_controller_spec.rb
+++ b/spec/controllers/errors_controller_spec.rb
@@ -54,15 +54,26 @@ describe ErrorsController do
   end
 
   describe "GET #show in production mode" do
-
     after :all do
       Rails.env = ActiveSupport::StringInquirer.new("test")
     end
 
-    it "sets @fix[:ssl] as true" do
-      Rails.env = ActiveSupport::StringInquirer.new("production")
-      get :show, id: 1
-      expect(assigns(:fix)[:ssl]).to be true
+    context "production environment" do
+      before :each do
+        Rails.env = ActiveSupport::StringInquirer.new("production")
+      end
+
+      it "sets @fix[:ssl] as true when check_ssl_usage is enabled" do
+        APP_CONFIG["check_ssl_usage"] = { "enabled" => true }
+        get :show, id: 1
+        expect(assigns(:fix)[:ssl]).to be true
+      end
+
+      it "sets @fix[:ssl] as false when check_ssl_usage is disabled" do
+        APP_CONFIG["check_ssl_usage"] = { "enabled" => false }
+        get :show, id: 1
+        expect(assigns(:fix)[:ssl]).to be false
+      end
     end
 
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,6 +37,9 @@ RSpec.configure do |config|
 
     # Clear the global config before each test.
     APP_CONFIG.clear
+    # this value affects the application controller, we have to make sure
+    # it has the default value we expect
+    APP_CONFIG["check_ssl_usage"] = { "enabled" => true }
   end
 
   config.order = :random


### PR DESCRIPTION
The default is to enforce ssl usage on production, however in certain circumstances (e.g.: out internal integration test suite) it's actually more convenient to not use ssl.