### PR TITLE
[packaging] first firstboot configuration of apache

### DIFF
--- a/packaging/suse/scripts/portus-firstboot
+++ b/packaging/suse/scripts/portus-firstboot
@@ -26,6 +26,7 @@ fi
 # Write hostname to configuration files
 sed -e "s/__HOSTNAME__/$HOSTNAME/g" /srv/Portus/packaging/suse/conf/registry.config.yml.in > /etc/registry/config.yml
 sed -e "s/__HOSTNAME__/$HOSTNAME/g" /srv/Portus/public/landing.html.in > /srv/www/htdocs/index.html
+sed -e "s/__HOSTNAME__/$HOSTNAME/g" -i /etc/apache2/vhosts.d/portus.conf
 cp /srv/Portus/public/landing.css /srv/www/htdocs/
 
 /srv/Portus/packaging/suse/scripts/configure_ssl.sh


### PR DESCRIPTION
in firstboot we are not calling config_apache.sh script so that the
hostname is not being set up

This is duplication, but don't worry, a PR that changes this scripts
will follow.

Meanwhile, this fixes the appliance.

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>