### PR TITLE
compose: don't setup the CATALOG_CRON manually, just inherit it

### DIFF
--- a/docker/crono-supervisord.conf
+++ b/docker/crono-supervisord.conf
@@ -2,4 +2,4 @@
 nodaemon=true
 
 [program:crono]
-command=/bin/bash -c "CATALOG_CRON=10.seconds bundle exec crono"
+command=/bin/bash -c "bundle exec crono"


### PR DESCRIPTION
Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>