### PR TITLE
Ignore the `bin/portus` script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /config/config-local.yml
 docker/environment
 docker/registry/config.yml
+/bin/portus


### PR DESCRIPTION
Allow developers to write the `bin/portus` script as a way to setup Portus with
an alternative configuration.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>