### PR TITLE
Added support for general LDAP uid attribute.

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -39,6 +39,9 @@ ldap:
   # The base where users are located (e.g. "ou=users,dc=example,dc=com").
   base: ""
 
+  # The LDAP attribute where to search for username. The default is 'uid'.
+  uid: "uid"
+
   # Portus needs an email for each user, but there's no standard way to get
   # that from LDAP servers. You can tell Portus how to get the email from users
   # registered in the LDAP server with this configurable value. There are three

--- a/lib/portus/ldap.rb
+++ b/lib/portus/ldap.rb
@@ -94,7 +94,8 @@ module Portus
     # server.
     def search_options
       {}.tap do |opts|
-        opts[:filter] = "(uid=#{username})"
+        uid = APP_CONFIG["ldap"]["uid"]
+        opts[:filter] = "(#{uid}=#{username})"
         opts[:base]   = APP_CONFIG["ldap"]["base"] unless APP_CONFIG["ldap"]["base"].empty?
       end
     end

--- a/spec/lib/portus/ldap_spec.rb
+++ b/spec/lib/portus/ldap_spec.rb
@@ -100,7 +100,8 @@ describe Portus::LDAP do
       "enabled"  => true,
       "hostname" => "hostname",
       "port"     => 389,
-      "base"     => "ou=users,dc=example,dc=com"
+      "base"     => "ou=users,dc=example,dc=com",
+      "uid"      => "uid"
     }
   end
 
@@ -159,7 +160,7 @@ describe Portus::LDAP do
   end
 
   it "fetches the right bind options" do
-    APP_CONFIG["ldap"] = { "enabled" => true, "base" => "" }
+    APP_CONFIG["ldap"] = { "enabled" => true, "base" => "", "uid" => "uid" }
     lm = LdapMock.new(username: "name", password: "1234")
     opts = lm.bind_options_test
     expect(opts.size).to eq 2
@@ -172,6 +173,11 @@ describe Portus::LDAP do
     expect(opts[:filter]).to eq "(uid=name)"
     expect(opts[:password]).to eq "1234"
     expect(opts[:base]).to eq "ou=users,dc=example,dc=com"
+
+    APP_CONFIG["ldap"] = { "enabled" => true, "base" => "", "uid" => "foo" }
+    lm = LdapMock.new(username: "name", password: "12341234")
+    opts = lm.bind_options_test
+    expect(opts[:filter]).to eq "(foo=name)"
   end
 
   describe "#find_or_create_user!" do


### PR DESCRIPTION
I added support for general LDAP uid attribute since this is necessary in some cases. I tried to follow [Gitlab LDAP configuration](https://gitlab.com/gitlab-org/gitlab-ce/blob/master/config/gitlab.yml.example).

Note: This is my first code in ruby so feel free to criticize.

Signed-off-by: Tomas Dohnalek <dohnto@gmail.com>