### PR TITLE
ldap: set the email to null if it couldn't be guessed

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,7 @@ class ApplicationController < ActionController::Base
   #      this case, the user will be asked to submit an email.
   #   2. Everything is fine, go to the root url.
   def after_sign_in_path_for(_resource)
-    current_user.email.empty? ? edit_user_registration_url : root_url
+    current_user.email? ? root_url : edit_user_registration_url
   end
 
   def after_sign_out_path_for(_resource)
@@ -52,7 +52,7 @@ class ApplicationController < ActionController::Base
   # Redirect users to their profile page if they haven't set up their email
   # account (this happens when signing up through LDAP suppor).
   def force_update_profile!
-    return unless current_user && current_user.email.empty?
+    return unless current_user && !current_user.email?
     return if protected_controllers?
 
     redirect_to edit_user_registration_url

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,7 @@
 module ApplicationHelper
   # Render the user profile picture depending on the gravatar configuration.
   def user_image_tag(email)
-    if APP_CONFIG.enabled?("gravatar")
+    if APP_CONFIG.enabled?("gravatar") && !email.nil? && !email.empty?
       gravatar_image_tag(email)
     else
       image_tag "user.svg", class: "user-picture"

--- a/app/views/devise/registrations/edit.html.slim
+++ b/app/views/devise/registrations/edit.html.slim
@@ -6,21 +6,21 @@
           ' Public Profile
       .panel-body
         = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: 'profile' }) do |f|
-          - if current_user.email.empty?
+          - unless current_user.email?
             p
               | Your profile is not complete. Please, submit an email to be used in this Portus instance.
           .form-group class=(current_user.email.empty? ? "has-error" : "")
             .field
-              - if current_user.email.empty?
-                = f.label :email, "Email", class: "control-label", title: "This profile is not complete. You need to provide an email first"
-              - else
+              - if current_user.email?
                 = f.label :email
+              - else
+                = f.label :email, "Email", class: "control-label", title: "This profile is not complete. You need to provide an email first"
               = f.text_field(:email, class: 'form-control', required: true, autofocus: true)
           .form-group
             .actions
               = f.submit('Update', class: 'btn btn-primary', disabled: true)
 
-    - unless current_user.email.empty?
+    - if current_user.email?
       - unless current_user.admin? && @admin_count == 1
         .panel.panel-default
           .panel-heading
@@ -34,7 +34,7 @@
                       any affiliations with any team will be lost.
                   = submit_tag('Disable', class: 'btn btn-primary')
 
-  - unless current_user.email.empty?
+  - if current_user.email?
     - if current_user.ldap_name.nil?
       .col-sm-6
         .panel.panel-default

--- a/db/migrate/20151029145958_remove_not_null_constraint_on_users_email.rb
+++ b/db/migrate/20151029145958_remove_not_null_constraint_on_users_email.rb
@@ -1,0 +1,5 @@
+class RemoveNotNullConstraintOnUsersEmail < ActiveRecord::Migration
+  def change
+    change_column :users, :email, :string, :null => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150928112551) do
+ActiveRecord::Schema.define(version: 20151029145958) do
 
   create_table "activities", force: :cascade do |t|
     t.integer  "trackable_id",   limit: 4
@@ -125,7 +125,7 @@ ActiveRecord::Schema.define(version: 20150928112551) do
 
   create_table "users", force: :cascade do |t|
     t.string   "username",               limit: 255, default: "",    null: false
-    t.string   "email",                  limit: 255, default: "",    null: false
+    t.string   "email",                  limit: 255, default: ""
     t.string   "encrypted_password",     limit: 255, default: "",    null: false
     t.string   "reset_password_token",   limit: 255
     t.datetime "reset_password_sent_at"

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -17,6 +17,14 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(user_image_tag("user@example.com")).to eq(
         '<img class="user-picture" src="/images/user.svg" alt="User" />')
     end
+
+    it "uses the fa icon if the user had no email set" do
+      APP_CONFIG["gravatar"] = { "enabled" => false }
+      expect(user_image_tag("")).to eq(
+        '<img class="user-picture" src="/images/user.svg" alt="User" />')
+      expect(user_image_tag(nil)).to eq(
+        '<img class="user-picture" src="/images/user.svg" alt="User" />')
+    end
   end
 
   describe "#activity_time_tag" do

--- a/spec/lib/portus/ldap_spec.rb
+++ b/spec/lib/portus/ldap_spec.rb
@@ -243,6 +243,18 @@ describe Portus::LDAP do
       expect(created.username.start_with?("name")).to be_truthy
       expect(created.admin?).to be_falsey
     end
+
+    it "allows multiple users to have no email setup" do
+      APP_CONFIG["ldap"]["guess_email"] = { "enabled" => false }
+
+      lm = LdapMock.new(username: "name", password: "12341234")
+      lm.find_or_create_user_test!
+
+      lm = LdapMock.new(username: "another", password: "12341234")
+      lm.find_or_create_user_test!
+
+      expect(User.count).to eq 2
+    end
   end
 
   describe "#generate_random_name" do
@@ -341,36 +353,36 @@ describe Portus::LDAP do
       ]
     end
 
-    it "returns an empty email if disabled" do
+    it "returns a nil email if disabled" do
       ge = { "enabled" => false, "attr" => "" }
       APP_CONFIG["ldap"] = { "enabled" => true, "base" => "", "guess_email" => ge }
 
       lm = LdapMock.new(username: "name", password: "12341234")
-      expect(lm.guess_email_test(valid_response)).to eq ""
+      expect(lm.guess_email_test(valid_response)).to be_nil
     end
 
-    it "returns an empty email if no records have been found" do
+    it "returns a nil email if no records have been found" do
       ge = { "enabled" => true, "attr" => "" }
       APP_CONFIG["ldap"] = { "enabled" => true, "base" => "", "guess_email" => ge }
 
       lm = LdapMock.new(username: "name", password: "12341234")
-      expect(lm.guess_email_test([])).to eq ""
+      expect(lm.guess_email_test([])).to be_nil
     end
 
-    it "returns an empty email if more than one dn gets returned" do
+    it "returns a nil email if more than one dn gets returned" do
       ge = { "enabled" => true, "attr" => "" }
       APP_CONFIG["ldap"] = { "enabled" => true, "base" => "", "guess_email" => ge }
 
       lm = LdapMock.new(username: "name", password: "12341234")
-      expect(lm.guess_email_test(multiple_dn)).to eq ""
+      expect(lm.guess_email_test(multiple_dn)).to be_nil
     end
 
-    it "returns an empty email if the dc hostname could not be guessed" do
+    it "returns a nil email if the dc hostname could not be guessed" do
       ge = { "enabled" => true, "attr" => "" }
       APP_CONFIG["ldap"] = { "enabled" => true, "base" => "", "guess_email" => ge }
 
       lm = LdapMock.new(username: "name", password: "12341234")
-      expect(lm.guess_email_test(empty_dc)).to eq ""
+      expect(lm.guess_email_test(empty_dc)).to be_nil
     end
 
     it "returns a valid email if the dc can be guessed" do
@@ -381,12 +393,12 @@ describe Portus::LDAP do
       expect(lm.guess_email_test(valid_response)).to eq "name@example.com"
     end
 
-    it "returns an email if the specified attribute does not exist" do
+    it "returns a nil email if the specified attribute does not exist" do
       ge = { "enabled" => true, "attr" => "non_existing" }
       APP_CONFIG["ldap"] = { "enabled" => true, "base" => "", "guess_email" => ge }
 
       lm = LdapMock.new(username: "name", password: "12341234")
-      expect(lm.guess_email_test(valid_response)).to eq ""
+      expect(lm.guess_email_test(valid_response)).to be_nil
     end
 
     it "returns a valid email if the given attribute exists" do


### PR DESCRIPTION
This way we avoid problems with two consecutive LDAP users trying to sign up
with no email. In order to do this, I've had to enable null values in the email
field, which needed some small modifications here and there.

Fixes #514

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>