### PR TITLE
compose: don't use slashes for the sed command on the registry's entr…

### DIFF
--- a/docker/registry/entry.sh
+++ b/docker/registry/entry.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ ! -e /registry/config.yml ]; then
-  sed -e "s/DOCKER_HOST/${DOCKER_HOST}/g" /registry/config.yml.template > /registry/config.yml
+  sed -e "s|DOCKER_HOST|${DOCKER_HOST}|g" /registry/config.yml.template > /registry/config.yml
 fi
 
 registry /registry/config.yml


### PR DESCRIPTION
…ypoint

The DOCKER_HOST might be set to something that starts with "tcp://". This is
the case for example when setting up a docker host through Docker machine.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>