### PR TITLE
Add Navalia to the local configuration file

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -99,3 +99,11 @@ check_ssl_usage:
 # See: https://github.com/SUSE/Portus/issues/510
 jwt_expiration_time:
   value: "5.minutes"
+
+# The "Navalia" service allows Portus to have automated buid images from
+# known Dockerfiles.
+# The service is disabled by default. It's recommended to change this setting
+# either via environment variable or by config-local.yml
+navalia:
+  enabled: false
+  address: navalia.test.lan


### PR DESCRIPTION
Make it possible to configure the location of the Navalia service.

Signed-off-by: Flavio Castelli <fcastelli@suse.com>