### PR TITLE
Move create namespace link

### DIFF
--- a/app/views/namespaces/index.html.slim
+++ b/app/views/namespaces/index.html.slim
@@ -3,6 +3,27 @@ span
     i.fa.fa-info-circle
     | What's this?
 
+.panel.panel-default
+  .panel-heading
+    h5
+      ' Special namespaces
+  .panel-body
+    .table-responsive
+      table.table.table-stripped.table-hover
+        col.col-40
+        col.col-30
+        col.col-20
+        col.col-10
+        thead
+          tr
+            th Name
+            th Repositories
+            th Created
+            th Public
+        tbody
+          - @special_namespaces.each do |namespace|
+            = render partial: 'namespaces/namespace', locals: {namespace: namespace}
+
 - if Registry.any?
   #add_namespace_form.collapse
     = form_for :namespace, url: namespaces_path, remote: true, html: {id: 'new-namespace-form', class: 'form-horizontal', role: 'form'} do |f|
@@ -23,37 +44,15 @@ span
           .col-md-offset-2.col-md-7
             = f.submit('Create', class: 'btn btn-primary')
 
-
 .panel.panel-default
   .panel-heading
     h5
-      ' Special namespaces
+      ' Namespaces you have access to
       - if Registry.any?
         .pull-right
           a#add_namespace_btn.btn.btn-xs.btn-link.js-toggle-button[role="button"]
             i.fa.fa-plus-circle
             | Create new namespace
-  .panel-body
-    .table-responsive
-      table.table.table-stripped.table-hover
-        col.col-40
-        col.col-30
-        col.col-20
-        col.col-10
-        thead
-          tr
-            th Name
-            th Repositories
-            th Created
-            th Public
-        tbody
-          - @special_namespaces.each do |namespace|
-            = render partial: 'namespaces/namespace', locals: {namespace: namespace}
-
-.panel.panel-default
-  .panel-heading
-    h5
-      ' Namespaces you have access to
   .panel-body
     .table-responsive
       table.table.table-stripped.table-hover

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -22,7 +22,7 @@ describe CommentsController, type: :controller do
     { foo: "not valid" }
   end
 
-  describe "PUT #create" do
+  describe "POST #create" do
     context "with valid params" do
       it "creates a new comment" do
         sign_in owner


### PR DESCRIPTION
Move the "create namespace" link

The link has been moved inside of the "Namespaces you have access to" container as opposed to the "Special namespaces" one.

It makes more sense to have the link in there because the new namespaces that can be created are not going to be special ones.

## Before
![before](https://cloud.githubusercontent.com/assets/22728/11682885/d5f90f48-9e67-11e5-87b4-00dfc373d489.png)

## After

![after](https://cloud.githubusercontent.com/assets/22728/11682886/d5fdd762-9e67-11e5-96f2-589fb5e94f7a.png)

