### PR TITLE
lib: use an open timeout of 2 seconds for HTTP requests

### DIFF
--- a/app/models/registry.rb
+++ b/app/models/registry.rb
@@ -81,7 +81,7 @@ class Registry < ActiveRecord::Base
       # according to the documentation we have to assume that the registry is
       # not implementing the v2 of the API.
       return "Error: registry does not implement v2 of the API." unless r
-    rescue Errno::ETIMEDOUT, Errno::ECONNREFUSED, SocketError
+    rescue Errno::ETIMEDOUT, Errno::ECONNREFUSED, SocketError, Net::OpenTimeout
       msg = "Error: connection refused. The given registry is not available!"
     rescue Net::HTTPBadResponse
       if use_ssl

--- a/lib/portus/http_helpers.rb
+++ b/lib/portus/http_helpers.rb
@@ -138,8 +138,9 @@ module Portus
     # Performs an HTTP request to the given URI and request object. It returns an
     # HTTP response that has been sent from the registry.
     def get_response_token(uri, req)
-      https = uri.scheme == "https"
-      Net::HTTP.start(uri.hostname, uri.port, use_ssl: https) do |http|
+      options = { use_ssl: uri.scheme == "https", open_timeout: 2 }
+
+      Net::HTTP.start(uri.hostname, uri.port, options) do |http|
         http.request(req)
       end
     end


### PR DESCRIPTION
This way we can make sure whether a registry is reachable or not faster.

Fixes #442

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>