### PR TITLE
lib/portus: require "net/http"

### DIFF
--- a/lib/portus/http_helpers.rb
+++ b/lib/portus/http_helpers.rb
@@ -1,3 +1,5 @@
+require "net/http"
+
 module Portus
   # Implements all the methods and classes that are needed by the RegistryClient.
   # This separation has been done because this module deals with HTTP helpers and


### PR DESCRIPTION
Apparently some users require this in order to make crono work.

Fixes #395

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>