### PR TITLE
The proper number of teams for admin/users

### DIFF
--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -40,7 +40,7 @@
                       i.fa.fa-lg[class="fa-toggle-#{user.admin? ? 'on': 'off'}"]
 
               td= user.teams.reduce(0){ |sum, t| sum += t.namespaces.count}
-              td= user.teams.count
+              td= user.teams.all_non_special.count
               td.enabled-btn
                 - if current_user.id == user.id && @admin_count == 1
                   i.fa.fa-lg.fa-toggle-on


### PR DESCRIPTION
Virtual/hidden teams are no longer counted for the "number of teams"-column under admin/users.

Fixes: #614

Signed-off-by: Jürgen Löhel <jloehel@suse.com>