### PR TITLE
parse DOCKER_HOST when already set

### DIFF
--- a/compose-setup.sh
+++ b/compose-setup.sh
@@ -67,9 +67,15 @@ HERE
     exit 1
 fi
 
-# Get the docker host by picking the IP from the docker0 interface. This is the
-# safest way to reference the Docker host (see issues #417 and #382).
-DOCKER_HOST=${DOCKER_HOST=$(/sbin/ifconfig docker0 | grep -E -o "([0-9]{1,3}[\.]){3}[0-9]{1,3}" | head -1)}
+if [ ! -z $DOCKER_HOST ]; then
+  # DOCKER_HOST is already set
+  # this could be the case when the user is on OSX or for whatever reason is using docker-machine.
+  DOCKER_HOST=$(echo $DOCKER_HOST | grep -E -o '([0-9]{1,3}[\.]){3}[0-9]{1,3}' | head -1)
+else
+  # Get the docker host by picking the IP from the docker0 interface. This is the
+  # safest way to reference the Docker host (see issues #417 and #382).
+  DOCKER_HOST=$(/sbin/ifconfig docker0 | grep -E -o '([0-9]{1,3}[\.]){3}[0-9]{1,3}' | head -1)
+fi
 echo "DOCKER_HOST=${DOCKER_HOST}" > docker/environment
 
 FORCE=0


### PR DESCRIPTION
fix #473

DOCKER_HOST could be set by user or docker-machine.

Signed-off-by: Ben Rexin <ben@rexin.at>

ps: i'm unsure if this should be mentioned in changelog. 