### PR TITLE
docker-compose: fix Portus when using compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,6 @@ registry:
     - ./docker/registry:/registry
     - /registry_data
   entrypoint: /registry/entry.sh
-  env_file: docker/environment
   links:
     - web
   ports:

--- a/docker/compose-common.yml
+++ b/docker/compose-common.yml
@@ -5,5 +5,6 @@ web:
     - "3000:3000"
 registry:
   image: library/registry:2.1.1
+  env_file: environment
   ports:
     - "5000:5000"


### PR DESCRIPTION
Fix DOCKER_HOST not being populated properly when using docker-compose,
resulting in users not being able to to use Portus with the compose
setup.

Signed-off-by: Aleksa Sarai <asarai@suse.com>