### PR TITLE
portusctl: fix permissions of Rails' logs

### DIFF
--- a/packaging/suse/portusctl/lib/configurator.rb
+++ b/packaging/suse/portusctl/lib/configurator.rb
@@ -164,6 +164,11 @@ EOM
       return
     end
 
+    # portusctl runs as root and creates this file for the 1st time, so
+    # we must fix its permissions
+    FileUtils.chown_R("root", "www", "/srv/Portus/log/production.log")
+    FileUtils.chmod_R(0664, "/srv/Portus/log/production.log")
+
     services = [
       ["portus_crono", false],
       ["apache2", true]


### PR DESCRIPTION
portusctl runs as root user when there's no log/production.log. That
causes the production.log to be created by the root user and owned by
the root group. That makes impossible for passenger to write messages
to it.

This fixes issue #409

Signed-off-by: Flavio Castelli <fcastelli@suse.com>