### PR TITLE
catalog: handle the removal of tags gracefully

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -97,11 +97,12 @@ class Repository < ActiveRecord::Base
         tags.delete_at(idx)
       else
         Tag.create!(name: tag, repository: repository, author: portus)
+        logger.tagged("catalog") { logger.info "Created the tag '#{tag}'." }
       end
     end
 
     # Finally remove the tags that are left and return the repo.
-    Tag.where(name: tags).delete_all
+    Tag.where(name: tags).find_each(&:delete_and_update!)
     repository.reload
   end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -8,4 +8,11 @@ class Tag < ActiveRecord::Base
   # We don't validate the tag, because we will fetch that from the registry,
   # and that's guaranteed to have a good format.
   validates :name, uniqueness: { scope: "repository_id" }
+
+  # Delete this tag and update its activity.
+  def delete_and_update!
+    logger.tagged("catalog") { logger.info "Removed the tag '#{name}'." }
+    PublicActivity::Activity.where(recipient: self).update_all(parameters: { tag_name: name })
+    destroy
+  end
 end

--- a/app/views/public_activity/repository/_push.csv.slim
+++ b/app/views/public_activity/repository/_push.csv.slim
@@ -1,1 +1,8 @@
-= CSV.generate_line(['repository', "#{activity.trackable.namespace.global? ? activity.trackable.namespace.registry.hostname : activity.trackable.namespace.name}/#{activity.trackable.name}:#{activity.recipient.name}", 'push tag', '-', activity.owner.username, activity.created_at, "-"])
+- unless activity.trackable.nil?
+  - if activity.recipient.nil?
+    - if activity.parameters[:tag_name].nil?
+      = CSV.generate_line(['repository', "#{activity.trackable.namespace.global? ? activity.trackable.namespace.registry.hostname : activity.trackable.namespace.name}/#{activity.trackable.name}", 'push tag', '-', activity.owner.username, activity.created_at, "-"])
+    - else
+      = CSV.generate_line(['repository', "#{activity.trackable.namespace.global? ? activity.trackable.namespace.registry.hostname : activity.trackable.namespace.name}/#{activity.trackable.name}:#{activity.parameters[:tag_name]}", 'push tag', '-', activity.owner.username, activity.created_at, "-"])
+  - else
+    = CSV.generate_line(['repository', "#{activity.trackable.namespace.global? ? activity.trackable.namespace.registry.hostname : activity.trackable.namespace.name}/#{activity.trackable.name}:#{activity.recipient.name}", 'push tag', '-', activity.owner.username, activity.created_at, "-"])

--- a/app/views/public_activity/repository/_push.html.slim
+++ b/app/views/public_activity/repository/_push.html.slim
@@ -9,7 +9,13 @@ li
         = "#{activity.owner.username} pushed "
       = link_to activity.trackable.namespace.clean_name, activity.trackable.namespace
       | /
-      = link_to "#{activity.trackable.name}:#{activity.recipient.name}", activity.trackable
+      - if activity.recipient.nil?
+        - if activity.parameters[:tag_name].nil?
+          = link_to "#{activity.trackable.name}", activity.trackable
+        - else
+          = link_to "#{activity.trackable.name}:#{activity.parameters[:tag_name]}", activity.trackable
+      - else
+        = link_to "#{activity.trackable.name}:#{activity.recipient.name}", activity.trackable
     small
       i.fa.fa-clock-o
       = activity_time_tag activity.created_at


### PR DESCRIPTION
Now, when a tag gets removed by the catalog job, its activities will be updated
by saving the `tag_name` extra parameter. This parameter will be used by the
views to handle missing tags. Moreover, I've added more log messages.

Fixes #506
Fixes #443

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>