### PR TITLE
namespaces: add a space after the "Belongs to: " string

### DIFF
--- a/app/views/namespaces/show.html.slim
+++ b/app/views/namespaces/show.html.slim
@@ -46,7 +46,7 @@
         = @namespace.clean_name
     h6.label.label-info
       | Belongs to:
-      = @namespace.team.name
+      = " #{@namespace.team.name}"
   .panel-body
     .table-responsive
       table.table.table-stripped.table-hover


### PR DESCRIPTION
Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>