### PR TITLE
Fix search placeholder color.

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,6 +5,7 @@
 @import 'bootstrap/variables';
 @import 'lifeitup/variables';
 @import 'variables';
+@import 'mixins';
 @import 'bootstrap';
 @import 'lifeitup/lifeitup';
 

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -36,13 +36,7 @@ header {
         border-bottom: 1px solid $white;
         border-right: 0px solid $white;
         color: $white;
-
-      }
-      ::-webkit-input-placeholder,
-      :-moz-placeholder,
-      ::-moz-placeholder,
-      :-ms-input-placeholder {
-        color: $white;
+        @include input-placeholder($white);
       }
       button[type="submit"] {
         border-radius: 0 4px 4px 0;

--- a/app/assets/stylesheets/mixins.scss
+++ b/app/assets/stylesheets/mixins.scss
@@ -1,0 +1,15 @@
+// Mixin for overriding input placeholder.
+@mixin input-placeholder($color) {
+  &::-webkit-input-placeholder {
+    color: $color;
+  }
+  &:-moz-placeholder { /* Firefox 18- */
+    color: $color;
+  }
+  &::-moz-placeholder { /* Firefox 19+ */
+    color: $color;
+  }
+  &:-ms-input-placeholder {
+    color: $color;
+  }
+}


### PR DESCRIPTION
Closes #119

- Fixes the search placeholder while providing a mixin for future cases.
- Explicitly stating that opacity of the button to be 1. Before it was dimmed out when disabled, creating a strange style.
- Removing the outline and box-shadow to clean it up a bit.

### Screenshots
![portus](https://cloud.githubusercontent.com/assets/1928691/10272865/9782da80-6ae3-11e5-88b0-b40f96e3a156.png)


Signed-off-by: Bryce Reitano <bryce@rocketmade.com>