### PR TITLE
Add namespace "library" for official images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rails:4.2.2
+FROM library/rails:4.2.2
 MAINTAINER Flavio Castelli <fcastelli@suse.com>
 
 RUN mkdir /portus

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ crono:
     - db
 
 db:
-  image: mariadb
+  image: library/mariadb
   environment:
     MYSQL_ROOT_PASSWORD: portus
 

--- a/docker/compose-common.yml
+++ b/docker/compose-common.yml
@@ -4,6 +4,6 @@ web:
   ports:
     - "3000:3000"
 registry:
-  image: registry:2.1.1
+  image: library/registry:2.1.1
   ports:
     - "5000:5000"


### PR DESCRIPTION
User may use third-party mirror instead of docker.io. And those
mirrors may not support library as their default for none namespace.

Signed-off-by: depay <depay19@163.com>