### PR TITLE
Allowed controlled anonymous access with public namespaces

### DIFF
--- a/app/views/namespaces/_namespace.html.slim
+++ b/app/views/namespaces/_namespace.html.slim
@@ -9,6 +9,11 @@ tr id="namespace_#{namespace.id}"
           rel="nofollow"
           href=url_for(toggle_public_namespace_path(namespace))
           ]
-          i.fa.fa-lg class="fa-toggle-#{namespace.public? ? 'on': 'off'}"
+          - if namespace.public?
+            i.fa.fa-lg class="fa-toggle-on"
+          - else
+            i.fa.fa-lg class="fa-toggle-off" title="Click so anyone can pull from this namespace"
+    - elsif namespace.public?
+      i.fa.fa-lg class="fa-toggle-on" title="Anyone can pull images from this namespace"
     - else
-      i.fa.fa-lg class="fa-toggle-#{namespace.public? ? 'on': 'off'}"
+      i.fa.fa-lg class="fa-toggle-off"

--- a/app/views/namespaces/toggle_public.js.erb
+++ b/app/views/namespaces/toggle_public.js.erb
@@ -1,5 +1,14 @@
-$('#namespace_<%= namespace.id %> td a i').addClass("fa-toggle-<%= namespace.public? ? 'on' : 'off' %>");
-$('#namespace_<%= namespace.id %> td a i').removeClass("fa-toggle-<%= namespace.public? ? 'off' : 'on' %>");
+var ns = $('#namespace_<%= namespace.id %> td a i');
+
+<% if namespace.public? %>
+  ns.removeAttr("title");
+  ns.addClass("fa-toggle-on");
+  ns.removeClass("fa-toggle-off");
+<% else %>
+  ns.prop("title", "Click so anyone can pull from this namespace");
+  ns.addClass("fa-toggle-off");
+  ns.removeClass("fa-toggle-on");
+<% end %>
 
 $('#alert p').html("Namespace '<%= namespace.name %>' is now <%= namespace.public? ? 'public' : 'private' %>");
 $('#alert').fadeIn();

--- a/bin/client.rb
+++ b/bin/client.rb
@@ -7,6 +7,7 @@
 #   - catalog
 #   - delete <name> <digest>
 #   - manifest <name>[:<tag>]
+#   - ping <hostname:port> [use_ssl]
 
 registry = Registry.get
 if registry.nil? && ARGV.first != "ping"
@@ -58,6 +59,6 @@ when "ping"
     puts "Error: cannot reach the registry"
   end
 else
-  puts "Valid commands: catalog, delete, manifest."
+  puts "Valid commands: catalog, delete, manifest and ping."
   exit 1
 end

--- a/spec/api/v2/token_spec.rb
+++ b/spec/api/v2/token_spec.rb
@@ -92,16 +92,13 @@ describe "/v2/token" do
         APP_CONFIG["ldap"] = { "enabled" => true, "base" => "" }
         allow_any_instance_of(Portus::LDAP).to receive(:authenticate!).and_call_original
         allow_any_instance_of(Net::LDAP).to receive(:bind_as).and_return(true)
-        allow_any_instance_of(NamespacePolicy).to receive(:push?).and_return(true)
-        allow_any_instance_of(NamespacePolicy).to receive(:pull?).and_return(true)
       end
 
       it "authenticates if the HTTP Basic Authentication was given" do
         get v2_token_url,
           {
             service: registry.hostname,
-            account: "ldapuser",
-            scope:   "repository:ldapuser/busybox:push,pull"
+            account: "ldapuser"
           },
           "HTTP_AUTHORIZATION" => auth_mech.encode_credentials("ldapuser", "12341234")
 
@@ -118,8 +115,7 @@ describe "/v2/token" do
         get v2_token_url,
           {
             service: registry.hostname,
-            account: "ldapuser",
-            scope:   "repository:ldapuser/busybox:push,pull"
+            account: "ldapuser"
           }, {}
 
         expect(response.status).to eq 401


### PR DESCRIPTION
Before this patch, a "public" namespace allowed pulls to any Portus user.
However, it did not allow pull access to anonymous users.

After this patch, the TokensController won't authenticate every user, but only
those that have called the `docker login` command. From now on, it's up to each
policy to allow/disallow anonymous users. In particular, the only one that
allows access to anonymous users is the Namespace policy, and it only does it
for pull requests.

Fixes #279

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>