### PR TITLE
Use the Namespace#clean_name when displaying the name of a namespace always

### DIFF
--- a/app/views/namespaces/show.html.slim
+++ b/app/views/namespaces/show.html.slim
@@ -8,7 +8,7 @@
           i.fa.fa-pencil.fa-lg
     h5
       strong
-        '#{@namespace.name}
+        '#{@namespace.clean_name}
       ' namespace
       small
         a[data-placement="right"


### PR DESCRIPTION
Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>