### PR TITLE
config: allow developers to override some secrets

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -12,8 +12,16 @@
 
 development:
   secret_key_base: 8bc8ccc710eafd73d43cd59ac8881aadc89f7a6ab55f1ac11c97fb436a3931cc78c38e735e664958d9e793725f3d52178f4e2c376c346edbaca3936aebf66e27
+  <% if ENV["PORTUS_KEY_PATH"] %>
+  encryption_private_key_path: <%= ENV["PORTUS_KEY_PATH"] %>
+  <% else %>
   encryption_private_key_path: 'vagrant/conf/ca_bundle/server.key'
+  <% end %>
+  <% if ENV["PORTUS_MACHINE_FQDN"] %>
+  machine_fqdn: <%= ENV["PORTUS_MACHINE_FQDN"] %>
+  <% else %>
   machine_fqdn: 'portus.test.lan'
+  <% end %>
   portus_password: 'portus1234'
 
 test:


### PR DESCRIPTION
This is specially useful when testing setups with SSL.

Signed-off-by: Miquel Sabaté <msabate@suse.com>