### PR TITLE
portusctl: do not overwrite secrets file

### DIFF
--- a/packaging/suse/portusctl/lib/configurator.rb
+++ b/packaging/suse/portusctl/lib/configurator.rb
@@ -142,12 +142,14 @@ EOM
 
   # Creates the secrets.yml file used by Rails
   def secrets
+    destination = "/srv/Portus/config/secrets.yml"
+    return if File.exists?(destination)
     TemplateWriter.process(
       "secrets.yml.erb",
-      "/srv/Portus/config/secrets.yml",
+      destination,
       binding)
-    FileUtils.chown("root", "www", "/srv/Portus/config/secrets.yml")
-    FileUtils.chmod(0640, "/srv/Portus/config/secrets.yml")
+    FileUtils.chown("root", "www", destination)
+    FileUtils.chmod(0640, destination)
   end
 
   # Ensures all the required services are running


### PR DESCRIPTION
Do not overwrite the secrets file if it already exists. That would
cause a discrepancy of the password of the "portus" user.

Required to fix part of the problems reported inside of issue #376

Signed-off-by: Flavio Castelli <fcastelli@suse.com>