### PR TITLE
lib/portus: added a safer way to parse JSON requests/responses

### DIFF
--- a/app/controllers/api/v2/events_controller.rb
+++ b/app/controllers/api/v2/events_controller.rb
@@ -2,8 +2,8 @@
 class Api::V2::EventsController < Api::BaseController
   # A new notification is coming, register it if valid.
   def create
-    body = JSON.parse(request.body.read)
-    Portus::RegistryNotification.process!(body, Repository)
+    body = Portus::JSON.parse(request)
+    Portus::RegistryNotification.process!(body, Repository) unless body.nil?
     head status: :accepted
   end
 end

--- a/lib/portus/http_helpers.rb
+++ b/lib/portus/http_helpers.rb
@@ -63,13 +63,13 @@ module Portus
 
       # Add the errors as given by the registry.
       begin
-        body = JSON.parse(response.body)
+        body = ::JSON.parse(response.body)
         if body["errors"]
           str += "Reported by Registry:\n"
           body["errors"].each { |err| str += "#{err}\n" }
           str += "\n"
         end
-      rescue JSON::ParserError
+      rescue ::JSON::ParserError
         str += "Body:\n#{response.body}\n\n"
       end
 
@@ -102,7 +102,8 @@ module Portus
 
       res = get_response_token(uri, req)
       if res.code.to_i == 200
-        @token = JSON.parse(res.body)["token"]
+        # This JSON call is guaranteed to be safe.
+        @token = ::JSON.parse(res.body)["token"]
       else
         @token = nil
         raise AuthorizationError, "Cannot obtain authorization token: #{res}"

--- a/lib/portus/json.rb
+++ b/lib/portus/json.rb
@@ -1,0 +1,32 @@
+module Portus
+  # A safe version of the ::JSON class. This class catches exceptions and logs
+  # them properly. This class assumes that the given object is a
+  # request/response.
+  class JSON
+    # Parses the body of the given request/response. Any exception is catched
+    # by this application and it's properly logged.
+    #
+    # Returns the given parsed JSON object on success, nil otherwise.
+    def self.parse(obj)
+      # Depending on whether this is a request or a response, the body will be
+      # a string or an object that responds to :read.
+      body = obj.body.is_a?(String) ? obj.body : obj.body.read
+      ::JSON.parse(body)
+    rescue ::JSON::ParserError => e
+      Rails.logger.warn "JSON: parser error!"
+      ::Portus::JSON.detailed_error(obj, body, e)
+    rescue => e
+      Rails.logger.warn "JSON: Something went wrong!"
+      ::Portus::JSON.detailed_error(obj, body, e)
+    end
+
+    # Logs detailed information about what went wrong with the parsing of the
+    # given JSON code.
+    def self.detailed_error(obj, body, e)
+      Rails.logger.warn "The following exception has been raised: #{e.message}"
+      Rails.logger.warn "HTTP Code: #{obj.code}" if obj.respond_to? :code
+      Rails.logger.warn "Body:\n#{body}\n"
+      nil
+    end
+  end
+end

--- a/lib/portus/registry_client.rb
+++ b/lib/portus/registry_client.rb
@@ -22,7 +22,7 @@ module Portus
     def manifest(repository, tag = "latest")
       res = perform_request("#{repository}/manifests/#{tag}")
       if res.code.to_i == 200
-        JSON.parse(res.body)
+        ::Portus::JSON.parse(res)
       elsif res.code.to_i == 404
         handle_error res, repository: repository, tag: tag
       else
@@ -41,8 +41,8 @@ module Portus
     def catalog
       res = perform_request("_catalog")
       if res.code.to_i == 200
-        catalog = JSON.parse(res.body)
-        add_tags(catalog["repositories"])
+        catalog = ::Portus::JSON.parse(res)
+        add_tags(catalog["repositories"]) unless catalog.nil?
       elsif res.code.to_i == 404
         handle_error res
       else
@@ -79,7 +79,8 @@ module Portus
       repositories.each do |repo|
         res = perform_request("#{repo}/tags/list")
         return [] if res.code.to_i != 200
-        result << JSON.parse(res.body)
+        res = ::Portus::JSON.parse(res)
+        result << res unless res.nil?
       end
       result
     end

--- a/spec/lib/portus/json_spec.rb
+++ b/spec/lib/portus/json_spec.rb
@@ -1,0 +1,41 @@
+class MockBody
+  def initialize(contents)
+    @contents = contents
+  end
+
+  def read
+    @contents
+  end
+end
+
+class MockResponse
+  def initialize(should_fail)
+    @should_fail = should_fail
+  end
+
+  def body
+    MockBody.new(@should_fail ? "<" : "{}")
+  end
+
+  def code
+    9001 # It's over 9000!!
+  end
+end
+
+describe Portus::JSON do
+  it "returns a proper object on success" do
+    res = Portus::JSON.parse(MockResponse.new(false))
+    expect(res).to_not be_nil
+    expect(res).to be_empty
+  end
+
+  it "returns nil on error" do
+    expect(Rails.logger).to receive(:warn).with(/JSON: parser error!/)
+    expect(Rails.logger).to receive(:warn).with(/A JSON text must at least contain two octets/)
+    expect(Rails.logger).to receive(:warn).with(/HTTP Code: 9001/)
+    expect(Rails.logger).to receive(:warn).with(/Body/)
+
+    res = Portus::JSON.parse(MockResponse.new(true))
+    expect(res).to be_nil
+  end
+end


### PR DESCRIPTION
The Portus::JSON class has been added to the library. This class provides a
safer way to handle the contents of JSON requests/responses:

1. If an exception is raised, `self.parse` will catch it and return nil.
2. On error, a verbose message will be logged.

Note that this message will be logged in the :warn level, therefore even the
production log will notice any kind of error related to JSON
requests/responses. Any instances of JSON.parse worth changing have been
changed.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>