### PR TITLE
docker-compose: switch to Puma

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ unless ENV["PACKAGING"] && ENV["PACKAGING"] == "yes"
   group :development, :test do
     gem "byebug"
     gem "web-console", "~> 2.1.3"
-    gem "thin"
+    gem "puma"
     gem "awesome_print"
     gem "hirb"
     gem "wirb"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,6 @@ GEM
     crono (0.9.0)
       activerecord (~> 4.0)
       activesupport (~> 4.0)
-    daemons (1.2.2)
     database_cleaner (1.4.1)
     debug_inspector (0.0.2)
     devise (3.5.1)
@@ -95,7 +94,6 @@ GEM
     diff-lcs (1.2.5)
     docile (1.1.5)
     erubis (2.7.0)
-    eventmachine (1.0.7)
     execjs (2.6.0)
     factory_girl (4.5.0)
       activesupport (>= 3.0.0)
@@ -173,6 +171,7 @@ GEM
       activerecord (>= 3.0)
       i18n (>= 0.5.0)
       railties (>= 3.0.0)
+    puma (2.14.0)
     pundit (1.0.1)
       activesupport (>= 3.0.0)
     quiet_assets (1.1.0)
@@ -272,10 +271,6 @@ GEM
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
     temple (0.7.6)
-    thin (1.6.3)
-      daemons (~> 1.0, >= 1.0.9)
-      eventmachine (~> 1.0)
-      rack (~> 1.0)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (1.4.1)
@@ -342,6 +337,7 @@ DEPENDENCIES
   poltergeist
   pry-rails
   public_activity
+  puma
   pundit
   quiet_assets
   rack-mini-profiler
@@ -354,7 +350,6 @@ DEPENDENCIES
   simplecov
   slim
   sprockets (~> 2.12.3)
-  thin
   thor
   timecop
   turbolinks
@@ -364,3 +359,6 @@ DEPENDENCIES
   webmock
   wirb
   wirble
+
+BUNDLED WITH
+   1.10.4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,6 @@ web:
     - .:/portus
   links:
     - db
-  command: thin start
 
 db:
   image: mariadb

--- a/docker/compose-common.yml
+++ b/docker/compose-common.yml
@@ -1,6 +1,6 @@
 web:
   build: ..
-  command: thin start
+  command: puma -b tcp://0.0.0.0:3000 -w 3
   ports:
     - "3000:3000"
 registry:


### PR DESCRIPTION
Switch from thin to Puma. This is going to fix issues caused by thin
being stuck processing slow requests.

Fixes issue #423 and issue #376.

See this comment for more details:
https://github.com/SUSE/Portus/issues/376#issuecomment-146348415

Signed-off-by: Flavio Castelli <fcastelli@suse.com>