### PR TITLE
passwords: do not allow LDAP users to access the password reset procedure

### DIFF
--- a/app/controllers/auth/registrations_controller.rb
+++ b/app/controllers/auth/registrations_controller.rb
@@ -1,7 +1,8 @@
 class Auth::RegistrationsController < Devise::RegistrationsController
   layout "authentication", except: :edit
 
-  before_action :check_ldap, only: [:new, :create]
+  include CheckLDAP
+
   before_action :check_admin, only: [:new, :create]
   before_action :configure_sign_up_params, only: [:create]
   before_action :authenticate_user!, only: [:disable]
@@ -87,11 +88,6 @@ class Auth::RegistrationsController < Devise::RegistrationsController
   end
 
   protected
-
-  # Redirect to the login page if LDAP is enabled.
-  def check_ldap
-    redirect_to new_user_session_path if Portus::LDAP.enabled?
-  end
 
   # Returns true if the contents of the `params` hash contains the needed keys
   # to update the password of the user.

--- a/app/controllers/concerns/check_ldap.rb
+++ b/app/controllers/concerns/check_ldap.rb
@@ -1,0 +1,15 @@
+# CheckLDAP redirects the user to the new_user_session_path if LDAP support is
+# enabled. A `before_action` will be created for the :new and the :create
+# methods.
+module CheckLDAP
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :check_ldap, only: [:new, :create]
+  end
+
+  # Redirect to the login page if LDAP is enabled.
+  def check_ldap
+    redirect_to new_user_session_path if Portus::LDAP.enabled?
+  end
+end

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -3,6 +3,8 @@
 class PasswordsController < Devise::PasswordsController
   layout "authentication"
 
+  include CheckLDAP
+
   # Re-implemented from Devise to respond with a proper message on error.
   def create
     self.resource = resource_class.send_reset_password_instructions(resource_params)

--- a/spec/controllers/passwords_controller_spec.rb
+++ b/spec/controllers/passwords_controller_spec.rb
@@ -36,4 +36,20 @@ describe PasswordsController do
     @user.reload
     expect(@user.valid_password?("12341234")).to be false
   end
+
+  describe "LDAP support is enabled" do
+    before :each do
+      APP_CONFIG["ldap"] = { "enabled" => true }
+    end
+
+    it "redirects the user when trying to reach :new" do
+      get :new
+      expect(response).to redirect_to new_user_session_path
+    end
+
+    it "redirects the user when trying to :create" do
+      post :create, "user" => { "email" => @user.email }
+      expect(response).to redirect_to new_user_session_path
+    end
+  end
 end


### PR DESCRIPTION
It doesn't make sense for LDAP users to recover passwords this way, since
Portus acts just as a proxy between users and the LDAP server when it comes to
authentication.

Since this was exactly the same as for the signup page, I've put the code
inside of a concern that bith the RegistrationsController and the
PasswordsController use.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>