### PR TITLE
ldap: added support for SSL/TLS connections

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,10 @@
 inherit_from:
   - ./config/rubocop-suse.yml
 
+# TODO: (mssola) only the LDAP class requires this.
+Metrics/ClassLength:
+  Max: 120
+
 # TODO: (mssola) Some methods are offending this cop. In the SUSE's style guide
 # the approach is to use Rubocop's default value. In the near future I will
 # fix this.

--- a/config/config.yml
+++ b/config/config.yml
@@ -26,6 +26,10 @@ ldap:
   hostname: "ldap_hostname"
   port: 389
 
+  # Available options: "plain", "simple_tls" and "starttls". The default is
+  # "plain", the recommended is "starttls".
+  method: "plain"
+
   # The base where users are located (e.g. "ou=users,dc=example,dc=com").
   base: ""
 

--- a/lib/portus/ldap.rb
+++ b/lib/portus/ldap.rb
@@ -63,7 +63,18 @@ module Portus
       return nil if params[:user].nil?
 
       cfg = APP_CONFIG["ldap"]
-      adapter.new(host: cfg["hostname"], port: cfg["port"])
+      adapter.new(host: cfg["hostname"], port: cfg["port"], encryption: encryption(cfg))
+    end
+
+    # Returns the encryption method to be used. Invalid encryption methods will
+    # be mapped to "plain".
+    def encryption(config)
+      case config["method"]
+      when "starttls"
+        :start_tls
+      when "simple_tls"
+        :simple_tls
+      end
     end
 
     # Returns the class to be used for LDAP support. Mainly declared this way

--- a/spec/lib/portus/ldap_spec.rb
+++ b/spec/lib/portus/ldap_spec.rb
@@ -148,6 +148,14 @@ describe Portus::LDAP do
     expect(cfg).to_not be nil
     expect(cfg.opts[:host]).to eq "hostname"
     expect(cfg.opts[:port]).to eq 389
+    expect(cfg.opts[:encryption]).to be nil
+
+    # Test different encryption methods.
+    [["starttls", :start_tls], ["simple_tls", :simple_tls], ["lala", nil]].each do |e|
+      APP_CONFIG["ldap"]["method"] = e[0]
+      cfg = lm.load_configuration_test
+      expect(cfg.opts[:encryption]).to eq e[1]
+    end
   end
 
   it "fetches the right bind options" do


### PR DESCRIPTION
As expected, the Net::LDAP class supports this seamlessly. Moreover, the added
configuration is minimal: there is now the "method" configurable value with
three possible values ("plain", "simple_tls" and "starttls").

I'd say that "plain" is the best default, since it's the easiest to configure
from a server point of view. However, the recommended choice is "starttls",
as described in the documentation of this newly added value.

I've also relaxed a rubocop rule. I plan to fix this as soon as possible.

Fixes #311

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>