### PR TITLE
Make sure that the registry is reachable when creating it

### DIFF
--- a/app/models/registry.rb
+++ b/app/models/registry.rb
@@ -60,6 +60,41 @@ class Registry < ActiveRecord::Base
     [namespace, repo, tag_name]
   end
 
+  # Checks whether this registry is reachable. If it is, then an empty string
+  # is returned. Otherwise a string will be returned containing the reasoning
+  # of the reachability failure.
+  def reachable?
+    msg = ""
+
+    begin
+      r = client.reachable?
+
+      # At this point, !r is only possible if the returned code is 404, which
+      # according to the documentation we have to assume that the registry is
+      # not implementing the v2 of the API.
+      return "Error: registry does not implement v2 of the API." unless r
+    rescue Errno::ECONNREFUSED, SocketError
+      msg = "Error: connection refused. The given registry is not available!"
+    rescue Net::HTTPBadResponse
+      if use_ssl
+        msg = "Error: there's something wrong with your SSL configuration."
+      else
+        msg = "Error: not using SSL, but the given registry does use SSL."
+      end
+    rescue OpenSSL::SSL::SSLError
+      if use_ssl
+        msg = "Error: using SSL, but the given registry is not using SSL."
+      else
+        msg = "Error: there's something wrong with your SSL configuration."
+      end
+    rescue StandardError => e
+      # We don't know what went wrong :/
+      logger.info "Registry not reachable: #{e.message}"
+      msg = "Error: something went wrong. Check your configuration."
+    end
+    msg
+  end
+
   protected
 
   # Fetch the tag of the image contained in the current event. The Manifest API

--- a/app/views/admin/registries/new.html.slim
+++ b/app/views/admin/registries/new.html.slim
@@ -20,15 +20,29 @@ br
   .form-group
     = f.label :name, {class: 'control-label col-md-2'}
     .col-md-7
-      = f.text_field(:name, class: 'form-control', required: true, autofocus: true)
+      - if params[:name]
+        = f.text_field(:name, class: 'form-control', value: params[:name], required: true, autofocus: true)
+      - else
+        = f.text_field(:name, class: 'form-control', required: true, autofocus: true)
   .form-group
     = f.label :hostname, {class: 'control-label col-md-2'}
     .col-md-7
-      = f.text_field(:hostname, class: 'form-control', placeholder: 'registry.test.lan:5000', required: true)
+      - if params[:hostname]
+        = f.text_field(:hostname, class: 'form-control', value: params[:hostname], placeholder: 'registry.test.lan:5000', required: true)
+      - else
+        = f.text_field(:hostname, class: 'form-control', placeholder: 'registry.test.lan:5000', required: true)
   .form-group
     = f.label :use_ssl, "Use SSL", {class: 'control-label col-md-2', title: 'Set this to enable SSL in the communication between Portus and the Registry'}
     .col-md-7
-      = f.check_box(:use_ssl)
+      - if params[:use_ssl] == "true"
+        = f.check_box(:use_ssl, checked: true)
+      - else
+        = f.check_box(:use_ssl)
+  - unless flash[:alert].nil? || flash[:alert].empty?
+    .form-group.has-error
+      = label_tag :force, "Skip remote checks", {class: 'control-label col-md-2', title: "Force the creation of the registry, even if it's not reachable."}
+      .col-md-7
+        = check_box_tag(:force)
   .form-group
     .col-md-offset-2.col-md-7
       .btn-toolbar

--- a/bin/client.rb
+++ b/bin/client.rb
@@ -9,7 +9,7 @@
 #   - manifest <name>[:<tag>]
 
 registry = Registry.first
-if registry.nil?
+if registry.nil? && ARGV.first != "ping"
   puts "No registry has been configured!"
   exit 1
 end
@@ -35,6 +35,28 @@ when "manifest"
     name, tag = ARGV[1], "latest"
   end
   pp registry.client.manifest(name, tag)
+when "ping"
+  # No registry was found, trying to ping another one.
+  if registry.nil?
+    if ARGV.size == 2
+      use_ssl = false
+      puts "Beware: use_ssl omitted, assuming false."
+    elsif ARGV.size == 3
+      use_ssl = ARGV.last == "use_ssl"
+      puts "Beware: use \"use_ssl\", assuming false." unless use_ssl
+    else
+      puts "Usage: rails runner ping hostname:port [use_ssl]"
+      exit 1
+    end
+
+    registry = Registry.new(hostname: ARGV[1], use_ssl: use_ssl)
+  end
+
+  if registry.client.reachable?
+    puts "Registry reachable"
+  else
+    puts "Error: cannot reach the registry"
+  end
 else
   puts "Valid commands: catalog, delete, manifest."
   exit 1

--- a/lib/portus/registry_client.rb
+++ b/lib/portus/registry_client.rb
@@ -16,6 +16,18 @@ module Portus
       @password = password || Rails.application.secrets.portus_password
     end
 
+    # Returns whether the registry is reachable with the given credentials or
+    # not.
+    def reachable?
+      res = perform_request("", "get", false)
+
+      # If a 401 was retrieved, it means that at least the registry has been
+      # contacted. In order to get a 200, this registry should be created and
+      # an authorization requested. The former can be inconvenient, because we
+      # might want to test whether the registry is reachable.
+      !res.nil? && res.code.to_i == 401
+    end
+
     # Retrieves the manifest for the required repository:tag. If everything goes
     # well, it will return a parsed response from the registry, otherwise it will
     # raise either ManifestNotFoundError or a RuntimeError.

--- a/spec/controllers/admin/registries_controller_spec.rb
+++ b/spec/controllers/admin/registries_controller_spec.rb
@@ -27,17 +27,26 @@ RSpec.describe Admin::RegistriesController, type: :controller do
   end
 
   describe "POST #create" do
+    context "not using the Force" do
+      it "redirects when there's something wrong with the reachability of the registry" do
+        expect do
+          post :create, registry: attributes_for(:registry)
+        end.to change(Registry, :count).by(0)
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+
     context "no registry" do
       it "creates a new registry" do
         expect do
-          post :create, registry: attributes_for(:registry)
+          post :create, registry: attributes_for(:registry), force: true
         end.to change(Registry, :count).by(1)
       end
 
       it "assigns the freshly created registry to all the existing namespaces" do
         3.times { create(:team) }
 
-        post :create, registry: attributes_for(:registry)
+        post :create, registry: attributes_for(:registry), force: true
         registry = Registry.last
 
         Namespace.all.each { |n| expect(n.registry).to eq(registry) }
@@ -49,7 +58,7 @@ RSpec.describe Admin::RegistriesController, type: :controller do
         create(:registry)
 
         expect do
-          post :create, registry: attributes_for(:registry)
+          post :create, registry: attributes_for(:registry), force: true
         end.to raise_error(ActionController::RoutingError)
       end
     end
@@ -57,7 +66,7 @@ RSpec.describe Admin::RegistriesController, type: :controller do
     context "wrong params" do
       it "redirects to the new page" do
         expect do
-          post :create, registry: { name: "foo" }
+          post :create, registry: { name: "foo" }, force: true
         end.to change(Registry, :count).by(0)
       end
     end

--- a/spec/features/admin/registries_spec.rb
+++ b/spec/features/admin/registries_spec.rb
@@ -14,6 +14,31 @@ feature "Admin - Registries panel" do
     end
   end
 
+  describe "create" do
+    it "shows an alert on error, and you can force it afterwards", js: true do
+      visit new_admin_registry_path
+      expect(page).to_not have_content("Skip remote checks")
+      fill_in "registry_name", with: "registry"
+      fill_in "registry_hostname", with: "url_not_known:1234"
+      click_button "Create"
+
+      expect(page).to have_content("Skip remote checks")
+      expect(page).to have_content("something went wrong")
+      expect(Registry.any?).to be_falsey
+
+      # Use the force, Luke.
+
+      fill_in "registry_name", with: "registry"
+      fill_in "registry_hostname", with: "url_not_known:1234"
+      check "force"
+      click_button "Create"
+
+      expect(current_path).to eq admin_registries_path
+      expect(page).to have_content("Registry was successfully created.")
+      expect(Registry.any?).to be_truthy
+    end
+  end
+
   describe "update" do
     let!(:registry) { create(:registry) }
 


### PR DESCRIPTION
When creating a new registry, Portus will now check whether it's reachable or
not. If it is, it will continue as usual. However, if it's not reachable, then
Portus will redirect to the registries#new page and alert the user with some
useful message. When this redirect happens, the user will have available an
extra checkbox called "Force". If the user checks it, then it's telling to
Portus to force the creation of the registry, even if it's not reachable.

Fixes #408

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>