### PR TITLE
Don't create an activity for a pushed image if the tag already exists

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -51,14 +51,16 @@ class Repository < ActiveRecord::Base
     actor = User.find_from_event(event)
     return if actor.nil?
 
-    # Get or create the repository as "namespace/repo"
+    # Get or create the repository as "namespace/repo". If both the repo and
+    # the given tag already exists, return early.
     repository = Repository.find_by(namespace: namespace, name: repo)
     if repository.nil?
       repository = Repository.create(namespace: namespace, name: repo)
+    elsif repository.tags.exists?(name: tag)
+      return
     end
 
-    tag = repository.tags.where(name: tag)
-      .first_or_create(name: tag, author: actor)
+    tag = repository.tags.create(name: tag, author: actor)
     repository.create_activity(:push, owner: actor, recipient: tag)
     repository
   end

--- a/app/models/team_user.rb
+++ b/app/models/team_user.rb
@@ -7,7 +7,7 @@
 class TeamUser < ActiveRecord::Base
   enum role: [:viewer, :contributor, :owner]
 
-  scope :enabled, -> { joins(:user).where("users.enabled" => true) }
+  scope :enabled, -> { joins(:user).where("users.enabled" => true).distinct }
 
   validates :team, presence: true
   validates :user, presence: true, uniqueness: { scope: :team }

--- a/app/policies/public_activity/activity_policy.rb
+++ b/app/policies/public_activity/activity_policy.rb
@@ -36,7 +36,7 @@ class PublicActivity::ActivityPolicy
                "(team_users.user_id = ? OR namespaces.public = ?)",
                "Repository", user.id, true)
 
-      team_activities.union_all(namespace_activities).union_all(repository_activities)
+      team_activities.union_all(namespace_activities).union_all(repository_activities).distinct
     end
   end
 end

--- a/app/policies/repository_policy.rb
+++ b/app/policies/repository_policy.rb
@@ -13,6 +13,7 @@ class RepositoryPolicy
         .where("namespaces.public = :namespace_public OR " \
                "users.id = :user_id",
                namespace_public: true, user_id: @user.id)
+        .distinct
     end
   end
 end

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -41,6 +41,22 @@ describe Repository do
     let(:registry) { create(:registry, hostname: "registry.test.lan") }
     let(:user) { create(:user) }
 
+    context "adding an existing repo/tag" do
+      it "does not add a new activity when an already existing repo/tag already existed" do
+        event = { "actor" => { "name" => user.username } }
+
+        # First we create it, and make sure that it creates the activity.
+        expect do
+          Repository.add_repo(event, registry.global_namespace, repository_name, tag_name)
+        end.to change(PublicActivity::Activity, :count).by(1)
+
+        # And now it shouldn't create more activities.
+        expect do
+          Repository.add_repo(event, registry.global_namespace, repository_name, tag_name)
+        end.to change(PublicActivity::Activity, :count).by(0)
+      end
+    end
+
     context "event does not match regexp of manifest" do
       let(:event) do
         e = build(:raw_push_manifest_event).to_test_hash


### PR DESCRIPTION
I've also fixed a weird situation in which different elements from the
dashboard were repeated twice. I've fixed this by specifying a `distinct`.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>