### PR TITLE
Fix broken install instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,7 +139,7 @@
             <pre>
 $ git clone https://github.com/SUSE/Portus.git
 $ cd Portus
-$ docker-compose up
+$ ./compose-setup.sh
             </pre>
           </div>
           <div class="col-sm-6 text-left">


### PR DESCRIPTION
When `docker-compose up` was run, it hit the following error:

    Couldn't find env file: [redacted]/Portus/docker/environment