### PR TITLE
portusctl: added the "logs" command

### DIFF
--- a/packaging/suse/portusctl/lib/cli.rb
+++ b/packaging/suse/portusctl/lib/cli.rb
@@ -130,6 +130,15 @@ class Cli < Thor
     Runner.bundler_exec(args[0], exec_args, {})
   end
 
+  desc "logs", "Collect all the logs used for debugging purposes"
+  def logs(*args)
+    warn "Extra arguments ignored..." unless args.empty?
+    ensure_root
+
+    Runner.produce_versions_file!
+    Runner.tar_files("log/production.log", "log/crono.log", "log/versions.log")
+  end
+
   private
 
   def ensure_root

--- a/packaging/suse/portusctl/lib/constants.rb
+++ b/packaging/suse/portusctl/lib/constants.rb
@@ -9,3 +9,4 @@ end
 # See packaging/suse/bin/portusctl
 BUNDLER_BIN = ENV["BUNDLER_BIN"]
 HOSTNAME    = (dockerized? ? `hostname -f` : `hostnamectl --static status`).chomp
+PORTUS_ROOT = "/srv/Portus"


### PR DESCRIPTION
This command fetches all the logs needed for debugging purposes.

Fixes #411

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>