### PR TITLE
set RUBYLIB when running bundle in portusctl

### DIFF
--- a/packaging/suse/bin/portusctl
+++ b/packaging/suse/bin/portusctl
@@ -3,6 +3,7 @@
 export RAILS_ENV=production
 export GEM_PATH=/srv/Portus/vendor/bundle/ruby/2.1.0/
 export BUNDLER_BIN=/srv/Portus/vendor/bundle/ruby/2.1.0/bin/bundler.ruby2.1
+export RUBYLIB=$(ls -d /srv/Portus/vendor/bundle/ruby/2.1.0/gems/bundler*)/lib/
 
 cd /srv/Portus
 $BUNDLER_BIN exec packaging/suse/portusctl/bin/portusctl "$@"


### PR DESCRIPTION
We have found that under certain circumstances, portusctl fails to run
bundler.

After debugging it, we found out that on our test machine RUBYLIB was
set as

/usr/lib64/ruby/gems/2.1.0/gems/bundler-1.10.6/lib/

which was causing bundler not being able to run, since this is a
different version than the one we have in /srv/Portus/vendor/....

My guess is that this is because of rubygem-bundler being installed on
that system.

This commit sets that environment variable to our bundler directory.

fix issue#612