### PR TITLE
registries: remove the "Back" button from the #new page

### DIFF
--- a/app/views/admin/registries/new.html.slim
+++ b/app/views/admin/registries/new.html.slim
@@ -47,7 +47,5 @@
             = check_box_tag(:force)
       .form-group
         .col-md-offset-2.col-md-7
-          .btn-toolbar
-            = link_to "Back", admin_registries_path, class: 'btn btn-default'
-            = f.submit('Create', class: 'btn btn-primary')
+          = f.submit('Create', class: 'btn btn-primary')
 


### PR DESCRIPTION
Since we now redirect the admins to the new_admin_registry_path when no
registry has been created yet, this button does no longer make sense.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>