### PR TITLE
review gem versions to match the ones available in SUSE Enterprise Linux

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 4.2.2"
-gem "jquery-rails", "~> 4.0.4"
+gem "jquery-rails"
 gem "sass-rails", ">= 3.2"
 gem "slim"
 gem "pundit"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,7 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.1)
-    active_model_serializers (0.9.3)
+    active_model_serializers (0.9.0)
       activemodel (>= 3.2)
     active_record_union (1.1.0)
       activerecord (>= 4.0)
@@ -94,7 +94,7 @@ GEM
     diff-lcs (1.2.5)
     docile (1.1.5)
     erubis (2.7.0)
-    execjs (2.6.0)
+    execjs (2.2.2)
     factory_girl (4.5.0)
       activesupport (>= 3.0.0)
     factory_girl_rails (4.5.0)
@@ -117,9 +117,8 @@ GEM
     hike (1.2.3)
     hirb (0.7.3)
     i18n (0.7.0)
-    jquery-rails (4.0.4)
-      rails-dom-testing (~> 1.0)
-      railties (>= 4.2.0)
+    jquery-rails (3.1.3)
+      railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
     jquery-turbolinks (2.1.0)
       railties (>= 3.1.0)
@@ -207,7 +206,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rainbow (2.0.0)
-    rake (10.4.2)
+    rake (10.3.2)
     responders (2.1.0)
       railties (>= 4.2.0, < 5)
     rspec-core (3.3.0)
@@ -258,8 +257,8 @@ GEM
       json (~> 1.8)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
-    slim (3.0.6)
-      temple (~> 0.7.3)
+    slim (2.0.2)
+      temple (~> 0.6.6)
       tilt (>= 1.3.3, < 2.1)
     slop (3.6.0)
     sprockets (2.12.3)
@@ -271,7 +270,7 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
-    temple (0.7.6)
+    temple (0.6.7)
     thor (0.18.1)
     thread_safe (0.3.5)
     tilt (1.4.1)
@@ -329,7 +328,7 @@ DEPENDENCIES
   git-review
   gravatar_image_tag
   hirb
-  jquery-rails (~> 4.0.4)
+  jquery-rails
   jquery-turbolinks
   json-schema
   jwt

--- a/app/views/errors/_status_title.html.slim
+++ b/app/views/errors/_status_title.html.slim
@@ -1,9 +1,8 @@
-- case @status
-  - when 401
-    | Unauthorized!
-  - when 404
-    | Page not found!
-  - when 422
-    | Unprocessable Entity
-  - else
-    | Something's wrong with our lighthouse.
+- if @status == 401
+  | Unauthorized!
+- elsif @status == 404
+  | Page not found!
+- elsif @status == 422
+  | Unprocessable Entity
+- else
+  | Something's wrong with our lighthouse.

--- a/app/views/namespaces/show.html.slim
+++ b/app/views/namespaces/show.html.slim
@@ -8,8 +8,7 @@
       - if can_manage_namespace?(@namespace)
         .pull-right
           button.btn.btn-link.btn-xs.btn-edit-role[
-            value="#{@namespace.id}",
-            class="button_namespace_description"]
+            value="#{@namespace.id}" class="button_namespace_description"]
             i.fa.fa-pencil.fa-lg
             | Edit namespace
       small

--- a/app/views/teams/show.html.slim
+++ b/app/views/teams/show.html.slim
@@ -14,12 +14,11 @@
           tabindex="0" data-html="true"]
             i.fa.fa-info-circle
       - if can_manage_team?(@team)
-      .pull-right
-        button.btn.btn-link.btn-xs.btn-edit-role[
-          value="#{@team.id}",
-          class="button_team_description"]
-          i.fa.fa-pencil
-          | Edit team
+        .pull-right
+          button.btn.btn-link.btn-xs.btn-edit-role[
+            value="#{@team.id}" class="button_team_description"]
+            i.fa.fa-pencil
+            | Edit team
   .panel-body
     .description
       - if @team.description.blank?


### PR DESCRIPTION
Server

fix bnc#953771: Release of Portus build requirements to SLE-12 codestream

I had to fix some slim issues that appeared when downgrading to 2.0.2,
as not using "," but " " to separate values in an array, and use
"if-elsif-else" clauses instead of "case-when"

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>