### PR TITLE
fix sprockets_rails version so that it matches the one in SLES

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -271,7 +271,7 @@ GEM
       multi_json (~> 1.0)
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
-    sprockets-rails (2.3.2)
+    sprockets-rails (2.3.1)
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)


### PR DESCRIPTION
fix bsc#953771 Release of Portus build requirements to SLE-12 codestream