### PR TITLE
Introduce application tokens

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,10 @@ gem "redcarpet"
 gem "font-awesome-rails"
 gem "bootstrap-typeahead-rails"
 
+# Used to store application tokens. This is already a Rails depedency. However
+# better safe than sorry...
+gem "bcrypt"
+
 # This is already a Rails dependency, but we use it to run portusctl
 gem "thor"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -320,6 +320,7 @@ DEPENDENCIES
   active_record_union
   awesome_print
   base32
+  bcrypt
   bootstrap-sass (~> 3.3.4)
   bootstrap-typeahead-rails
   byebug

--- a/app/assets/javascripts/registrations.coffee
+++ b/app/assets/javascripts/registrations.coffee
@@ -1,0 +1,12 @@
+$(document).on "page:change", ->
+  $('#add_application_token_btn').on 'click', (event) ->
+      $('#add_application_token_form').toggle 400, "swing", ->
+        if $('#add_application_token_form').is(':visible')
+          $('#add_team_btn i').addClass("fa-minus-circle")
+          $('#add_team_btn i').removeClass("fa-plus-circle")
+          $('#team_name').focus()
+          layout_resizer()
+        else
+          $('#add_team_btn i').removeClass("fa-minus-circle")
+          $('#add_team_btn i').addClass("fa-plus-circle")
+          layout_resizer()

--- a/app/assets/stylesheets/activities.scss
+++ b/app/assets/stylesheets/activities.scss
@@ -71,6 +71,12 @@
       &.change-description {
         background: $activity-change-description;
       }
+      &.application-token-created {
+        background: $activity-application-token-created;
+      }
+      &.application-token-destroyed {
+        background: $activity-application-token-destroyed;
+      }
     }
   }
 }

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -81,6 +81,8 @@ $activity-remove-member-team:            $yellow;
 $activity-change-role:                   $orange;
 $activity-team-created:                  $pink;
 $activity-repo-pushed:                   $purple;
+$activity-application-token-created:     $orange-dark;
+$activity-application-token-destroyed:   $red;
 
 
 // placeholder

--- a/app/controllers/application_tokens_controller.rb
+++ b/app/controllers/application_tokens_controller.rb
@@ -1,0 +1,39 @@
+# ApplicationTokensController manages the creation/removal of application tokens
+class ApplicationTokensController < ApplicationController
+  respond_to :js
+
+  # POST /application_tokens
+  def create
+    @plain_token = Devise.friendly_token
+
+    @application_token = ApplicationToken.new(create_params)
+    @application_token.user = current_user
+    @application_token.token_salt = BCrypt::Engine.generate_salt
+    @application_token.token_hash = BCrypt::Engine.hash_secret(
+      @plain_token,
+      @application_token.token_salt)
+
+    if @application_token.save
+      @application_token.create_activity!(:create, current_user)
+      respond_with @application_token
+    else
+      respond_with @application_token.errors, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE /application_token/1
+  def destroy
+    @application_token = ApplicationToken.find(params[:id])
+    @application_token.create_activity!(:destroy, current_user)
+    @application_token.destroy
+
+    respond_with @application_token
+  end
+
+  private
+
+  def create_params
+    permitted = [:application]
+    params.require(:application_token).permit(permitted)
+  end
+end

--- a/app/models/application_token.rb
+++ b/app/models/application_token.rb
@@ -1,0 +1,25 @@
+class ApplicationToken < ActiveRecord::Base
+  include PublicActivity::Common
+
+  belongs_to :user
+
+  validates :application, uniqueness: { scope: "user_id" }
+
+  validate :limit_number_of_tokens_per_user, on: :create
+
+  def limit_number_of_tokens_per_user
+    max_reached =  ApplicationToken.where(user_id: user_id).count >= User::APPLICATION_TOKENS_MAX
+    errors.add(
+      :base,
+      "Users cannot have more than #{User::APPLICATION_TOKENS_MAX} " \
+      "application tokens") if max_reached
+  end
+
+  # Create the activity regarding this application token.
+  def create_activity!(type, owner)
+    create_activity(
+      type,
+      owner:      owner,
+      parameters: { application: application })
+  end
+end

--- a/app/policies/public_activity/activity_policy.rb
+++ b/app/policies/public_activity/activity_policy.rb
@@ -37,7 +37,16 @@ class PublicActivity::ActivityPolicy
                "(team_users.user_id = ? OR namespaces.public = ?)",
                "Repository", user.id, true)
 
-      team_activities.union_all(namespace_activities).union_all(repository_activities).distinct
+      # Show application tokens activities related only to the current user
+      application_token_activities = @scope
+        .where("activities.trackable_type = ? AND activities.owner_id = ?",
+               "ApplicationToken", user.id)
+
+      team_activities
+        .union_all(namespace_activities)
+        .union_all(repository_activities)
+        .union_all(application_token_activities)
+        .distinct
     end
   end
 end

--- a/app/views/application_tokens/_application_token.html.slim
+++ b/app/views/application_tokens/_application_token.html.slim
@@ -1,0 +1,13 @@
+tr id="application_token_#{application_token.id}"
+  td= application_token.application
+  td
+    a[class="btn btn-default"
+      data-placement="left"
+      data-toggle="popover"
+      data-title="Please confirm"
+      data-content='<p>Are you sure you want to remove this token?</p><a class="btn btn-default">No</a> <a class="btn btn-primary" data-method="delete" rel="nofollow" data-remote="true" href="#{url_for(application_token)}">Yes</a>'
+      data-html="true"
+      tabindex="0"
+      role="button"
+      ]
+      i.fa.fa-trash.fa-lg

--- a/app/views/application_tokens/create.js.erb
+++ b/app/views/application_tokens/create.js.erb
@@ -1,0 +1,13 @@
+<% if @application_token.errors.any? %>
+  $('#alert p').html("<%= escape_javascript(@application_token.errors.full_messages.join('<br/>')) %>");
+  $('#alert').fadeIn();
+<% else %>
+  $("<%= escape_javascript(render @application_token) %>").appendTo("#application_tokens");
+  $('#alert p').html("New token created: <code><%= @plain_token %></code>");
+  $('#alert').fadeIn();
+  $('#add_application_token_form').fadeOut();
+  <% if current_user.application_tokens.count >= User::APPLICATION_TOKENS_MAX %>
+    $('#add_application_token_btn').attr("disabled", "disabled");
+  <% end %>
+<% end %>
+

--- a/app/views/application_tokens/destroy.js.erb
+++ b/app/views/application_tokens/destroy.js.erb
@@ -1,0 +1,11 @@
+<% if @application_token.errors.any? %>
+  $('#alert p').html("<%= escape_javascript(@application_token.errors.full_messages.join('<br/>')) %>");
+  $('#alert').fadeIn();
+<% else %>
+  $("#application_token_<%= @application_token.id %>").remove();
+  $('#alert p').html("<em>\"<%= @application_token.application %>\"</em> token has been removed");
+  $('#alert').fadeIn();
+  <% if current_user.application_tokens.count < User::APPLICATION_TOKENS_MAX %>
+    $('#add_application_token_btn').removeAttr("disabled");
+  <% end %>
+<% end %>

--- a/app/views/devise/registrations/edit.html.slim
+++ b/app/views/devise/registrations/edit.html.slim
@@ -20,6 +20,41 @@
             .actions
               = f.submit('Update', class: 'btn btn-primary', disabled: true)
 
+    #add_application_token_form.collapse
+      = form_for :application_token, url: application_tokens_path, remote: true, html: {id: 'new-application-token-form', class: 'form-horizontal', role: 'form'} do |f|
+          .form-group
+            = f.label :application, {class: 'control-label col-md-2'}
+            .col-md-7
+              = f.text_field(:application, class: 'form-control', required: true, placeholder: "Application's name")
+          .form-group
+            .col-md-offset-2.col-md-7
+              = f.submit('Create', class: 'btn btn-primary')
+
+    .panel.panel-default
+      .panel-heading
+        h5
+          ' Application tokens
+          .pull-right
+            a#add_application_token_btn.btn.btn-xs.btn-link.js-toggle-button[
+              disabled="#{current_user.application_tokens.count >= User::APPLICATION_TOKENS_MAX ? 'disabled' : ''}"
+              role="button"
+              ]
+              i.fa.fa-plus-circle
+              | Create new token
+      .panel-body
+        .table-responsive
+          table.table.table-striped.table-hover
+            colgroup
+              col.col-90
+              col.col-10
+            thead
+              tr
+                th Application
+                th Remove
+            tbody#application_tokens
+              - current_user.application_tokens.each do |token|
+                = render partial: 'application_tokens/application_token', locals: {application_token: token}
+
     - if current_user.email?
       - unless current_user.admin? && @admin_count == 1
         .panel.panel-default

--- a/app/views/public_activity/application_token/_create.csv.slim
+++ b/app/views/public_activity/application_token/_create.csv.slim
@@ -1,0 +1,1 @@
+= CSV.generate_line(["application token", "#{activity.parameters[:application]}", "create", "-", activity.owner.username, activity.created_at, "-"])

--- a/app/views/public_activity/application_token/_create.html.slim
+++ b/app/views/public_activity/application_token/_create.html.slim
@@ -1,0 +1,15 @@
+li
+  .activity-type.application-token-created
+    i.fa.fa-key
+  .user-image
+    = user_image_tag(activity.owner.email)
+  .description
+    h6
+      strong
+        = activity.owner.username
+        |  created a token for the "
+        em= activity.parameters[:application]
+        | " application
+    small
+      i.fa.fa-clock-o
+      = activity_time_tag activity.created_at

--- a/app/views/public_activity/application_token/_destroy.csv.slim
+++ b/app/views/public_activity/application_token/_destroy.csv.slim
@@ -1,0 +1,1 @@
+= CSV.generate_line(["application token", "#{activity.parameters[:application]}", "destroy", "-", activity.owner.username, activity.created_at, "-"])

--- a/app/views/public_activity/application_token/_destroy.html.slim
+++ b/app/views/public_activity/application_token/_destroy.html.slim
@@ -1,0 +1,15 @@
+li
+  .activity-type.application-token-destroyed
+    i.fa.fa-key
+  .user-image
+    = user_image_tag(activity.owner.email)
+  .description
+    h6
+      strong
+        = activity.owner.username
+        |  removed the token of "
+        em= activity.parameters[:application]
+        | " application
+    small
+      i.fa.fa-clock-o
+      = activity_time_tag activity.created_at

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,8 @@ Rails.application.routes.draw do
     resources :comments, only: [:create, :destroy]
   end
 
+  resources :application_tokens, only: [:create, :destroy]
+
   devise_for :users, controllers: { registrations: "auth/registrations",
                                     sessions:      "auth/sessions",
                                     passwords:     "passwords" }

--- a/db/migrate/20151117181723_create_application_tokens.rb
+++ b/db/migrate/20151117181723_create_application_tokens.rb
@@ -1,0 +1,12 @@
+class CreateApplicationTokens < ActiveRecord::Migration
+  def change
+    create_table :application_tokens do |t|
+      t.string :application, null: false
+      t.string :token_hash, null:false
+      t.string :token_salt, null:false
+      t.integer :user_id, null:false
+    end
+
+    add_index :application_tokens, :user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151124150353) do
+ActiveRecord::Schema.define(version: 20151207153613) do
 
   create_table "activities", force: :cascade do |t|
     t.integer  "trackable_id",   limit: 4
@@ -30,6 +30,15 @@ ActiveRecord::Schema.define(version: 20151124150353) do
   add_index "activities", ["owner_id", "owner_type"], name: "index_activities_on_owner_id_and_owner_type", using: :btree
   add_index "activities", ["recipient_id", "recipient_type"], name: "index_activities_on_recipient_id_and_recipient_type", using: :btree
   add_index "activities", ["trackable_id", "trackable_type"], name: "index_activities_on_trackable_id_and_trackable_type", using: :btree
+
+  create_table "application_tokens", force: :cascade do |t|
+    t.string  "application", limit: 255, null: false
+    t.string  "token_hash",  limit: 255, null: false
+    t.string  "token_salt",  limit: 255, null: false
+    t.integer "user_id",     limit: 4,   null: false
+  end
+
+  add_index "application_tokens", ["user_id"], name: "index_application_tokens_on_user_id", using: :btree
 
   create_table "comments", force: :cascade do |t|
     t.text     "body",          limit: 65535
@@ -85,6 +94,7 @@ ActiveRecord::Schema.define(version: 20151124150353) do
     t.integer  "namespace_id", limit: 4
     t.datetime "created_at",                            null: false
     t.datetime "updated_at",                            null: false
+    t.string   "source_url",   limit: 255, default: "", null: false
   end
 
   add_index "repositories", ["name", "namespace_id"], name: "index_repositories_on_name_and_namespace_id", unique: true, using: :btree

--- a/spec/controllers/application_tokens_controller_spec.rb
+++ b/spec/controllers/application_tokens_controller_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+describe ApplicationTokensController do
+  let(:user)       { create(:user) }
+
+  before :each do
+    sign_in user
+  end
+
+  describe "POST #create" do
+    let(:application) { "test application" }
+
+    it "creates the token" do
+      expect do
+        post :create, application_token: { application: application }, format: "js"
+      end.to change(user.application_tokens, :count).by(1)
+    end
+
+    it "creates an activity event" do
+      expect do
+        post :create, application_token: { application: application }, format: "js"
+      end.to change(PublicActivity::Activity, :count).by(1)
+
+      activity = PublicActivity::Activity.last
+      expect(activity.owner).to eq(user)
+      expect(activity.parameters[:application]).to eq(application)
+    end
+
+    it "responds with unprocessable entity when the token cannot be created" do
+      create(:application_token, application: application, user: user)
+      expect do
+        post :create, application_token: { application: application }, format: "js"
+      end.to change(user.application_tokens, :count).by(0)
+
+      expect(response.status).to be 422
+    end
+
+  end
+
+  describe "DELETE #destroy" do
+    it "removes the token" do
+      token = create(:application_token, user: user)
+      expect do
+        delete :destroy, id: token.id, format: "js"
+      end.to change(user.application_tokens, :count).by(-1)
+    end
+
+    it "creates an activity event" do
+      token = create(:application_token, user: user)
+      expect do
+        delete :destroy, id: token.id, format: "js"
+      end.to change(PublicActivity::Activity, :count).by(1)
+
+      activity = PublicActivity::Activity.last
+      expect(activity.owner).to eq(user)
+      expect(activity.parameters[:application]).to eq(token.application)
+    end
+  end
+
+end

--- a/spec/factories/activities.rb
+++ b/spec/factories/activities.rb
@@ -52,4 +52,18 @@ FactoryGirl.define do
     recipient_type "Tag"
   end
 
+  factory :activity_application_token_created, class: PublicActivity::Activity do
+    trackable_type "ApplicationToken"
+    owner_type "User"
+    key "application_token.created"
+    parameters Hash.new(application: "test application")
+  end
+
+  factory :activity_application_token_destroyed, class: PublicActivity::Activity do
+    trackable_type "ApplicationToken"
+    owner_type "User"
+    key "application_token.destroyed"
+    parameters Hash.new(application: "test application")
+  end
+
 end

--- a/spec/factories/application_token.rb
+++ b/spec/factories/application_token.rb
@@ -1,0 +1,13 @@
+FactoryGirl.define do
+  factory :application_token do
+    sequence :application do |i|
+      "application #{i}"
+    end
+
+    # the plain token is application
+    token_salt { BCrypt::Engine.generate_salt }
+    token_hash { BCrypt::Engine.hash_secret(application, token_salt) }
+
+    association :user, factory: :user
+  end
+end

--- a/spec/features/application_tokens_spec.rb
+++ b/spec/features/application_tokens_spec.rb
@@ -1,0 +1,100 @@
+require "rails_helper"
+
+feature "Application tokens" do
+  let!(:user) { create(:user) }
+
+  before do
+    login_as user, scope: :user
+  end
+
+  describe "ApplicationTokens#create" do
+    scenario "As an user I can create a new token", js: true do
+      expect(user.application_tokens).to be_empty
+
+      visit edit_user_registration_path
+      find("#add_application_token_btn").click
+      fill_in "Application", with: "awesome-application"
+      wait_for_effect_on("#add_application_token_form")
+
+      click_button "Create"
+      wait_for_ajax
+      wait_for_effect_on("#add_application_token_form")
+
+      expect(user.application_tokens.count).to be(1)
+      expect(current_path).to eql edit_user_registration_path
+
+      wait_for_effect_on("#alert")
+      expect(page).to have_content("New token created")
+      expect(page).to have_content("awesome-application")
+    end
+
+    scenario "As an user I cannot create two tokens with the same name", js: true do
+      create(:application_token, application: "awesome-application", user: user)
+
+      visit edit_user_registration_path
+      find("#add_application_token_btn").click
+      fill_in "Application", with: "awesome-application"
+      wait_for_effect_on("#add_application_token_form")
+
+      click_button "Create"
+      wait_for_ajax
+      wait_for_effect_on("#add_application_token_form")
+
+      expect(user.application_tokens.count).to be(1)
+      expect(current_path).to eql edit_user_registration_path
+
+      wait_for_effect_on("#alert")
+      expect(page).to have_content("Application has already been taken")
+    end
+
+    scenario "As an user the create new token link is disabled when I reach the limit", js: true do
+      (User::APPLICATION_TOKENS_MAX - 1).times do
+        create(:application_token, user: user)
+      end
+
+      visit edit_user_registration_path
+      find("#add_application_token_btn").click
+      fill_in "Application", with: "awesome-application"
+      wait_for_effect_on("#add_application_token_form")
+
+      click_button "Create"
+      wait_for_ajax
+      wait_for_effect_on("#add_application_token_form")
+
+      expect(current_path).to eql edit_user_registration_path
+
+      wait_for_effect_on("#alert")
+      expect(page).to have_content("New token created")
+      expect(page).to have_content("awesome-application")
+      expect(disabled?("#add_application_token_btn")).to be true
+    end
+
+    scenario "As an user I cannot create tokens once I reach my limit", js: true do
+      User::APPLICATION_TOKENS_MAX.times do
+        create(:application_token, user: user)
+      end
+
+      visit edit_user_registration_path
+      expect(disabled?("#add_application_token_btn")).to be true
+    end
+  end
+
+  describe "ApplicationTokens#destroy" do
+    scenario "As an user I can revoke a token", js: true do
+      token = create(:application_token, user: user)
+
+      visit edit_user_registration_path
+
+      find("#application_token_#{token.id} a.btn").click
+      # I don't know how to wait for popovers, since they're created entirely
+      # with JS
+      sleep 0.5
+      find(".popover-content .btn-primary").click
+
+      wait_for_ajax
+      wait_for_effect_on("#alert")
+
+      expect(page).to have_content("token has been removed")
+    end
+  end
+end

--- a/spec/models/application_token_spec.rb
+++ b/spec/models/application_token_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+describe ApplicationToken do
+  context "validator" do
+    let(:user) { create(:user) }
+
+    it "checks for the uniqueness of application" do
+      create(:application_token, application: "test", user: user)
+      expect do
+        ApplicationToken.create!(
+          application: "test",
+          token_hash:  "hash",
+          token_salt:  "salt",
+          user:        user
+        )
+      end.to raise_error(ActiveRecord::RecordInvalid, /Application has already been taken/)
+    end
+
+    it "allows the same application name to be reaused by different users" do
+      create(:application_token, application: "test", user: user)
+
+      user2 = create(:user)
+      expect do
+        ApplicationToken.create!(
+          application: "test",
+          token_hash:  "hash",
+          token_salt:  "salt",
+          user:        user2
+        )
+      end.not_to raise_error
+    end
+
+    it "checks for the number of tokens created by an user" do
+      User::APPLICATION_TOKENS_MAX.times do
+        create(:application_token, user: user)
+      end
+
+      expect do
+        ApplicationToken.create!(
+          application: "test",
+          token_hash:  "hash",
+          token_salt:  "salt",
+          user:        user
+        )
+      end.to raise_error(
+        ActiveRecord::RecordInvalid,
+        /Users cannot have more than #{User::APPLICATION_TOKENS_MAX} application tokens/)
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -190,4 +190,25 @@ describe User do
       end
     end
   end
+
+  describe "#application_token_valid?" do
+    let(:user) { create(:user) }
+
+    it "returns false when there are no tokens" do
+      expect(user.application_token_valid?("foo")).to be false
+    end
+
+    it "returns true when there's a token matching" do
+      # the factory uses appication's name as plain token
+      create(:application_token, application: "good", user: user)
+      create(:application_token, application: "bad", user: user)
+      expect(user.application_token_valid?("good")).to be true
+    end
+
+    it "returns false when there's no token matching" do
+      # the factory uses appication's name as plain token
+      create(:application_token, application: "bad", user: user)
+      expect(user.application_token_valid?("good")).to be false
+    end
+  end
 end

--- a/spec/policies/public_activity/activity_policy_spec.rb
+++ b/spec/policies/public_activity/activity_policy_spec.rb
@@ -107,7 +107,19 @@ describe PublicActivity::ActivityPolicy do
         create(:activity_repository_push,
                trackable_id: tag.repository.id,
                recipient_id: tag.id,
-               owner_id:     activity_owner.id)
+               owner_id:     activity_owner.id),
+        create_activity_application_token_created(user)
+      ]
+
+      expect(Pundit.policy_scope(user, PublicActivity::Activity).to_a).to match_array(activities)
+    end
+
+    it "returns pertinent application token activities" do
+      # application token owned by another user
+      create_activity_application_token_created(create(:user))
+
+      activities = [
+        create_activity_application_token_created(user)
       ]
 
       expect(Pundit.policy_scope(user, PublicActivity::Activity).to_a).to match_array(activities)
@@ -144,6 +156,13 @@ describe PublicActivity::ActivityPolicy do
            owner_id:     event_owner.id,
            recipient_id: member.id,
            parameters:   { old_role: old_role, new_role: new_role })
+  end
+
+  def create_activity_application_token_created(owner)
+    token = create(:application_token, user: owner)
+    create(:activity_application_token_created,
+           trackable_id: token.id,
+           owner_id:     owner.id)
   end
 
 end


### PR DESCRIPTION
Right now the Docker client stores the credentials in plain
format on the host. This is really bad from a security point of view,
especially for users using LDAP to authenticated.

This commit introduces the concept of "application tokens". Each user
can have at most 5 application tokens. The tokens are created in a
random secure way by Portus and are stored inside of its database after
being hashed via bcrypt.

The application tokens can be used by all the programs authenticating
against a Docker registry protected by Portus (e.g.: the docker cli
client). They cannot be used to log into Portus' web interface.

The application tokens can be revoked at any time by using a new UI.

## Screenshots

### Token management UI
![new-token](https://cloud.githubusercontent.com/assets/22728/11692418/a19d819c-9e9f-11e5-97d2-310128328a81.png)

Notice a new token has just been created

### Token removal

![tag-remove](https://cloud.githubusercontent.com/assets/22728/11692419/a19f3294-9e9f-11e5-9817-ab884a6c0e06.png)

After the token has been removed:
![tag-removed](https://cloud.githubusercontent.com/assets/22728/11692421/a1aa089a-9e9f-11e5-8692-36d5d9ce8b08.png)

### Token limit reached

This user has already 5 tokens, hence he cannot add new ones:
![token-disabled](https://cloud.githubusercontent.com/assets/22728/11692420/a1a665f0-9e9f-11e5-8c74-f90641b89701.png)
