### PR TITLE
public_activity: simplify messages of users acting upon themselves

### DIFF
--- a/app/views/public_activity/team/_change_member_role.html.slim
+++ b/app/views/public_activity/team/_change_member_role.html.slim
@@ -6,9 +6,12 @@ li
   .description
     h6
       strong
-        = "#{activity.owner.username} changed role of user #{activity.recipient.username} "
+        - if activity.owner == activity.recipient
+          = "#{activity.owner.username} changed its role "
+        - else
+          = "#{activity.owner.username} changed role of user #{activity.recipient.username} "
       = "from #{activity.parameters[:old_role]} to #{activity.parameters[:new_role]} "
-      = "whithin the team "
+      = "within the team "
       = link_to activity.trackable.name, activity.trackable
     small
       i.fa.fa-clock-o

--- a/app/views/public_activity/team/_remove_member.html.slim
+++ b/app/views/public_activity/team/_remove_member.html.slim
@@ -6,8 +6,11 @@ li
   .description
     h6
       strong
-        = "#{activity.owner.username} removed user #{activity.recipient.username} "
-      = "with role #{activity.parameters[:role]} from the "
+        - if activity.owner == activity.recipient
+          = "#{activity.owner.username} removed itself "
+        - else
+          = "#{activity.owner.username} removed user #{activity.recipient.username} "
+      = "from the "
       = link_to activity.trackable.name, activity.trackable
       |  team
     small


### PR DESCRIPTION
Users can remove themselves from a team, and owners can step down as owners of
a team. In these cases, it's weird to see a message like "mssola removed user
mssola ...". Instead, now the same message will say "mssola removed itself
...".

Moreover, in the case of removing a team member, it's weird in my opinion to
state the old role of that user. So, comparing on the removal of a team member:

- before: "mssola removed user mssola with role owner from the docker team"
- after:  "mssola removed itself from the docker team"

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>