### PR TITLE
Audit: track more events related with repositories

### DIFF
--- a/app/assets/stylesheets/activities.scss
+++ b/app/assets/stylesheets/activities.scss
@@ -50,6 +50,12 @@
       &.repo-pushed {
         background: $activity-repo-pushed;
       }
+      &.repo-automated-created{
+        background: $activity-repo-automated-created;
+      }
+      &.repo-edit{
+        background: $activity-repo-edit;
+      }
       &.team-created {
         background: $activity-team-created;
       }

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -81,6 +81,9 @@ $activity-remove-member-team:            $yellow;
 $activity-change-role:                   $orange;
 $activity-team-created:                  $pink;
 $activity-repo-pushed:                   $purple;
+$activity-repo-automated-created:        $pink;
+$activity-repo-edit:                     $orange;
+
 
 
 // placeholder

--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -37,6 +37,10 @@ class RepositoriesController < ApplicationController
 
     if @repository.save
       flash[:notice] = "Automated repository created successfully!"
+      @repository.create_activity(
+        :create,
+        owner:      current_user,
+        parameters: { source_url: @repository.source_url })
       redirect_to @repository
     else
       flash[:alert] = @repository.errors.full_messages
@@ -56,7 +60,18 @@ class RepositoriesController < ApplicationController
     @repository = Repository.find(params[:id])
     authorize @repository
 
+    old_source = @repository.source_url
+
     @repository.update_attributes(update_params)
+
+    @repository.create_activity(
+      :edit,
+      owner:      current_user,
+      parameters: {
+        new_source: @repository.source_url,
+        old_source: old_source
+      }
+    )
     redirect_to @repository, notice: "Repository updated successfully!"
   end
 

--- a/app/helpers/repositories_helper.rb
+++ b/app/helpers/repositories_helper.rb
@@ -2,6 +2,49 @@
 # them, dangling repositories that used to contain them. Because of this, this
 # helper renders the proper HTML for push activities, while being safe at it.
 module RepositoriesHelper
+  # Renders a create activity, that is, an automated repository has just been created
+  def render_create_activity(activity)
+    owner = content_tag(:strong, "#{fetch_owner(activity)} created ")
+
+    namespace = render_namespace(activity)
+    namespace += " / " unless namespace.empty?
+
+    source_url = content_tag(:code, activity.parameters[:source_url])
+
+    owner + namespace + render_repository(activity) + " with source URL set to " + source_url
+  end
+
+  # Renders a edit activity, that is, a repository has just been edited
+  def render_edit_activity(activity)
+    owner = content_tag(:strong, "#{fetch_owner(activity)} edited ")
+
+    namespace = render_namespace(activity)
+    namespace += " / " unless namespace.empty?
+
+    old_source = activity.parameters[:old_source]
+    new_source = activity.parameters[:new_source]
+
+    message = ActiveSupport::SafeBuffer.new("")
+
+    if old_source.blank?
+      unless new_source.blank?
+        message << " set source URL to "
+        message << content_tag(:code, new_source)
+      end
+    else
+      if new_source.blank?
+        message = " making it a non-automated repository"
+      else
+        message << " changing source URL from "
+        message << content_tag(:code, old_source)
+        message << " to "
+        message << content_tag(:code, new_source)
+      end
+    end
+
+    owner + namespace + render_repository(activity) + message
+  end
+
   # Renders a push activity, that is, a repository has been pushed.
   def render_push_activity(activity)
     owner = content_tag(:strong, "#{fetch_owner(activity)} pushed ")

--- a/app/views/public_activity/repository/_create.csv.slim
+++ b/app/views/public_activity/repository/_create.csv.slim
@@ -1,0 +1,5 @@
+- unless activity.trackable.nil?
+  - if activity.recipient.nil?
+    = CSV.generate_line(['repository', "#{activity.trackable.namespace.global? ? activity.trackable.namespace.registry.hostname : activity.trackable.namespace.name}/#{activity.trackable.name}", 'create', '-', activity.owner.username, activity.created_at, "source url #{activity.parameters[:source_url]}"])
+  - else
+    = CSV.generate_line(['repository', "#{activity.trackable.namespace.global? ? activity.trackable.namespace.registry.hostname : activity.trackable.namespace.name}/#{activity.trackable.name}:#{activity.recipient.name}", 'create', '-', activity.owner.username, activity.created_at, "source url #{activity.parameters[:source_url]}"])

--- a/app/views/public_activity/repository/_create.html.slim
+++ b/app/views/public_activity/repository/_create.html.slim
@@ -1,0 +1,11 @@
+li
+  .activity-type.repo-automated-created
+    i.fa.fa-code
+  .user-image
+    = user_image_tag(activity.owner.email)
+  .description
+    h6
+      = render_create_activity(activity)
+    small
+      i.fa.fa-clock-o
+      = activity_time_tag activity.created_at

--- a/app/views/public_activity/repository/_edit.csv.slim
+++ b/app/views/public_activity/repository/_edit.csv.slim
@@ -1,0 +1,5 @@
+- unless activity.trackable.nil?
+  - if activity.recipient.nil?
+    = CSV.generate_line(['repository', "#{activity.trackable.namespace.global? ? activity.trackable.namespace.registry.hostname : activity.trackable.namespace.name}/#{activity.trackable.name}", 'edit', '-', activity.owner.username, activity.created_at, "old source #{activity.parameters[:old_source].blank? ? 'not set' : activity.parameters[:old_source]} - new source #{activity.parameters[:new_source].blank? ? 'not set' : activity.parameters[:new_source]}"])
+  - else
+    = CSV.generate_line(['repository', "#{activity.trackable.namespace.global? ? activity.trackable.namespace.registry.hostname : activity.trackable.namespace.name}/#{activity.trackable.name}:#{activity.recipient.name}", 'create', '-', activity.owner.username, activity.created_at, "old source #{activity.parameters[:old_source].blank? ? 'not set' : activity.parameters[:old_source]} - new source #{activity.parameters[:new_source].blank? ? 'not set' : activity.parameters[:new_source]}"])

--- a/app/views/public_activity/repository/_edit.html.slim
+++ b/app/views/public_activity/repository/_edit.html.slim
@@ -1,0 +1,11 @@
+li
+  .activity-type.repo-edit
+    i.fa.fa-edit
+  .user-image
+    = user_image_tag(activity.owner.email)
+  .description
+    h6
+      = render_edit_activity(activity)
+    small
+      i.fa.fa-clock-o
+      = activity_time_tag activity.created_at

--- a/spec/helpers/repositories_helper_spec.rb
+++ b/spec/helpers/repositories_helper_spec.rb
@@ -148,5 +148,110 @@ RSpec.describe RepositoriesHelper, type: :helper do
         idx += 1
       end
     end
+
+    describe "render edit activity" do
+      let!(:registry)   { create(:registry, hostname: "registry:5000") }
+      let!(:namespace)  { create(:namespace, name: "namespace", registry: registry) }
+      let!(:owner)      { create(:user) }
+      let!(:repo)       { create(:repository, name: "repo", namespace: namespace) }
+
+      it "works when the new source is empty" do
+        repo.create_activity(
+          :edit,
+          owner:      owner,
+          parameters: { old_source: "old", new_source: "" })
+
+        html = render_edit_activity(PublicActivity::Activity.last)
+        expect(html).to eq(
+          "<strong>#{owner.username} edited </strong>" \
+          "<a href=\"/namespaces/#{namespace.id}\">#{namespace.name}</a>" \
+          " / <a href=\"/repositories/#{repo.id}\">repo</a>" \
+          " making it a non-automated repository"
+        )
+      end
+
+      it "works when all the sources are not empty" do
+        repo.create_activity(
+          :edit,
+          owner:      owner,
+          parameters: { old_source: "old", new_source: "new" })
+
+        html = render_edit_activity(PublicActivity::Activity.last)
+        expect(html).to eq(
+          "<strong>#{owner.username} edited </strong>" \
+          "<a href=\"/namespaces/#{namespace.id}\">#{namespace.name}</a>" \
+          " / <a href=\"/repositories/#{repo.id}\">repo</a>" \
+          " changing source URL from <code>old</code> to <code>new</code>"
+        )
+      end
+
+      it "works when the old source is empty" do
+        repo.create_activity(
+          :edit,
+          owner:      owner,
+          parameters: { old_source: "", new_source: "new" })
+
+        html = render_edit_activity(PublicActivity::Activity.last)
+        expect(html).to eq(
+          "<strong>#{owner.username} edited </strong>" \
+          "<a href=\"/namespaces/#{namespace.id}\">#{namespace.name}</a>" \
+          " / <a href=\"/repositories/#{repo.id}\">repo</a>" \
+          " set source URL to <code>new</code>"
+        )
+      end
+
+      it "works when the new source is empty" do
+        repo.create_activity(
+          :edit,
+          owner:      owner,
+          parameters: { old_source: "old", new_source: "" })
+
+        html = render_edit_activity(PublicActivity::Activity.last)
+        expect(html).to eq(
+          "<strong>#{owner.username} edited </strong>" \
+          "<a href=\"/namespaces/#{namespace.id}\">#{namespace.name}</a>" \
+          " / <a href=\"/repositories/#{repo.id}\">repo</a>" \
+          " making it a non-automated repository"
+        )
+      end
+
+      it "works when all the sources are not empty" do
+        repo.create_activity(
+          :edit,
+          owner:      owner,
+          parameters: { old_source: "old", new_source: "new" })
+
+        html = render_edit_activity(PublicActivity::Activity.last)
+        expect(html).to eq(
+          "<strong>#{owner.username} edited </strong>" \
+          "<a href=\"/namespaces/#{namespace.id}\">#{namespace.name}</a>" \
+          " / <a href=\"/repositories/#{repo.id}\">repo</a>" \
+          " changing source URL from <code>old</code> to <code>new</code>"
+        )
+      end
+    end
+
+    describe "render create activity" do
+      let!(:registry)   { create(:registry, hostname: "registry:5000") }
+      let!(:namespace)  { create(:namespace, name: "namespace", registry: registry) }
+      let!(:owner)      { create(:user) }
+      let!(:repo)       { create(:repository, name: "repo", namespace: namespace) }
+
+      it "works as expected" do
+        repo.create_activity(
+          :create,
+          owner:      owner,
+          parameters: { source_url: "git" })
+
+        html = render_create_activity(PublicActivity::Activity.last)
+        expect(html).to eq(
+          "<strong>#{owner.username} created </strong>" \
+          "<a href=\"/namespaces/#{namespace.id}\">#{namespace.name}</a>" \
+          " / <a href=\"/repositories/#{repo.id}\">repo</a>" \
+          " with source URL set to <code>git</code>"
+        )
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Track the following events:
  * automated repository creation
  * edit of `source_url`


![more-repo-events](https://cloud.githubusercontent.com/assets/22728/11719786/9d2a046a-9f5c-11e5-9424-c013d8d1e0b9.png)
