### PR TITLE
Using typeahead to autocomplete teams when creating a namespace

### DIFF
--- a/app/assets/javascripts/teams.coffee
+++ b/app/assets/javascripts/teams.coffee
@@ -1,4 +1,19 @@
 $(document).on "page:change", ->
+
+  set_typeahead = (url) ->
+    bloodhound = new Bloodhound(
+        datumTokenizer: Bloodhound.tokenizers.obj.whitespace('name'),
+        queryTokenizer: Bloodhound.tokenizers.whitespace,
+        remote:
+          cache: false,
+          url: url,
+          wildcard: '%QUERY'
+      )
+    bloodhound.initialize()
+    $('.remote .typeahead').typeahead null,
+      displayKey: 'name',
+      source: bloodhound.ttAdapter()
+
   $('#add_team_user_btn').on 'click', (event) ->
     $('#team_user_user').val('')
     $('#team_user_role').val('viewer')
@@ -12,6 +27,8 @@ $(document).on "page:change", ->
         $('#add_team_user_btn i').removeClass("fa-minus-circle")
         $('#add_team_user_btn i').addClass("fa-plus-circle")
         layout_resizer()
+    team_id = $('.remote').attr('id')
+    set_typeahead(team_id  +  '/typeahead/%QUERY')
 
   open_close_icon = (icon) ->
     if icon.hasClass('fa-close')
@@ -38,22 +55,6 @@ $(document).on "page:change", ->
       $('#namespace_description').focus()
   )
 
-  searchSelektor = $('.remote .typeahead')
-  teamID = $('.remote').attr('id')
-  bloodhound = new Bloodhound(
-    datumTokenizer: Bloodhound.tokenizers.obj.whitespace('username'),
-    queryTokenizer: Bloodhound.tokenizers.whitespace,
-    remote:
-      cache: false,
-      url: teamID  +  '/typeahead/%QUERY',
-      wildcard: '%QUERY'
-  )
-  bloodhound.initialize()
-
-  $('.remote .typeahead').typeahead null,
-    displayKey: 'username',
-    source: bloodhound.ttAdapter()
-
   $('#add_namespace_btn').unbind('click').on 'click', (event) ->
     $('#namespace_namespace').val('')
 
@@ -72,6 +73,7 @@ $(document).on "page:change", ->
         $('#add_namespace_btn i').removeClass("fa-minus-circle")
         $('#add_namespace_btn i').addClass("fa-plus-circle")
         layout_resizer()
+    set_typeahead('/namespaces/typeahead/%QUERY')
 
   $('#add_team_btn').on 'click', (event) ->
     $('#team_name').val('')

--- a/app/controllers/namespaces_controller.rb
+++ b/app/controllers/namespaces_controller.rb
@@ -6,7 +6,7 @@ class NamespacesController < ApplicationController
   before_action :check_team, only: [:create]
   before_action :check_role, only: [:create]
 
-  after_action :verify_authorized, except: :index
+  after_action :verify_authorized, except: [:index, :typeahead]
   after_action :verify_policy_scoped, only: :index
 
   # GET /namespaces
@@ -49,6 +49,17 @@ class NamespacesController < ApplicationController
   # PATCH/PUT /namespace/1.json
   def update
     change_name_description(@namespace, :namespace)
+  end
+
+  # GET /namespace/typeahead/%QUERY
+  def typeahead
+    @query = params[:query]
+    valid_teams = TeamUser.get_valid_team_ids(current_user.id)
+    matches = Team.search_from_query(valid_teams, "#{@query}%").pluck(:name)
+    matches = matches.map { |team| { name: team } }
+    respond_to do |format|
+      format.json { render json: matches.to_json }
+    end
   end
 
   # PATCH/PUT /namespace/1/toggle_public

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -44,7 +44,7 @@ class TeamsController < ApplicationController
     authorize @team
     @query = params[:query]
     matches = User.search_from_query(@team.member_ids, "#{@query}%").pluck(:username)
-    matches = matches.map { |user| { username: user } }
+    matches = matches.map { |user| { name: user } }
     respond_to do |format|
       format.json { render json: matches.to_json }
     end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,6 +1,13 @@
 class Team < ActiveRecord::Base
   include PublicActivity::Common
 
+  # Returns all the teams that are not special. By special team we mean:
+  #   - It's the global namespace (see: Registry#create_namespaces!).
+  #   - It's a personal namespace (see: User#create_personal_namespace!).
+  #
+  # Right now, all the special namespaces are simply marked as hidden.
+  scope :all_non_special, -> { where(hidden: false) }
+
   validates :name, presence: true, uniqueness: true
   validates :owners, presence: true
   has_many :namespaces
@@ -14,16 +21,13 @@ class Team < ActiveRecord::Base
   has_many :viewers, -> { merge TeamUser.viewer },
     through: :team_users, source: :user
 
-  # Returns all the teams that are not special. By special team we mean:
-  #   - It's the global namespace (see: Registry#create_namespaces!).
-  #   - It's a personal namespace (see: User#create_personal_namespace!).
-  def self.all_non_special
-    # Right now, all the special namespaces are simply marked as hidden.
-    Team.where(hidden: false)
-  end
-
   # Returns all the member-IDs
   def member_ids
     team_users.pluck(:user_id)
+  end
+
+  # Returns all teams whose name match the query
+  def self.search_from_query(valid_teams, query)
+    all_non_special.where(id: valid_teams).where(arel_table[:name].matches(query))
   end
 end

--- a/app/models/team_user.rb
+++ b/app/models/team_user.rb
@@ -25,6 +25,11 @@ class TeamUser < ActiveRecord::Base
     team.create_activity type, owner: owner, recipient: user, parameters: params
   end
 
+  # Returns all team IDs which are manageable by one user
+  def self.get_valid_team_ids(id)
+    owner.where(user_id: id).pluck(:team_id)
+  end
+
   # Returns true if the member of this team is the only owner of it.
   def only_owner?
     team.owners.exists?(user.id) && team.owners.count == 1

--- a/app/policies/namespace_policy.rb
+++ b/app/policies/namespace_policy.rb
@@ -30,9 +30,9 @@ class NamespacePolicy
       namespace.team.contributors.exists?(user.id)
   end
 
-  alias_method :all?,    :push?
-  alias_method :create?, :push?
-  alias_method :update?, :push?
+  alias_method :all?,       :push?
+  alias_method :create?,    :push?
+  alias_method :update?,    :push?
 
   def toggle_public?
     raise Pundit::NotAuthorizedError, "must be logged in" unless user

--- a/app/views/namespaces/index.html.slim
+++ b/app/views/namespaces/index.html.slim
@@ -13,7 +13,8 @@ span
         .form-group
           = f.label :team, {class: 'control-label col-md-2'}
           .col-md-7
-            = f.text_field(:team, class: 'form-control', required: true, placeholder: "Name of the team")
+            .remote
+              = f.text_field(:team, class: 'form-control typeahead', required: true, placeholder: "Name of the team")
         .form-group
           = f.label :description, {class: 'control-label col-md-2'}
           .col-md-7

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   resources :namespaces, only: [:create, :index, :show, :update] do
     put "toggle_public", on: :member
   end
+  get "namespaces/typeahead/:query" => "namespaces#typeahead", :defaults => { format: "json" }
 
   resources :repositories, only: [:index, :show] do
     post :toggle_star, on: :member

--- a/spec/controllers/namespaces_controller_spec.rb
+++ b/spec/controllers/namespaces_controller_spec.rb
@@ -223,6 +223,28 @@ describe NamespacesController do
     end
   end
 
+  describe "typeahead" do
+    render_views
+    it "does allow to search for valid teams by owner" do
+      testing_team = create(:team, name: "testing", owners: [owner])
+      sign_in owner
+      get :typeahead, query: "test", format: "json"
+      expect(response.status).to eq(200)
+      teamnames = JSON.parse(response.body)
+      expect(teamnames.length).to eq(1)
+      expect(teamnames[0]["name"]).to eq(testing_team.name)
+    end
+
+    it "does not allow to search by viewers" do
+      create(:team, name: "testing", owners: [owner], viewers: [viewer])
+      sign_in viewer
+      get :typeahead, query: "test", format: "json"
+      expect(response.status).to eq(200)
+      teamnames = JSON.parse(response.body)
+      expect(teamnames.length).to eq(0)
+    end
+  end
+
   describe "activity tracking" do
     before :each do
       sign_in owner

--- a/spec/controllers/teams_controller_spec.rb
+++ b/spec/controllers/teams_controller_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe TeamsController, type: :controller do
       get :typeahead, id: team.id, query: "user", format: "json"
       usernames = JSON.parse(response.body)
       expect(usernames.length).to eq(1)
-      expect(usernames[0]["username"]).to eq("user2")
+      expect(usernames[0]["name"]).to eq("user2")
     end
 
     it "does not allow to search by contributers or viewers" do


### PR DESCRIPTION
Fixes: #558

Signed-off-by: Jürgen Löhel <jloehel@suse.com>