### PR TITLE
compose: support Docker 1.9 overlay networking

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -2,7 +2,7 @@ default: &default
   adapter: mysql2
   encoding: utf8
 <% if ENV['COMPOSE'] %>
-  host: db
+  host: <%= ENV['PORTUS_DB_HOST'] %>
   username: root
   password: portus
 <% end %>

--- a/docker-compose.overlay.yml
+++ b/docker-compose.overlay.yml
@@ -1,0 +1,32 @@
+web:
+  extends:
+    file: docker/compose-common.yml
+    service: web
+  env_file: docker/environment
+  volumes:
+    - .:/portus
+
+crono:
+  image: portus_web
+  command: /usr/bin/supervisord
+  env_file: docker/environment
+  volumes:
+    - .:/portus
+
+db:
+  image: library/mariadb
+  environment:
+    MYSQL_ROOT_PASSWORD: portus
+  env_file: docker/environment
+
+registry:
+  extends:
+    file: docker/compose-common.yml
+    service: registry
+  volumes:
+    - ./docker/registry:/registry
+    - /registry_data
+  entrypoint: /registry/entry.sh
+  env_file: docker/environment
+  ports:
+    - 5001:5001 # required to access debug service

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,35 +1,25 @@
 web:
   extends:
-    file: docker/compose-common.yml
+    file: docker-compose.overlay.yml
     service: web
-  volumes:
-    - .:/portus
   links:
     - db
 
 crono:
-  image: portus_web
-  command: /usr/bin/supervisord
-  volumes:
-    - .:/portus
+  extends:
+    file: docker-compose.overlay.yml
+    service: crono
   links:
     - db
 
 db:
-  image: library/mariadb
-  environment:
-    MYSQL_ROOT_PASSWORD: portus
+  extends:
+    file: docker-compose.overlay.yml
+    service: db
 
 registry:
   extends:
-    file: docker/compose-common.yml
+    file: docker-compose.overlay.yml
     service: registry
-  volumes:
-    - ./docker/registry:/registry
-    - /registry_data
-  entrypoint: /registry/entry.sh
-  env_file: docker/environment
   links:
     - web
-  ports:
-    - 5001:5001 # required to access debug service

--- a/docker/registry/config.yml.template
+++ b/docker/registry/config.yml.template
@@ -18,7 +18,7 @@ auth:
 notifications:
   endpoints:
     - name: portus
-      url: http://web:3000/v2/webhooks/events
+      url: http://PORTUS_WEB_HOST:3000/v2/webhooks/events
       timeout: 500ms
       threshold: 5
       backoff: 1s

--- a/docker/registry/entry.sh
+++ b/docker/registry/entry.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
 if [ ! -e /registry/config.yml ]; then
-  sed -e "s|DOCKER_HOST|${DOCKER_HOST}|g" /registry/config.yml.template > /registry/config.yml
+  sed -e "{
+    s|DOCKER_HOST|${DOCKER_HOST}|g;
+    s|PORTUS_WEB_HOST|${PORTUS_WEB_HOST}|g;
+  }" /registry/config.yml.template > /registry/config.yml
 fi
 
 registry /registry/config.yml


### PR DESCRIPTION
Rather than using the (quite outdated) links system, use the new overlay
network driver added in Docker 1.9. While this support is currently (as
of Docker compose 1.5.2) experimental, it works pretty well.

Signed-off-by: Aleksa Sarai <asarai@suse.com>

The two setups (linksv1 and overlay) are completely independant,
and doesn't require any configuration generation.