### PR TITLE
Fixed the crono job overflowing the `log` column

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,8 @@ MAINTAINER Flavio Castelli <fcastelli@suse.com>
 ENV COMPOSE=1
 EXPOSE 3000
 
-# install supervisord, this is required to run cronos
-RUN apt-get update && apt-get install -y supervisor
-RUN ln -s /portus/docker/crono-supervisord.conf /etc/supervisor/conf.d/crono.conf
-
 WORKDIR /portus
 COPY Gemfile* ./
 RUN bundle install --retry=3
 
 ADD . .
-

--- a/compose-setup.sh
+++ b/compose-setup.sh
@@ -97,6 +97,10 @@ docker-compose up -d
 
 setup_database
 
+# At this point, the DB is up and running. Therefore, at this point the crono
+# container will certainly work.
+docker-compose restart crono
+
 # The cleaned up host. We do this because when the $DOCKER_HOST variable was
 # already set, then it might come with the port included.
 final_host=$(echo $DOCKER_HOST | grep -E -o '([0-9]{1,3}[\.]){3}[0-9]{1,3}' | head -1)

--- a/db/migrate/20151215152138_remove_log_from_crono_job.rb
+++ b/db/migrate/20151215152138_remove_log_from_crono_job.rb
@@ -1,0 +1,5 @@
+class RemoveLogFromCronoJob < ActiveRecord::Migration
+  def change
+    remove_column :crono_jobs, :log, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151207153613) do
+ActiveRecord::Schema.define(version: 20151215152138) do
 
   create_table "activities", force: :cascade do |t|
     t.integer  "trackable_id",   limit: 4
@@ -52,12 +52,11 @@ ActiveRecord::Schema.define(version: 20151207153613) do
   add_index "comments", ["user_id"], name: "index_comments_on_user_id", using: :btree
 
   create_table "crono_jobs", force: :cascade do |t|
-    t.string   "job_id",            limit: 255,   null: false
-    t.text     "log",               limit: 65535
+    t.string   "job_id",            limit: 255, null: false
     t.datetime "last_performed_at"
     t.boolean  "healthy",           limit: 1
-    t.datetime "created_at",                      null: false
-    t.datetime "updated_at",                      null: false
+    t.datetime "created_at",                    null: false
+    t.datetime "updated_at",                    null: false
   end
 
   add_index "crono_jobs", ["job_id"], name: "index_crono_jobs_on_job_id", unique: true, using: :btree

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ web:
 
 crono:
   image: portus_web
-  command: /usr/bin/supervisord
+  entrypoint: bundle exec crono
   volumes:
     - .:/portus
   links:

--- a/docker/crono-supervisord.conf
+++ b/docker/crono-supervisord.conf
@@ -1,5 +1,0 @@
-[supervisord]
-nodaemon=true
-
-[program:crono]
-command=/bin/bash -c "bundle exec crono"


### PR DESCRIPTION
Before this commit, the crono job kept on adding the log into the `log` column
from the `crono_jobs` table. This is, of course, a bad thing. What I did to fix
this is to simply remove this columns from the DB, and crono is ok with that.
Running crono again with this patch runs in the very same way as it used to be,
but without adding the log all the time.

Moreover, the log is supposed to go to the stdout, as envisioned by the
Twelve-Factor App manifesto: http://12factor.net. Docker follows this too, and
by doing so then the log of this job blends in with docker-compose logs
command. This has two main consequences:

1. The user can decide how to manage logs in an easier way, so there's no way
   that we run out of disk (an issue we were having).
2. supervisor is no longer needed. Instead, we take advantage of the
   compose-setup.sh script to do it properly. Before this patch, for some
   reason the catalog job did not reach the db container.

Fixes #479
Fixes #505

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>