### PR TITLE
portusctl: show example of Registry's configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_script:
   - mysql -e 'create database portus_test;'
 script:
   - bundle exec rspec spec
+  - bundle exec rubocop -V
   - bundle exec rubocop -F
 env:
   global:

--- a/packaging/suse/portusctl/lib/configurator.rb
+++ b/packaging/suse/portusctl/lib/configurator.rb
@@ -112,17 +112,21 @@ EOM
 
   # Creates registry's configuration
   def registry
-    # Add the certificated used by Portus to sign the JWT tokens
-    ssldir = "/etc/registry/ssl.crt"
-    FileUtils.mkdir_p(ssldir)
-    FileUtils.ln_sf(
-      "/etc/apache2/ssl.crt/#{HOSTNAME}-server.crt",
-      File.join(ssldir, "portus.crt"))
+    if @options["local-registry"]
+      # Add the certificated used by Portus to sign the JWT tokens
+      ssldir = "/etc/registry/ssl.crt"
+      FileUtils.mkdir_p(ssldir)
+      FileUtils.ln_sf(
+        "/etc/apache2/ssl.crt/#{HOSTNAME}-server.crt",
+        File.join(ssldir, "portus.crt"))
 
-    TemplateWriter.process(
-      "registry.yml.erb",
-      "/etc/registry/config.yml",
-      binding)
+      TemplateWriter.process(
+        "registry.yml.erb",
+        "/etc/registry/config.yml",
+        binding)
+    else
+      TemplateWriter.render("registry.yml.erb", binding)
+    end
   end
 
   # Creates the config-local.yml file used by Portus

--- a/packaging/suse/portusctl/lib/template_writer.rb
+++ b/packaging/suse/portusctl/lib/template_writer.rb
@@ -3,14 +3,25 @@
 class TemplateWriter
   # Process the given template and writes it to the final destination
   def self.process(template_name, output, context)
-    template = File.join(
-      File.expand_path("../../templates", __FILE__),
-        template_name)
-
-    conf  = ERB.new(File.read(template), nil, "<>").result(context)
+    t = render(template_name, context)
 
     File.open(output, "w") do |file|
-      file.write(conf)
+      file.write(t)
     end
+  end
+
+  # Returns the ERB template defined inside of `template_name` using
+  # the provided context
+  def self.render(template_name, context)
+    ERB.new(load_template(template_name), nil, "<>").result(context)
+  end
+
+  # Looks for the template inside of the default project directory and
+  # then returns a string containing it.
+  def self.load_template(template_name)
+    t = File.join(
+      File.expand_path("../../templates", __FILE__),
+        template_name)
+    File.read(t)
   end
 end

--- a/packaging/suse/portusctl/templates/registry.yml.erb
+++ b/packaging/suse/portusctl/templates/registry.yml.erb
@@ -6,17 +6,35 @@ storage:
   delete:
     enabled: true
 http:
+<% if @options["local-registry"] %>
   addr: :5000
+<% else %>
+  addr: :5000 # or even <%= @options["secure"] ? ":443" : ":80" %> if you are running on a dedicated host
+<% end %>
+<% if @options["secure"] %>
   tls:
+<% if @options["local-registry"] %>
     certificate: /etc/registry/ssl.crt/portus.crt
     key: /srv/Portus/config/server.key
+<% else %>
+    certificate: /etc/registry/ssl.crt/<DISTRIBUTION HOST CERTIFICATE>.crt
+    key: /etc/registry/<DISTRIBUTION HOST KEY>.key
+<% end %>
+<% end %>
 
 auth:
   token:
     realm: <%= @options["secure"] ? "https" : "http"%>://<%= HOSTNAME %>/v2/token
+<% if @options["local-registry"] %>
     service: <%= HOSTNAME %>:5000
     issuer: <%= HOSTNAME %>
     rootcertbundle: /etc/registry/ssl.crt/portus.crt
+<% else %>
+    service: <DISTRIBUTION HOSTNAME>:5000 # no need to add the port # when listening over http or https
+    issuer: <%= HOSTNAME %>
+    rootcertbundle: /etc/registry/ssl.crt/portus.crt # remember to copy Portus' crt file from Portus' host
+<% end %>
+
 notifications:
   endpoints:
     - name: portus


### PR DESCRIPTION
Show a working example of Registry's configuration when the Registry is
not running on the same host of Portus.