### PR TITLE
config: set the mailer URL options in an initializer

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,8 +38,6 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
-  config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
-
   # Set this to true when debugging a mailer.
   config.action_mailer.raise_delivery_errors = false
 end

--- a/config/initializers/mailer_url_options.rb
+++ b/config/initializers/mailer_url_options.rb
@@ -1,0 +1,17 @@
+# If you're on staging/production, then you must be using SSL. Otherwise, if
+# you're on development mode and you have set your own FQDN, then we assume
+# that SSL is in place too. Otherwise, SSL is not setup.
+if !Rails.env.development? || !ENV["PORTUS_MACHINE_FQDN"].empty?
+  protocol = "https://"
+else
+  protocol = "http://"
+end
+
+host = Rails.application.secrets.machine_fqdn
+ActionMailer::Base.default_url_options[:host]     = host
+ActionMailer::Base.default_url_options[:protocol] = protocol
+
+Rails.logger.tagged("Mailer config") do
+  Rails.logger.info "Host:     #{host}"
+  Rails.logger.info "Protocol: #{protocol}"
+end


### PR DESCRIPTION
We guess the host and the protocol with the information we have on startup.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>