### PR TITLE
registry: return the proper error when fetching the manifest fails

### DIFF
--- a/app/models/registry.rb
+++ b/app/models/registry.rb
@@ -71,8 +71,10 @@ class Registry < ActiveRecord::Base
     man = client.manifest(target["repository"], target["digest"])
     man["tag"]
 
-  rescue
-    logger.error("Could not fetch the tag for target #{target}.")
+  rescue StandardError => e
+    logger.info("Could not fetch the tag for target #{target}")
+    logger.info("Reason: #{e.message}")
+    nil
   end
 
   # Create the global namespace for this registry and create the personal

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -37,14 +37,12 @@ describe Repository do
   end
 
   describe "handle push event" do
-
     let(:tag_name) { "latest" }
     let(:repository_name) { "busybox" }
     let(:registry) { create(:registry, hostname: "registry.test.lan") }
     let(:user) { create(:user) }
 
     context "event does not match regexp of manifest" do
-
       let(:event) do
         e = build(:raw_push_manifest_event).to_test_hash
         e["target"]["repository"] = repository_name
@@ -55,14 +53,11 @@ describe Repository do
 
       it "sends event to logger" do
         VCR.use_cassette("registry/get_image_manifest_webhook", record: :none) do
-          error_msg = "Could not fetch the tag for target"
-          expect(Rails.logger).to receive(:error).with(/^#{error_msg}/)
           expect do
             Repository.handle_push_event(event)
           end.to change(Repository, :count).by(0)
         end
       end
-
     end
 
     context "event comes from an unknown registry" do
@@ -92,7 +87,6 @@ describe Repository do
       end
 
       it "sends event to logger" do
-        expect(Rails.logger).to receive(:error)
         expect do
           Repository.handle_push_event(@event)
         end.to change(Repository, :count).by(0)


### PR DESCRIPTION
As noted by @morodin in the issue #338, when Portus fails the fetch the
manifest, it adds a new tag "1" into the database. This is due to a regression
introduced in 09dc052721ad560e4fb56c585f6193d3305fc578. In this case, on
failure the `get_tag_from_manifest` method returned true on error, because
that's what the logger returns. This commit makes sure that in this case nil is
returned.

Moreover, Portus will now also log the error that has happenned when fetching
the manifest.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>