### PR TITLE
Add table icons for namespaces and teams.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ and [#294](https://github.com/SUSE/Portus/pull/294).
 - Now users can be enabled/disabled. See PR [#240](https://github.com/SUSE/Portus/pull/240).
 - Fixed the authentication process for Docker 1.8. See PR
 [#282](https://github.com/SUSE/Portus/pull/282).
+- Added icons to the following tables: teams and members. See PR
+[#388](https://github.com/SUSE/Portus/pull/388).
 - And some minor fixes here and there.
 
 ## 1.0.1

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,17 +14,9 @@
 @import 'images';
 @import 'dashboard';
 @import 'panels';
+@import 'tables';
 @import 'forms';
 @import 'types';
-
-.table > thead > tr > th,
-.table > tbody > tr > th,
-.table > tfoot > tr > th,
-.table > thead > tr > td,
-.table > tbody > tr > td,
-.table > tfoot > tr > td {
-  vertical-align: middle;
-}
 
 #profile .panel {
   max-width: 700px;

--- a/app/assets/stylesheets/tables.scss
+++ b/app/assets/stylesheets/tables.scss
@@ -1,0 +1,13 @@
+.table > thead > tr > th,
+.table > tbody > tr > th,
+.table > tfoot > tr > th,
+.table > thead > tr > td,
+.table > tbody > tr > td,
+.table > tfoot > tr > td {
+  vertical-align: middle;
+}
+
+
+.table > tbody > tr > td.table-icon {
+  text-align: center;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,8 +1,4 @@
 module ApplicationHelper
-  def can_manage_namespace?(namespace)
-    current_user.admin? || namespace.team.owners.exists?(current_user.id)
-  end
-
   # Render the user profile picture depending on the gravatar configuration.
   def user_image_tag(email)
     if APP_CONFIG.enabled?("gravatar")

--- a/app/helpers/namespaces_helper.rb
+++ b/app/helpers/namespaces_helper.rb
@@ -1,0 +1,5 @@
+module NamespacesHelper
+  def can_manage_namespace?(namespace)
+    current_user.admin? || namespace.team.owners.exists?(current_user.id)
+  end
+end

--- a/app/helpers/teams_helper.rb
+++ b/app/helpers/teams_helper.rb
@@ -12,4 +12,31 @@ module TeamsHelper
       "-"
     end
   end
+
+  # Render the namespace scope icon.
+  def team_scope_icon(team)
+    if team.team_users.count > 1
+      icon = "fa-users"
+      title = "Team"
+    else
+      icon = "fa-user"
+      title = "Personal"
+    end
+
+    content_tag :i, "", class: "fa #{icon} fa-lg", title: title
+  end
+
+  # Render the team user role icon.
+  def team_user_role_icon(team_user)
+    icon = case team_user.role
+           when "owner"
+             "fa-key"
+           when "contributor"
+             "fa-exchange"
+           when "viewer"
+             "fa-eye"
+           end
+
+    content_tag :i, "", class: "fa #{icon} fa-lg", title: team_user.role.titleize
+  end
 end

--- a/app/views/admin/namespaces/index.html.slim
+++ b/app/views/admin/namespaces/index.html.slim
@@ -5,13 +5,15 @@
   .panel-body
     .table-responsive
       table.table.table-stripped.table-hover
-        col.col-50
         col.col-40
+        col.col-30
+        col.col-20
         col.col-10
         thead
           tr
             th Name
             th Repositories
+            th Created At
             th Public
         tbody
           - @special_namespaces.each do |namespace|
@@ -24,13 +26,15 @@
   .panel-body
     .table-responsive
       table.table.table-stripped.table-hover
-        col.col-50
         col.col-40
+        col.col-30
+        col.col-20
         col.col-10
         thead
           tr
             th Name
             th Repositories
+            th Created At
             th Public
         tbody
           - @namespaces.each do |namespace|

--- a/app/views/admin/teams/index.html.slim
+++ b/app/views/admin/teams/index.html.slim
@@ -6,13 +6,15 @@
     .table-responsive
       table.table.table-striped.table-hover
         colgroup
-          col.col-30
-          col.col-30
+          col.col-5
+          col.col-20
+          col.col-20
           col.col-10
           col.col-15
           col.col-15
         thead
           tr
+            th
             th Team
             th Role
             th Hidden

--- a/app/views/team_users/_team_user.html.slim
+++ b/app/views/team_users/_team_user.html.slim
@@ -1,4 +1,5 @@
 tr id="team_user_#{team_user.id}"
+  td.table-icon= team_user_role_icon(team_user)
   td= team_user.user.username
   td
     .role= team_user.role.titleize

--- a/app/views/teams/_team.html.slim
+++ b/app/views/teams/_team.html.slim
@@ -1,4 +1,5 @@
 tr
+  td.table-icon= team_scope_icon(team)
   td= link_to team.name, team
   td= role_within_team(team)
   - if current_page?(url_for admin_teams_path)

--- a/app/views/teams/index.html.slim
+++ b/app/views/teams/index.html.slim
@@ -20,12 +20,14 @@
     .table-responsive
       table.table.table-striped.table-hover
         colgroup
+          col.col-5
           col.col-30
-          col.col-30
+          col.col-25
           col.col-20
           col.col-20
         thead
           tr
+            th
             th Team
             th Role
             th Number of members

--- a/app/views/teams/show.html.slim
+++ b/app/views/teams/show.html.slim
@@ -34,15 +34,18 @@
       table.table.table-striped.table-hover
         colgroup
           - if can_manage_team?(@team)
+            col.col-5
             col.col-40
-            col.col-40
+            col.col-35
             col.col-10
             col.col-10
           - else
+            col.col-5
             col.col-50
-            col.col-50
+            col.col-45
         thead
           tr
+            th
             th User
             th Role
             - if can_manage_team?(@team)

--- a/packaging/suse/portusctl/lib/configurator.rb
+++ b/packaging/suse/portusctl/lib/configurator.rb
@@ -143,7 +143,7 @@ EOM
   # Creates the secrets.yml file used by Rails
   def secrets
     destination = "/srv/Portus/config/secrets.yml"
-    return if File.exists?(destination)
+    return if File.exist?(destination)
     TemplateWriter.process(
       "secrets.yml.erb",
       destination,

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,42 +1,6 @@
 require "rails_helper"
 
 RSpec.describe ApplicationHelper, type: :helper do
-
-  let(:registry)    { create(:registry) }
-  let(:admin)       { create(:admin) }
-  let(:owner)       { create(:user) }
-  let(:viewer)      { create(:user) }
-  let(:contributor) { create(:user) }
-  let(:team) do
-    create(:team,
-           owners:       [owner],
-           contributors: [contributor],
-           viewers:      [viewer])
-  end
-  let(:namespace) { create(:namespace, team: team) }
-
-  describe "can_manage_namespace?" do
-    it "returns true if current user is an owner of the namespace" do
-      sign_in owner
-      expect(helper.can_manage_namespace?(namespace)).to be true
-    end
-
-    it "returns false if current user is a viewer of the namespace" do
-      sign_in viewer
-      expect(helper.can_manage_namespace?(namespace)).to be false
-    end
-
-    it "returns false if current user is a contributor of the namespace" do
-      sign_in contributor
-      expect(helper.can_manage_namespace?(namespace)).to be false
-    end
-
-    it "returns true if current user is an admin even when he is not related with the namespace" do
-      sign_in admin
-      expect(helper.can_manage_namespace?(namespace)).to be true
-    end
-  end
-
   describe "#user_image_tag" do
     # Mocking the gravatar_image_tag
     def gravatar_image_tag(email)

--- a/spec/helpers/namespaces_helper_spec.rb
+++ b/spec/helpers/namespaces_helper_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe NamespacesHelper, type: :helper do
+  let(:registry)    { create(:registry) }
+  let(:admin)       { create(:admin) }
+  let(:owner)       { create(:user) }
+  let(:viewer)      { create(:user) }
+  let(:contributor) { create(:user) }
+  let(:team) do
+    create(:team,
+           owners:       [owner],
+           contributors: [contributor],
+           viewers:      [viewer])
+  end
+  let(:namespace) { create(:namespace, team: team) }
+
+  describe "can_manage_namespace?" do
+    it "returns true if current user is an owner of the namespace" do
+      sign_in owner
+      expect(helper.can_manage_namespace?(namespace)).to be true
+    end
+
+    it "returns false if current user is a viewer of the namespace" do
+      sign_in viewer
+      expect(helper.can_manage_namespace?(namespace)).to be false
+    end
+
+    it "returns false if current user is a contributor of the namespace" do
+      sign_in contributor
+      expect(helper.can_manage_namespace?(namespace)).to be false
+    end
+
+    it "returns true if current user is an admin even when he is not related with the namespace" do
+      sign_in admin
+      expect(helper.can_manage_namespace?(namespace)).to be true
+    end
+  end
+end

--- a/spec/helpers/teams_helper_spec.rb
+++ b/spec/helpers/teams_helper_spec.rb
@@ -46,4 +46,38 @@ RSpec.describe TeamsHelper, type: :helper do
       expect(helper.role_within_team(team)).to eq "-"
     end
   end
+
+  describe "team_scope_icon" do
+    it "renders with the proper icon for a team with one member" do
+      personal_team = create(:team, owners: [owner])
+      expect(helper.team_scope_icon(personal_team)).to eq(
+        '<i class="fa fa-user fa-lg" title="Personal"></i>')
+    end
+
+    it "renders with the proper icon for a team with multiple members" do
+      expect(helper.team_scope_icon(team)).to eq(
+        '<i class="fa fa-users fa-lg" title="Team"></i>')
+    end
+  end
+
+  describe "team_user_role_icon" do
+    before(:each) do
+      team
+    end
+
+    it "renders with the proper icon for owner" do
+      expect(helper.team_user_role_icon(owner.team_users.first)).to eq(
+        '<i class="fa fa-key fa-lg" title="Owner"></i>')
+    end
+
+    it "renders with the proper icon for contributor" do
+      expect(helper.team_user_role_icon(contributor.team_users.first)).to eq(
+        '<i class="fa fa-exchange fa-lg" title="Contributor"></i>')
+    end
+
+    it "renders with the proper icon for viewer" do
+      expect(helper.team_user_role_icon(viewer.team_users.first)).to eq(
+        '<i class="fa fa-eye fa-lg" title="Viewer"></i>')
+    end
+  end
 end


### PR DESCRIPTION
Closes #36

Additionally, I fixed the deprecation that RuboCop was complaining about. 

Many of the icons are debatable, but I felt these fit the bill pretty well.

### Screenshots

![portus_1](https://cloud.githubusercontent.com/assets/1928691/10272123/1b3d1c8e-6ad8-11e5-992a-54b9d2d43c10.png)
![portus_2](https://cloud.githubusercontent.com/assets/1928691/10272124/1b3da550-6ad8-11e5-87b2-aa57cdd729f1.png)
![portus_3](https://cloud.githubusercontent.com/assets/1928691/10272125/1b3e5f36-6ad8-11e5-9af6-fb3d90447d80.png)

Signed-off-by: Bryce Reitano <bryce@rocketmade.com>