### PR TITLE
Added LDAP authentication support.

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -42,6 +42,12 @@ ldap:
   # The LDAP attribute where to search for username. The default is 'uid'.
   uid: "uid"
 
+  # LDAP credentials used to search for a user.
+  authentication:
+    enabled: false
+    bind_dn: ""
+    password: ""
+
   # Portus needs an email for each user, but there's no standard way to get
   # that from LDAP servers. You can tell Portus how to get the email from users
   # registered in the LDAP server with this configurable value. There are three


### PR DESCRIPTION
I tried to add an authentication subsection in LDAP section to configuration and utilized this in LDAP authentication. This addresses issue #378.

I know that rubocop is failing due to too long class (is this really hard constraint? 140 lines is not really that much :) ) and some alignment in hash, which I am unable to find out what is the proper way of dealing with this. Also I think, that the testsuite is missing some tests, so maybe you can suggest which ones.

Signed-off-by: Tomas Dohnalek <dohnto@gmail.com>