### PR TITLE
compose: use the IP of the hostname instead of the fully qualified name

### DIFF
--- a/compose-setup.sh
+++ b/compose-setup.sh
@@ -51,7 +51,7 @@ usage() {
   echo "  -f force removal of data"
 }
 
-DOCKER_HOST=${DOCKER_HOST=$(hostname -f)}
+DOCKER_HOST=${DOCKER_HOST=$(hostname -i)}
 echo "DOCKER_HOST=${DOCKER_HOST}" > docker/environment
 
 FORCE=0


### PR DESCRIPTION
This avoids problems when running this on OSX

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>