### PR TITLE
Added the `signup` configurable value

### DIFF
--- a/app/controllers/auth/registrations_controller.rb
+++ b/app/controllers/auth/registrations_controller.rb
@@ -3,6 +3,7 @@ class Auth::RegistrationsController < Devise::RegistrationsController
 
   include CheckLDAP
 
+  before_action :check_signup, only: [:new, :create]
   before_action :check_admin, only: [:new, :create]
   before_action :configure_sign_up_params, only: [:create]
   before_action :authenticate_user!, only: [:disable]
@@ -79,6 +80,11 @@ class Auth::RegistrationsController < Devise::RegistrationsController
   def check_admin
     @admin = User.admins.any?
     @first_user_admin = APP_CONFIG.enabled?("first_user_admin")
+  end
+
+  # Redirect to the login page if users cannot access the signup page.
+  def check_signup
+    redirect_to new_user_session_path unless APP_CONFIG.enabled?("signup")
   end
 
   def configure_sign_up_params

--- a/app/controllers/auth/sessions_controller.rb
+++ b/app/controllers/auth/sessions_controller.rb
@@ -5,7 +5,9 @@ class Auth::SessionsController < Devise::SessionsController
   # or LDAP support is enabled, work as usual. Otherwise, redirect always to
   # the signup page.
   def new
-    if User.not_portus.any? || Portus::LDAP.enabled?
+    signup_allowed = !Portus::LDAP.enabled? && APP_CONFIG.enabled?("signup")
+
+    if User.not_portus.any? || !signup_allowed
       @errors_occurred = flash[:alert] && !flash[:alert].empty?
       super
     else

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,6 +13,16 @@ module ApplicationHelper
     time_tag ct, time_ago_in_words(ct), title: ct
   end
 
+  # Returns true of signup is enabled.
+  def signup_enabled?
+    !Portus::LDAP.enabled? && APP_CONFIG.enabled?("signup")
+  end
+
+  # Returns true if the login form should show the "first user admin" alert.
+  def show_first_user_alert?
+    !User.not_portus.any? && APP_CONFIG.enabled?("first_user_admin") && Portus::LDAP.enabled?
+  end
+
   # Render markdown to safe HTML.
   # Images, unsafe link protocols and styles are not allowed to render.
   # HTML-Tags will be filtered.

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -13,14 +13,13 @@ section.row-0
           - else
             i.fa.fa-check Login
 
-        - if Portus::LDAP.enabled?
-          - unless User.not_portus.any?
-            .alert.alert-info
-              strong Note:
-              |  The first user to be created will have admin permissions !
-        - else
+        - if signup_enabled?
           .row
             .col-sm-6.create-new-account
               = link_to 'Create a new account', new_user_registration_url, class: 'btn btn-link'
             .col-sm-6.forgot-password
               = link_to "I forgot my password", new_user_password_path, class: 'btn btn-link'
+        - if show_first_user_alert?
+          .alert.alert-info
+            strong Note:
+            |  The first user to be created will have admin permissions !

--- a/config/config.yml
+++ b/config/config.yml
@@ -79,6 +79,14 @@ ldap:
 first_user_admin:
   enabled: true
 
+# If enabled, then users can signup with the signup form. If enabled is set to
+# true and verify is set to true, then users who sign up have to go through a
+# verification process. Otherwise, if verify is set to false and signup is
+# enabled, then users can signup directly. This is ignored if LDAP is enabled.
+signup:
+  enabled: true
+  verify: false # TODO: (mssola) this is ignored for now.
+
 # By default require ssl to be enabled when running on production
 check_ssl_usage:
   enabled: true

--- a/lib/tasks/portus.rake
+++ b/lib/tasks/portus.rake
@@ -1,5 +1,4 @@
 namespace :portus do
-
   desc "Create the account used by Portus to talk with Registry's API"
   task create_api_account: :environment do
     User.create!(

--- a/spec/controllers/auth/registrations_controller_spec.rb
+++ b/spec/controllers/auth/registrations_controller_spec.rb
@@ -5,9 +5,9 @@ describe Auth::RegistrationsController do
   let(:valid_session) { {} }
 
   describe "POST #create" do
-
     before :each do
       request.env["devise.mapping"] = Devise.mappings[:user]
+      APP_CONFIG["signup"] = { "enabled" => true }
     end
 
     it "defaults admin to false when omitted" do
@@ -42,7 +42,6 @@ describe Auth::RegistrationsController do
       }
       expect(User.find_by!(username: "wonnabeadministrator")).not_to be_admin
     end
-
   end
 
   describe "PUT #update" do

--- a/spec/features/auth/login_feature_spec.rb
+++ b/spec/features/auth/login_feature_spec.rb
@@ -15,11 +15,17 @@ feature "Login feature" do
 
   scenario "It does show a warning for the admin creation in LDAP support", js: true do
     User.delete_all
+    APP_CONFIG["first_user_admin"] = { "enabled" => false }
     APP_CONFIG["ldap"] = { "enabled" => true }
     visit new_user_session_path
 
-    expect(page).to have_content("The first user to be created will have admin permissions !")
+    expect(page).to_not have_content("The first user to be created will have admin permissions !")
     expect(page).to_not have_content("Create a new account")
+
+    APP_CONFIG["first_user_admin"] = { "enabled" => true }
+    visit new_user_session_path
+
+    expect(page).to have_content("The first user to be created will have admin permissions !")
 
     create(:admin)
 

--- a/spec/features/auth/signup_feature_spec.rb
+++ b/spec/features/auth/signup_feature_spec.rb
@@ -4,6 +4,7 @@ feature "Signup feature" do
   before do
     create(:admin)
     APP_CONFIG["first_user_admin"] = { "enabled" => true }
+    APP_CONFIG["signup"]           = { "enabled" => true }
     visit new_user_registration_url
   end
 
@@ -127,5 +128,16 @@ feature "Signup feature" do
     expect(current_path).to eql(new_user_session_path)
     click_link("Create a new account")
     expect(current_path).to eql(new_user_registration_path)
+  end
+
+  describe "signup disabled" do
+    before do
+      APP_CONFIG["signup"] = { "enabled" => false }
+    end
+
+    scenario "does not allow the user to access the signup page if disabled" do
+      visit new_user_registration_path
+      expect(current_path).to eq new_user_session_path
+    end
   end
 end

--- a/spec/features/forgotten_password_spec.rb
+++ b/spec/features/forgotten_password_spec.rb
@@ -4,7 +4,8 @@ feature "Forgotten password support" do
   let!(:user) { create(:admin) }
 
   before :each do
-    APP_CONFIG["email"] = {
+    APP_CONFIG["signup"] = { "enabled" => true }
+    APP_CONFIG["email"]  = {
       "from"     => "test@example.com",
       "name"     => "Portus",
       "reply_to" => "no-reply@example.com"

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -64,4 +64,43 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(markdown(html_tag)).to eq "<p>alert(&#39;foo&#39;);</p>\n"
     end
   end
+
+  describe "#signup_enabled?" do
+    it "tells when signup is enabled and when it's not" do
+      APP_CONFIG["signup"] = { "enabled" => true }
+      APP_CONFIG["ldap"]   = { "enabled" => false }
+      expect(signup_enabled?).to be_truthy
+
+      APP_CONFIG["ldap"] = { "enabled" => true }
+      expect(signup_enabled?).to be_falsey
+
+      APP_CONFIG["signup"] = { "enabled" => false }
+      expect(signup_enabled?).to be_falsey
+
+      APP_CONFIG["ldap"] = { "enabled" => false }
+      expect(signup_enabled?).to be_falsey
+    end
+  end
+
+  describe "#show_first_user_alert?" do
+    it "shows the first_user alert when needed" do
+      APP_CONFIG["ldap"]             = { "enabled" => true }
+      APP_CONFIG["first_user_admin"] = { "enabled" => true }
+      expect(show_first_user_alert?).to be_truthy
+
+      APP_CONFIG["first_user_admin"] = { "enabled" => false }
+      expect(show_first_user_alert?).to be_falsey
+
+      APP_CONFIG["ldap"] = { "enabled" => false }
+      expect(show_first_user_alert?).to be_falsey
+
+      APP_CONFIG["first_user_admin"] = { "enabled" => true }
+      expect(show_first_user_alert?).to be_falsey
+
+      create(:admin)
+      APP_CONFIG["ldap"]             = { "enabled" => true }
+      APP_CONFIG["first_user_admin"] = { "enabled" => true }
+      expect(show_first_user_alert?).to be_falsey
+    end
+  end
 end


### PR DESCRIPTION
When enabled (default behavior), then any user can access to the signup page.
Otherwise, users are not able to enter the signup form. This is ignored in LDAP
mode.

Note that I've also added the `verify` configurable value. This is supposed to
be implemented in the near future, as described in the related issues.

See issues #179 and #283

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>