### PR TITLE
catalog_job: skip repos belonging to a non-existing namespace

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -71,9 +71,13 @@ class Repository < ActiveRecord::Base
   # This method will transparently create/remove the tags that the given
   # repository is supposed to have.
   #
+  # Note that if the repo is said to be contained inside of a namespace that
+  # does not really exist, then this method will do nothing.
+  #
   # Returns the final repository object.
   def self.create_or_update!(repo)
     namespace, name = Namespace.get_from_name(repo["name"])
+    return if namespace.nil?
     repository = Repository.find_or_create_by!(name: name, namespace: namespace)
 
     # Add the needed tags.

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -6,7 +6,6 @@ def get_url(repo, tag)
 end
 
 describe Repository do
-
   it { should belong_to(:namespace) }
   it { should have_many(:tags) }
   it { should have_many(:stars) }
@@ -308,6 +307,10 @@ describe Repository do
       repo = Repository.create_or_update!(repo)
       expect(repo.name).to eq "busybox"
       expect(repo.tags.map(&:name).sort).to match_array(["0.1", "latest"])
+
+      # Trying to create a repo into an unknown namespace.
+      repo = { "name" => "unknown/repo1", "tags" => ["latest", "0.1"] }
+      expect(Repository.create_or_update!(repo)).to be_nil
     end
   end
 end


### PR DESCRIPTION
When fetching the catalog, if a given repo is supposed to belong to a namespace
that doesn't exist, do nothing. This is more likely to be a problem in the
registry, since we do not allow to create repos in namespaces that are not in
the system.

This commit also closes the possibility for the CatalogJob to be used as an
automatic migration tool.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>