### PR TITLE
Added SSL support for the communication between Portus and the registry

### DIFF
--- a/app/jobs/catalog_job.rb
+++ b/app/jobs/catalog_job.rb
@@ -11,8 +11,7 @@ class CatalogJob < ActiveJob::Base
     return if registry.nil?
 
     begin
-      client = Portus::RegistryClient.new(registry.hostname)
-      cat = client.catalog
+      cat = registry.client.catalog
 
       # Update the registry in a transaction, since we don't want to leave the DB
       # in an unknown state because of an update failure.

--- a/app/views/admin/registries/index.html.slim
+++ b/app/views/admin/registries/index.html.slim
@@ -20,11 +20,20 @@
             tr
               th Name
               th Hostname
+              th SSL
           tbody
             - @registries.each do |registry|
-              tr
+              tr id="registry_#{registry.id}"
                 td= registry.name
                 td= registry.hostname
+                td
+                  a.btn.btn-default[data-remote="true"
+                      data-method="put"
+                      rel="nofollow"
+                      href=url_for(admin_registry_path(registry))
+                      title="Enable/disable SSL in the communication between Portus and this registry"
+                      ]
+                      i.fa.fa-lg class="fa-toggle-#{registry.use_ssl? ? 'on': 'off'}"
 
   p
     strong Note well:

--- a/app/views/admin/registries/new.html.slim
+++ b/app/views/admin/registries/new.html.slim
@@ -10,6 +10,10 @@ h1 New Registry
     .col-md-7
       = f.text_field(:hostname, class: 'form-control', placeholder: 'registry.test.lan', required: true)
   .form-group
+    = f.label :use_ssl, "Use SSL", {class: 'control-label col-md-2', title: 'Set this to enable SSL in the communication between Portus and the Registry'}
+    .col-md-7
+      = f.check_box(:use_ssl)
+  .form-group
     .col-md-offset-2.col-md-7
       = f.submit('Create', class: 'btn btn-primary')
 

--- a/app/views/admin/registries/update.js.erb
+++ b/app/views/admin/registries/update.js.erb
@@ -1,0 +1,12 @@
+<% if @registry.errors.empty? %>
+  $('#alert p').html("Registry '<%= @registry.name %>' is <%= @registry.use_ssl? ? 'now using SSL' : 'not using SSL anymore' %>.");
+  $('#alert .alert').removeClass('alert-danger')
+
+  $('#registry_<%= @registry.id %> td a i').addClass("fa-toggle-<%= @registry.use_ssl? ? 'on' : 'off' %>");
+  $('#registry_<%= @registry.id %> td a i').removeClass("fa-toggle-<%= @registry.use_ssl? ? 'off' : 'on' %>");
+<% else %>
+  $('#alert p').html("Selected registry does not exist!");
+  $('#alert .alert').addClass('alert-danger')
+<% end %>
+
+$('#alert').fadeIn();

--- a/bin/client.rb
+++ b/bin/client.rb
@@ -8,17 +8,21 @@
 #   - delete <name> <digest>
 #   - manifest <name>[:<tag>]
 
-client = Portus::RegistryClient.new("registry.test.lan")
+registry = Registry.first
+if registry.nil?
+  puts "No registry has been configured!"
+  exit 1
+end
 
 case ARGV.first
 when "catalog"
-  pp client.catalog
+  pp registry.client.catalog
 when "delete"
   if ARGV.length == 2
     puts "You have to specify first the name, and then the digest"
     exit 1
   end
-  pp client.delete(ARGV[1], ARGV[2])
+  pp registry.client.delete(ARGV[1], ARGV[2])
 when "manifest"
   if ARGV.length == 1
     puts "You have to at least specify the name of the image"
@@ -30,7 +34,7 @@ when "manifest"
   else
     name, tag = ARGV[1], "latest"
   end
-  pp client.manifest(name, tag)
+  pp registry.client.manifest(name, tag)
 else
   puts "Valid commands: catalog, delete, manifest."
   exit 1

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,7 @@ Rails.application.routes.draw do
   namespace :admin do
     resources :activities, only: [:index]
     resources :dashboard, only: [:index]
-    resources :registries, only: [:index, :create, :new]
+    resources :registries, only: [:index, :create, :new, :update]
     resources :namespaces, only: [:index]
     resources :teams, only: [:index]
     resources :users, only: [:index] do

--- a/db/migrate/20150923091830_add_use_ssl_to_registries.rb
+++ b/db/migrate/20150923091830_add_use_ssl_to_registries.rb
@@ -1,0 +1,5 @@
+class AddUseSslToRegistries < ActiveRecord::Migration
+  def change
+    add_column :registries, :use_ssl, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150915130327) do
+ActiveRecord::Schema.define(version: 20150923091830) do
 
   create_table "activities", force: :cascade do |t|
     t.integer  "trackable_id",   limit: 4
@@ -62,6 +62,7 @@ ActiveRecord::Schema.define(version: 20150915130327) do
     t.string   "hostname",   limit: 255, null: false
     t.datetime "created_at",             null: false
     t.datetime "updated_at",             null: false
+    t.boolean  "use_ssl",    limit: 1
   end
 
   add_index "registries", ["hostname"], name: "index_registries_on_hostname", unique: true, using: :btree

--- a/spec/controllers/admin/registries_controller_spec.rb
+++ b/spec/controllers/admin/registries_controller_spec.rb
@@ -19,11 +19,15 @@ RSpec.describe Admin::RegistriesController, type: :controller do
       get :new
       expect(response).to have_http_status(:success)
     end
+
+    it "returns a 404 if there's already a registry in place" do
+      create(:registry)
+      expect { get :new }.to raise_error(ActionController::RoutingError)
+    end
   end
 
   describe "POST #create" do
     context "no registry" do
-
       it "creates a new registry" do
         expect do
           post :create, registry: attributes_for(:registry)
@@ -46,7 +50,7 @@ RSpec.describe Admin::RegistriesController, type: :controller do
 
         expect do
           post :create, registry: attributes_for(:registry)
-        end.to change(Registry, :count).by(0)
+        end.to raise_error(ActionController::RoutingError)
       end
     end
 
@@ -56,6 +60,22 @@ RSpec.describe Admin::RegistriesController, type: :controller do
           post :create, registry: { name: "foo" }
         end.to change(Registry, :count).by(0)
       end
+    end
+  end
+
+  describe "PUT #update" do
+    let!(:registry) { create(:registry) }
+
+    it "does nothing if the registry was not found" do
+      expect do
+        put :update, id: registry.id + 1, format: :js
+      end.to raise_error(ActiveRecord::RecordNotFound)
+      expect(Registry.first.use_ssl).to be_falsey
+    end
+
+    it "registry found" do
+      put :update, id: registry.id, format: :js
+      expect(Registry.first.use_ssl).to be_truthy
     end
   end
 end

--- a/spec/factories/registries.rb
+++ b/spec/factories/registries.rb
@@ -1,11 +1,15 @@
 FactoryGirl.define do
   factory :registry do
     before(:create) { create(:admin) }
+
     sequence :hostname do |n|
       "registry hostname #{n}"
     end
+
     sequence :name do |n|
       "registry name #{n}"
     end
+
+    use_ssl false
   end
 end

--- a/spec/features/admin/registries_spec.rb
+++ b/spec/features/admin/registries_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+feature "Admin - Registries panel" do
+  let!(:admin) { create(:admin) }
+
+  before do
+    login_as admin
+  end
+
+  describe "toggling `use_ssl` from a registry" do
+    let!(:registry) { create(:registry) }
+
+    before :each do
+      visit admin_registries_path
+    end
+
+    it "toggles the `use_ssl` properly", js: true do
+      expect(page).to have_css("#registry_#{registry.id} .fa-toggle-off")
+      expect(page).to_not have_css("#registry_#{registry.id} .fa-toggle-on")
+      find("#registry_#{registry.id} td a i").click
+
+      wait_for_ajax
+      wait_for_effect_on("#alert")
+
+      expect(page).to_not have_css("#registry_#{registry.id} .fa-toggle-off")
+      expect(page).to have_css("#registry_#{registry.id} .fa-toggle-on")
+    end
+  end
+end

--- a/spec/models/registry_spec.rb
+++ b/spec/models/registry_spec.rb
@@ -1,7 +1,11 @@
 require "rails_helper"
 
-RSpec.describe Registry, type: :model do
+# Open up Portus::RegistryClient to inspect some attributes.
+Portus::RegistryClient.class_eval do
+  attr_reader :host, :use_ssl, :base_url, :username, :password
+end
 
+RSpec.describe Registry, type: :model do
   it { should have_many(:namespaces) }
 
   describe "#create_global_namespace" do
@@ -15,6 +19,20 @@ RSpec.describe Registry, type: :model do
 
       expect(owners.count).to be(2)
       expect(users).to match_array(owners)
+    end
+  end
+
+  describe "#client" do
+    let!(:registry) { create(:registry, use_ssl: true) }
+
+    it "returns a client with the proper config" do
+      client = registry.client
+
+      expect(client.host).to eq registry.hostname
+      expect(client.use_ssl).to be_truthy
+      expect(client.base_url).to eq "https://#{registry.hostname}/v2/"
+      expect(client.username).to eq "portus"
+      expect(client.password).to eq Rails.application.secrets.portus_password
     end
   end
 end


### PR DESCRIPTION
This fixes some known issues like the setup of the appliance, in which the
Portus instance and the registry just couldn't speak to each other.

In order to do this, the `use_ssl` attribute has been introduced. This
attribute can be changed in the "registries#show" page in the form of a toggle
box. There's also a checkbox that allows the admin to set `use_ssl` as true
when creating a new registry.

Moreover, this commit also brings some needed cleaning in regards to classes
dealing with registries.

Fixes #362

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>