### PR TITLE
Show the "I forgot my password" link when the signup is disabled

### DIFF
--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -13,11 +13,14 @@ section.row-0
           - else
             i.fa.fa-check Login
 
-        - if signup_enabled?
-          .row
+        .row
+          - if signup_enabled?
             .col-sm-6.create-new-account
               = link_to 'Create a new account', new_user_registration_url, class: 'btn btn-link'
             .col-sm-6.forgot-password
+              = link_to "I forgot my password", new_user_password_path, class: 'btn btn-link'
+          - else
+            .forgot-password
               = link_to "I forgot my password", new_user_password_path, class: 'btn btn-link'
         - if show_first_user_alert?
           .alert.alert-info

--- a/spec/features/auth/login_feature_spec.rb
+++ b/spec/features/auth/login_feature_spec.rb
@@ -72,6 +72,21 @@ feature "Login feature" do
     expect(current_path).to eq new_user_session_path
   end
 
+  scenario "Sign up is disabled", js: true do
+    APP_CONFIG["signup"] = { "enabled" => true }
+
+    visit root_path
+    expect(current_path).to eq root_path
+    expect(page).to have_content("Create a new account")
+
+    APP_CONFIG["signup"] = { "enabled" => false }
+
+    visit root_path
+    expect(current_path).to eq root_path
+    expect(page).to have_content("I forgot my password")
+    expect(page).to_not have_content("Create a new account")
+  end
+
   describe "User is lockable" do
     before :each do
       @attempts  = Devise.maximum_attempts


### PR DESCRIPTION
This is a fix for a regression in which Portus didn't show the "I forgot my
password" link in the sign in page when the `signup` configurable value was
disabled.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>