### PR TITLE
Add check for array of email in LDAP

### DIFF
--- a/lib/portus/ldap.rb
+++ b/lib/portus/ldap.rb
@@ -203,7 +203,11 @@ module Portus
       if cfg["attr"].empty?
         guess_from_dn(record["dn"])
       else
-        record[cfg["attr"]] || ""
+        email = record[cfg["attr"]] || ""
+
+        # Handle a LDAP record that has more than one entry.
+        email.is_a?(Array) ? email.first : email
+
       end
     end
 

--- a/spec/lib/portus/ldap_spec.rb
+++ b/spec/lib/portus/ldap_spec.rb
@@ -332,6 +332,15 @@ describe Portus::LDAP do
       ]
     end
 
+    let(:multiple_emails) do
+      [
+        {
+          "dn"    => ["ou=users,dc=example,dc=com"],
+          "email" => ["user1@example.com", "user2@example.com"]
+        }
+      ]
+    end
+
     it "returns an empty email if disabled" do
       ge = { "enabled" => false, "attr" => "" }
       APP_CONFIG["ldap"] = { "enabled" => true, "base" => "", "guess_email" => ge }
@@ -386,6 +395,14 @@ describe Portus::LDAP do
 
       lm = LdapMock.new(username: "name", password: "12341234")
       expect(lm.guess_email_test(valid_response)).to eq "user@example.com"
+    end
+
+    it "returns a the first vaild email if the given attr has a list" do
+      ge = { "enabled" => true, "attr" => "email" }
+      APP_CONFIG["ldap"] = { "enabled" => true, "base" => "", "guess_email" => ge }
+
+      lm = LdapMock.new(username: "name", password: "12341234")
+      expect(lm.guess_email_test(multiple_emails)).to eq "user1@example.com"
     end
   end
 end


### PR DESCRIPTION
This update handles when the defined LDAP attr has an array of emails not just a single string.