### PR TITLE
Added a page documenting how to create a secure registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,69 @@ $ bundle
 $ bundle exec jekyll serve
 ```
 
-### Gulp tasks (if you are editing the assets)
+## Adding a new documentation page
 
-If you are modifiying Less, JS or images in the /assets folder, you need to run GULP in your console in order to preprocess CSS, minify JS and compress the images.
+The documentation follows the `post` layout. This layout is used in combination
+with [Jekyll Collections](http://jekyllrb.com/docs/collections/). We have three
+collections:
 
-All you need to do is type the following:
+- `_features`: the documentation for a feature.
+- `_docs`: a page explaining a general topic (e.g. configuring Portus).
+- `_setups`: a step-by-step guide of a deployment method for Portus.
 
-```
-$ gulp
-```
+Each page of a Jekyll Collection has some headers specified in YAML format. In
+our case we have the following headers:
+
+- **layout**: set it to `post`.
+- **title**: the short title for the page. This will be displayed on the left
+sidebar.
+- **longtitle**: a longer explanation for the page. This is not used for the
+`_setups` collection. It will be shown in the `/features.html` and in the
+`/documentation.html` pages.
+- **order**: a numerical value stating the order of the page relative to the
+rest of the pages of the collection. This parameter is used when displaying
+each page in a list.
+
+Therefore, when you want to create a new documentation page, you have to think
+about in which collection does it fall, and then create the document with the
+proper headers. After that, you can write you page in Markdown format.
+
+## Editing the assets
+
+If you are modifiying Less, JS or images in the `/assets` folder, you need to
+run Gulp in your console in order to preprocess CSS, minify JS and compress
+the images. All you need to do is type the following:
+
+    $ gulp
 
 After that, you will have the site available at `localhost:4000`.
+
+Note that this command will take care of the `build` directory, which is the
+one used by the finally rendered HTML page. Therefore, do *not* add a new
+asset into the `build` directory manually. Instead, do it on the `/assets` one
+and let Gulp handle it for you. Also note that you have to add into git both
+versions of assets files.
+
+## Tips and tricks when writing new pages
+
+### Relative links
+
+Referencing another document is pretty easy, but there are some subtleties:
+
+- If you are referencing an indivial page, you have to use its `.html` name
+  instead of its `.md` name.
+- If you are referencing a page that is contained in a collection, the path is:
+  - Doc: `/docs/<name-document>.html`.
+  - Setup: `/docs/setups/<name-document>.html`.
+  - Feature: `/features/<name-document>.html`.
+- When referencing a title, you have to first write the URL to the document,
+  and then use the anchor related to it. For example, if the title is
+  `The Catalog API`, then the anchor to be appended to the name of the document
+  is: `#the-catalog-api`.
+
+Last but not least, images work in a similar way but they have `/build`
+prepended to their path. This is because Gulp will put the generated assets
+inside of this `build` directory.
 
 ## Licensing
 

--- a/_docs/Configuring-Portus.md
+++ b/_docs/Configuring-Portus.md
@@ -1,6 +1,7 @@
 ---
 title: Configuring Portus
 layout: post
+order: 1
 longtitle: How to configure Portus
 ---
 

--- a/_docs/Configuring-the-registry.md
+++ b/_docs/Configuring-the-registry.md
@@ -1,10 +1,11 @@
 ---
-title: Configuring your private registry
+title: Portus and your private registry
 layout: post
+order: 3
 longtitle: Letting Portus know about your private registry
 ---
 
-## Configuring your private registry for the first time
+## Registering your private registry into Portus
 
 Once you have deployed Portus successfully and you have logged in as an admin
 user, now it's time to tell Portus about the existence of your private

--- a/_docs/How-to-setup-secure-registry.md
+++ b/_docs/How-to-setup-secure-registry.md
@@ -1,0 +1,170 @@
+---
+title: Configuring a secure private registry
+layout: post
+order: 2
+longtitle: How to setup a secure private registry
+---
+
+## Creating the Registry
+
+### Docker Distribution
+
+The Docker Registry is a service that can talk to the docker daemon in order to
+upload and download docker images. Since version 2, the docker registry is
+called Distribution, and you can find the documentation
+[here](https://www.docker.com/docker-registry).
+
+There are multiple ways to deploy your own private registry. This page
+[explains](https://docs.docker.com/registry/deploying/) how to do this. From a
+deployment point of view, the only thing important for Portus is that it should
+be reachable. Note that this will be checked when adding your registry into
+Portus' database, as explained [here](/docs/Configuring-the-registry.html).
+
+### Configuring the Registry in a safe way
+
+Once you have your registry in place, you need to configure it. This can be
+done either through the `/etc/registry/config.yml` file or through [environment
+variables](https://github.com/docker/distribution/blob/master/docs/configuration.md#override-specific-configuration-options).
+For convenience, we will assume that you have access to the `config.yml` file.
+This is a config example:
+
+{% highlight yaml %}
+version: 0.1
+loglevel: debug
+storage:
+  filesystem:
+    rootdirectory: /var/lib/docker-registry
+  delete:
+    enabled: true
+http:
+  addr: :5000
+  tls:
+    certificate: /etc/nginx/ssl/my.registry.crt
+    key: /etc/nginx/ssl/my.registry.key
+auth:
+  token:
+    realm: https://my.registry/v2/token
+    service: my.registry:5000
+    issuer: my.registry
+    rootcertbundle: /etc/nginx/ssl/my.registry.crt
+notifications:
+  endpoints:
+    - name: portus
+      url: https://my.registry/v2/webhooks/events
+      timeout: 500ms
+      threshold: 5
+      backoff: 1s
+{% endhighlight %}
+
+Some things to note:
+
+- The **loglevel** is set to `debug`. You usually want to relax this as specified
+  [here](https://github.com/docker/distribution/blob/master/docs/configuration.md#log).
+- The **storage** has been configured to be on the filesystem. This is a pretty
+  basic and standard setup, but you can tweak it as much as you need. Just take a
+  look at [this document](https://github.com/docker/distribution/blob/master/docs/configuration.md#storage)
+  to learn all of the supported options. Also note that `deleted` has been set
+  to `true`. Even if this is not a requirement from Portus' side, it might be
+  in the future when removing images is supported.
+- The **http** config is set to listen to the `:5000` port, which is the default
+  value. Also note that in the `tls` configurable value we provide a
+  certificate and a key. This will be used so the communication between the
+  docker daemon and the registry is done through TLS. We *strongly* recommend
+  to use this, otherwise we cannot guarantee that the communication will be
+  secure. Both the key and the certificate will be generated automatically by
+  `portusctl` if you are using the [RPM package](/docs/setups/1_rpm_packages.html).
+  Moreover, you can also find an example
+  [here](/docs/setups/2_appliance.html#distribution-with-tls-for-communicating-with-docker-client)
+  about creating both the key and the certificate in openSUSE.
+- The **auth** value defines the communication between Portus and this
+  registry. Some important things to note:
+  - The **issues** should be the same as the one defined by `machine_fqdn` in
+    the `config/secrets.yml` file. This can be changed with the `PORTUS_MACHINE_FQDN`
+    environment variable.
+  - The **rootcertbundle** should point to the same location as the
+    `encryption_private_key_path` configurable value as defined also in the
+    `config/secrets.yml` file. This can be also tweaked with the `PORTUS_KEY_PATH`
+    environment variable.
+- The **notifications** configuration tells your registry where to send
+  notifications. In this case, you should specify Portus' `/v2/webhooks/events`
+  endpoint. This is used to synchronize the contents of the DB with the
+  registry. You can read more about this
+  [here](/features/1_Synchronizing-the-Registry-and-Portus.html).
+
+## Integrating the Registry with Portus
+
+From now on, we will suppose that a registry has already been created.
+
+### How does Portus authorize requests ?
+
+The next generation of Docker registries (those based on v2.0 or higher) push
+the authorization of requests to an external authorization service. In our
+case, this external authorization service will be Portus. If you would like to
+have a more clear picture about this, take a look at this
+[explanation](https://github.com/docker/distribution/blob/master/docs/spec/auth/token.md#docker-registry-v2-authentication-via-central-service)
+from Docker's documentation.
+
+When Portus receives an authorization request, it gets the following
+information:
+
+- The registry being targeted. Portus has to know the existence of the registry
+  being targeted by the request. This is better explained in this
+  [page](/docs/Configuring-the-registry.html).
+- Who is trying to perform the action. The user must be known to Portus, and
+  Portus will take into consideration whether the user is disabled, locked,
+  etc. If everything is fine, then it will check basic authorization data like
+  the password, etc.
+- Which actions are trying to be performed.
+- What is the target \<namespace\>/\<repo\>. Combining this with the given user
+  and the given action, Portus decides whether the user is authorized to
+  perform such action.
+
+If Portus decides that the user is authorized to perform the action, then it
+sends a JWT token suitable for the docker registry being targeted. You can read
+all the details about the format of this JWT token
+[here](https://github.com/docker/distribution/blob/master/docs/spec/auth/jwt.md).
+
+### Configuring the JWT token sent by Portus
+
+As stated in the previous section, the JWT token is used to handle the
+authentication between Portus and your private registry. There are some
+considerations in regards to this token.
+
+First of all, it needs the `machine_fqdn` secret to be set. You can find this
+in the `config/secrets.yml` file. If you change this file you should restart
+Portus afterwards. Note that in production you can just provide the
+`PORTUS_MACHINE_FQDN` environment variable.
+
+Another thing to consider is the expiration time of the token itself. By
+default it expires in 5 minutes. However, it's possible that the image to be
+uploaded is too big or the communication is too slow; and the upload can take
+more than 5 minutes. If this happens, then the upload will be cancelled from
+the registry's side, and it will fail. This is a known issue, and from Portus'
+side we provide [this workaround](/docs/Configuring-Portus.html#jwt-expiration-time).
+
+### Synchronizing the Registry and Portus
+
+As explained in [this](/features/1_Synchronizing-the-Registry-and-Portus.html)
+page, Portus is able to synchronize the contents of the registry and its
+database. In this regard, there are some considerations to be made.
+
+First of all, note that no synchronization will be made until the admin sets up
+the registry in Portus' database. This is better explained in this
+[page](/docs/Configuring-the-registry.html).
+
+Moreover, in order for this to happen, Portus needs the `portus` user to exist.
+This user is created when setting up Portus for the first time by the admin.
+This is done automatically by the `portusctl` tool if you are using the [provided
+RPM](/docs/setups/1_rpm_packages.html) (or if you are on development mode and
+you are using either the docker compose setup or the vagrant setup). If this is
+not your case, you have to create it after migrating the database by performing:
+
+    $ rake db:seed
+
+or
+
+    $ rake portus:create_api_account
+
+Note that neither of these commands will work if you have not set the
+`portus_password` secret value in the `config/secrets.yml` file. This value can
+be set on production with the environment variable `PORTUS_PASSWORD`.

--- a/_docs/how_we_release.md
+++ b/_docs/how_we_release.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Portus Releases
+order: 4
 longtitle: How we release Portus
 ---
 

--- a/_features/1_Synchronizing-the-Registry-and-Portus.md
+++ b/_features/1_Synchronizing-the-Registry-and-Portus.md
@@ -2,6 +2,7 @@
 layout: post
 title: Synchonizing the Registry and Portus
 longtitle: Synchronization with your private registry in order to fetch which images and tags are available
+order: 1
 ---
 
 ## Webhooks

--- a/_features/2_LDAP-support.md
+++ b/_features/2_LDAP-support.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: LDAP support
+order: 2
 longtitle: LDAP user authentication
 ---
 

--- a/_features/3_teams_namespaces_and_users.md
+++ b/_features/3_teams_namespaces_and_users.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Teams, namespaces and users
+order: 3
 longtitle: Fine-grained control of permissions
 ---
 

--- a/_features/4_audit.md
+++ b/_features/4_audit.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Audit
+order: 4
 longtitle: Monitoring of all the activities performed onto your private registry and Portus itself
 ---
 

--- a/_features/5_search.md
+++ b/_features/5_search.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Search
+order: 5
 longtitle: Search for repositories and tags inside of your private registry
 ---
 

--- a/_features/6_starring.md
+++ b/_features/6_starring.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Starring repositories
+order: 6
 longtitle: Star your favorite repositories
 ---
 

--- a/_features/7_disabling_users.md
+++ b/_features/7_disabling_users.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Disabling users
+order: 7
 longtitle: Disable users temporarily
 ---
 

--- a/_features/8_locking.md
+++ b/_features/8_locking.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Locking accounts for safety reasons
+order: 8
 longtitle: Users that fail at logging in too many times will have their account locked
 ---
 

--- a/_features/9_recovering_password.md
+++ b/_features/9_recovering_password.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Recovering the password
+order: 9
 longtitle: Users can recover their password if they forgot it
 ---
 

--- a/_features/disabling_signup.md
+++ b/_features/disabling_signup.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Disabling the sign up form
+order: 10
 longtitle: Disable the possibility of users signing up on their own
 ---
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -50,7 +50,8 @@
         <aside class="col-xs-3 aside-max">
           <h4>Documentation</h4>
           <ul>
-            {% for d in site.docs %}
+            {% assign docs = (site.docs | sort: 'order') %}
+            {% for d in docs %}
               <li>
                 <a href="{{ d.url | prepend: site.baseurl }}">
                   {{ d.title }}
@@ -60,7 +61,8 @@
           </ul>
           <h4>Setups</h4>
           <ul>
-            {% for s in site.setups %}
+            {% assign setups = (site.setups | sort: 'order') %}
+            {% for s in setups %}
               <li>
                 <a href="{{ s.url | prepend: site.baseurl }}">
                   {{ s.title }}
@@ -70,7 +72,8 @@
           </ul>
           <h4>Features</h4>
             <ul>
-            {% for f in site.features %}
+            {% assign features = (site.features | sort: 'order') %}
+            {% for f in features %}
               <li>
                 <a href="{{ f.url | prepend: site.baseurl }}">
                   {{ f.title }}

--- a/_setups/1_rpm_packages.md
+++ b/_setups/1_rpm_packages.md
@@ -1,5 +1,6 @@
 ---
 title: RPM packages
+order: 1
 layout: post
 ---
 

--- a/_setups/2_appliance.md
+++ b/_setups/2_appliance.md
@@ -1,5 +1,6 @@
 ---
 layout: post
+order: 2
 title: openSUSE Appliance
 ---
 

--- a/_setups/3_nginx_bare_metal.md
+++ b/_setups/3_nginx_bare_metal.md
@@ -1,5 +1,6 @@
 ---
 title: NGinx + Thin/Puma
+order: 3
 layout: post
 ---
 

--- a/_setups/4_portus_and_registry_on_the_same_fqdn.md
+++ b/_setups/4_portus_and_registry_on_the_same_fqdn.md
@@ -1,5 +1,6 @@
 ---
 layout: post
+order: 4
 title: Portus and the registry on the same FQDN using sub URI
 ---
 

--- a/documentation.md
+++ b/documentation.md
@@ -6,7 +6,8 @@ layout: post
 
 On this page you can find information about:
 
-{% for d in site.docs %}
+{% assign docs = (site.docs | sort: 'order') %}
+{% for d in docs %}
 - [{{ d.longtitle }}]({{ d.url }}).
 {% endfor %}
 

--- a/features.md
+++ b/features.md
@@ -9,6 +9,7 @@ Portus is an open source authorization service and user interface for the next
 generation Docker Registry. Portus has been enhanced over time with notable
 features. These being:
 
-{% for f in site.features %}
+{% assign features = (site.features | sort: 'order') %}
+{% for f in features %}
 - [{{ f.longtitle }}]({{ f.url }}).
 {% endfor %}


### PR DESCRIPTION
I've also added the `order` header for all pages, to keep a more sane approach to how we list pages. Moreover, I've also extended the documentation on how to setup this branch for development.