### PR TITLE
The team name on the "Belongs to" label is now a link

### DIFF
--- a/app/assets/stylesheets/labels.scss
+++ b/app/assets/stylesheets/labels.scss
@@ -1,4 +1,15 @@
 //labels
 .label.label-info{
   background: $primary-colour;
+
+  // Treat links inside of a label just like the label itself.
+  a {
+    background: $primary-colour;
+    color: $white;
+
+    &:hover {
+      background: $primary-colour;
+      color: $white;
+    }
+  }
 }

--- a/app/views/namespaces/show.html.slim
+++ b/app/views/namespaces/show.html.slim
@@ -44,8 +44,8 @@
       strong
         = @namespace.clean_name
     h6.label.label-info
-      | Belongs to:
-      = " #{@namespace.team.name}"
+      | <span>Belongs to: </span>
+      = link_to "#{@namespace.team.name}", @namespace.team
   .panel-body
     .table-responsive
       table.table.table-stripped.table-hover


### PR DESCRIPTION
Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>