### PR TITLE
Redirect logs to stdout

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem "net-ldap"
 gem "redcarpet"
 gem "font-awesome-rails"
 gem "bootstrap-typeahead-rails"
+gem "rails_stdout_logging", group: [:development, :staging, :production]
 
 # Used to store application tokens. This is already a Rails depedency. However
 # better safe than sorry...

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,6 +204,7 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.2)
       loofah (~> 2.0)
+    rails_stdout_logging (0.0.4)
     railties (4.2.2)
       actionpack (= 4.2.2)
       activesupport (= 4.2.2)
@@ -351,6 +352,7 @@ DEPENDENCIES
   quiet_assets
   rack-mini-profiler
   rails (~> 4.2.2)
+  rails_stdout_logging
   redcarpet
   rspec-rails
   rubocop

--- a/packaging/suse/portusctl/lib/cli.rb
+++ b/packaging/suse/portusctl/lib/cli.rb
@@ -137,6 +137,7 @@ class Cli < Thor
 
     Runner.produce_versions_file!
     Runner.produce_crono_log_file!
+    Runner.exec("cp", ["/var/log/apache2/error_log", File.join(PORTUS_ROOT, "log/production.log")])
     Runner.tar_files("log/production.log", "log/crono.log", "log/versions.log")
   end
 

--- a/packaging/suse/portusctl/lib/cli.rb
+++ b/packaging/suse/portusctl/lib/cli.rb
@@ -136,6 +136,7 @@ class Cli < Thor
     ensure_root
 
     Runner.produce_versions_file!
+    Runner.produce_crono_log_file!
     Runner.tar_files("log/production.log", "log/crono.log", "log/versions.log")
   end
 

--- a/packaging/suse/portusctl/lib/runner.rb
+++ b/packaging/suse/portusctl/lib/runner.rb
@@ -2,10 +2,15 @@
 class Runner
   # Run a simple external command
   def self.exec(cmd, args = [])
-    final_cmd = cmd + " " + args.map { |a| Shellwords.escape(a) }.join(" ")
+    final_cmd = Runner.escape_command(cmd, args)
     unless system(final_cmd)
       raise "Something went wrong while invoking: #{final_cmd}"
     end
+  end
+
+  # Returns a string containing the command with its arguments all escaped.
+  def self.escape_command(cmd, args = [])
+    cmd + " " + args.map { |a| Shellwords.escape(a) }.join(" ")
   end
 
   # Run an external command using the bundler binary shipped with Portus' RPM
@@ -39,6 +44,15 @@ class Runner
         rpm = `rpm -qi #{package}`
         file.puts("#{rpm}\n")
       end
+    end
+  end
+
+  # Creates a new file called "crono.log" with the logs stored by systemd about
+  # crono.
+  def self.produce_crono_log_file!
+    File.open(File.join(PORTUS_ROOT, "log/crono.log"), "w+") do |file|
+      cmd = Runner.escape_command("journalctl", ["--no-pager", "-u", "portus_crono"])
+      file.puts(`#{cmd}`)
     end
   end
 


### PR DESCRIPTION
This is one of the points of http://12factor.net/. It turns out to be quite
useful in this case to avoid issues with logs. Basically by spitting into the
stdout we allow deployers to manage logs as they want. For the different
setups:

- docker-compose: it's integrated with docker-compose logs.
- vagrant & rpm: by default saved in /var/log/apache2/error_log.
- NGinx setup: handled by puma.

Fixes #626

Signed-off-by: Miquel Sabaté Solà <mikisabate@gmail.com>