### PR TITLE
Show real error message on LDAP authentification

### DIFF
--- a/lib/portus/ldap.rb
+++ b/lib/portus/ldap.rb
@@ -35,7 +35,7 @@ module Portus
         # strategy.
         if @ldap.bind_as(bind_options)
           user = find_or_create_user!
-          user.valid? ? success!(user) : fail!(:invalid_username)
+          user.valid? ? success!(user) : fail!(user.errors.full_messages.join(","))
         else
           fail!(:ldap_bind_failed)
         end

--- a/spec/lib/portus/ldap_spec.rb
+++ b/spec/lib/portus/ldap_spec.rb
@@ -304,7 +304,8 @@ describe Portus::LDAP do
       APP_CONFIG["ldap"] = { "enabled" => true, "base" => "" }
       lm = LdapMock.new(username: "", password: "1234")
       lm.authenticate!
-      expect(lm.last_symbol).to be :invalid_username
+      expect(lm.last_symbol).to eq "Password is too short (minimum is 8 characters),"\
+        "Username Only alphanumeric characters are allowed. Minimum 4 characters, maximum 30."
     end
 
     it "returns a success if it was successful" do


### PR DESCRIPTION
Don't force error message to just be :invalid_username !