### PR TITLE
compose: do nothing if the DOCKER_HOST variable is already set

### DIFF
--- a/compose-setup.sh
+++ b/compose-setup.sh
@@ -35,7 +35,7 @@ clean() {
   echo "The setup will destroy the containers used by Portus, removing also their volumes."
   if [ $FORCE -ne 1 ]; then
     while true; do
-      read -p "Are you sure to delete all the data? (Y/N)" yn
+      read -p "Are you sure to delete all the data? (Y/N) " yn
       case $yn in
         [Yy]* )
           break;;
@@ -67,11 +67,7 @@ HERE
     exit 1
 fi
 
-if [ ! -z $DOCKER_HOST ]; then
-  # DOCKER_HOST is already set
-  # this could be the case when the user is on OSX or for whatever reason is using docker-machine.
-  DOCKER_HOST=$(echo $DOCKER_HOST | grep -E -o '([0-9]{1,3}[\.]){3}[0-9]{1,3}' | head -1)
-else
+if [ -z $DOCKER_HOST ]; then
   # Get the docker host by picking the IP from the docker0 interface. This is the
   # safest way to reference the Docker host (see issues #417 and #382).
   DOCKER_HOST=$(/sbin/ifconfig docker0 | grep -E -o '([0-9]{1,3}[\.]){3}[0-9]{1,3}' | head -1)
@@ -101,6 +97,10 @@ docker-compose up -d
 
 setup_database
 
+# The cleaned up host. We do this because when the $DOCKER_HOST variable was
+# already set, then it might come with the port included.
+final_host=$(echo $DOCKER_HOST | grep -E -o '([0-9]{1,3}[\.]){3}[0-9]{1,3}' | head -1)
+
 cat <<EOM
 
 ###################
@@ -109,22 +109,30 @@ cat <<EOM
 
 EOM
 
-echo "Make sure port 3000 and 5000 are open on host ${DOCKER_HOST}"
+echo "Make sure port 3000 and 5000 are open on host ${final_host}"
 printf "\n"
 
-echo "Open http://${DOCKER_HOST}:3000 with your browser and perform the following steps:"
-echo "  1 - Create an admin account"
-echo "  2 - Add a new registry: choose a custom name, enter ${DOCKER_HOST}:5000 as hostname"
+echo "Open http://${final_host}:3000 with your browser and perform the following steps:"
+printf "\n"
+echo "  1. Create an admin account"
+echo "  2. You will be redirected to a page where you have to register the registry. In this form:"
+echo "    - Choose a custom name for the registry."
+echo "    - Enter ${final_host}:5000 as the hostname."
+echo "    - Do *not* check the \"Use SSL\" checkbox, since this setup is not using SSL."
 printf "\n"
 
 echo "Perform the following actions on the docker hosts that need to interact with your registry:"
-echo " - Ensure the docker daemon is started with the '--insecure-registry ${DOCKER_HOST}:5000'"
-echo " - Perform the docker login"
+printf "\n"
+echo "  - Ensure the docker daemon is started with the '--insecure-registry ${final_host}:5000'"
+echo "  - Perform the docker login."
+printf "\n"
 echo "To authenticate against your registry using the docker cli do:"
-echo "  docker login -u <portus username> -p <password> -e <email> ${DOCKER_HOST}:5000"
+printf "\n"
+echo "  $ docker login -u <portus username> -p <password> -e <email> ${final_host}:5000"
 printf "\n"
 
 echo "To push an image to the private registry:"
-echo "  docker pull busybox"
-echo "  docker tag busybox ${DOCKER_HOST}:5000/<username>busybox"
-echo "  docker push ${DOCKER_HOST}:5000/<username>busybox"
+printf "\n"
+echo "  $ docker pull busybox"
+echo "  $ docker tag busybox ${final_host}:5000/<username>busybox"
+echo "  $ docker push ${final_host}:5000/<username>busybox"


### PR DESCRIPTION
This fixes the setup on environments that already set the DOCKER_HOST
environment variable. Since this variable can be set to something like
"tcp://IP:POR", the final message cleans up everything so only the IP is shown
together with the proper ports.

I've also cleaned up the final message so it's more well-formatted and verbose.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>