### PR TITLE
tokens: log errors from the tokens_controller into the :info level

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -13,7 +13,9 @@ class Api::BaseController < ActionController::Base
 
   protected
 
-  def deny_access
+  # It logs the exception message and sends a 401.
+  def deny_access(exception)
+    logger.info "Denied access on these grounds: #{exception.message}"
     head :unauthorized
   end
 end

--- a/app/models/namespace/auth_scope.rb
+++ b/app/models/namespace/auth_scope.rb
@@ -9,10 +9,8 @@ class Namespace::AuthScope < Portus::AuthScope
       found_resource = @registry.namespaces.find_by(name: @namespace_name)
     end
 
-    if found_resource.nil?
-      Rails.logger.warn "Cannot find namespace with name #{@namespace_name}"
-      raise ResourceNotFound
-    end
+    raise ResourceNotFound, "Cannot find namespace #{@namespace_name}" if found_resource.nil?
+
     found_resource
   end
 

--- a/app/models/registry/auth_scope.rb
+++ b/app/models/registry/auth_scope.rb
@@ -3,10 +3,7 @@
 class Registry::AuthScope < Portus::AuthScope
   def resource
     reg = Registry.find_by(hostname: @registry.hostname)
-    if reg.nil?
-      Rails.logger.warn "Could not find registry #{@registry.hostname}"
-      raise ResourceNotFound
-    end
+    raise ResourceNotFound, "Could not find registry #{@registry.hostname}" if reg.nil?
     reg
   end
 


### PR DESCRIPTION
This way we can get more info about what has failed when requesting the JWT
token in production. I've reviewed all the other logged messages, and they all
seem to have the proper log level.

Note that another sensitive part is when Portus tries to fetch the manifest
after a web event has occurred. This is already handled properly by the
`Registry#get_tag_from_manifest` method.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>