### PR TITLE
app: always use _path methods instead of *_url

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,11 +16,11 @@ class ApplicationController < ActionController::Base
   #      this case, the user will be asked to submit an email.
   #   2. Everything is fine, go to the root url.
   def after_sign_in_path_for(_resource)
-    current_user.email? ? root_url : edit_user_registration_url
+    current_user.email? ? root_path : edit_user_registration_path
   end
 
   def after_sign_out_path_for(_resource)
-    new_user_session_url
+    new_user_session_path
   end
 
   def fixes
@@ -55,7 +55,7 @@ class ApplicationController < ActionController::Base
     return unless current_user && !current_user.email?
     return if protected_controllers?
 
-    redirect_to edit_user_registration_url
+    redirect_to edit_user_registration_path
   end
 
   # Redirect admin users to the registries#new page if no registry has been

--- a/app/controllers/auth/registrations_controller.rb
+++ b/app/controllers/auth/registrations_controller.rb
@@ -24,7 +24,7 @@ class Auth::RegistrationsController < Devise::RegistrationsController
       sign_up(resource_name, resource)
       respond_with resource, location: after_sign_up_path_for(resource)
     else
-      redirect_to new_user_registration_url,
+      redirect_to new_user_registration_path,
         alert: resource.errors.full_messages
     end
   end
@@ -45,10 +45,10 @@ class Auth::RegistrationsController < Devise::RegistrationsController
     end
 
     if success
-      redirect_to edit_user_registration_url,
+      redirect_to edit_user_registration_path,
         notice: "Profile updated successfully!"
     else
-      redirect_to edit_user_registration_url,
+      redirect_to edit_user_registration_path,
         alert: resource.errors.full_messages
     end
   end

--- a/app/controllers/auth/sessions_controller.rb
+++ b/app/controllers/auth/sessions_controller.rb
@@ -14,7 +14,7 @@ class Auth::SessionsController < Devise::SessionsController
       # For some reason if we get here from the root path, we'll get a flashy
       # alert message.
       flash[:alert] = nil
-      redirect_to new_user_registration_url
+      redirect_to new_user_registration_path
     end
   end
 

--- a/app/views/devise/passwords/edit.html.slim
+++ b/app/views/devise/passwords/edit.html.slim
@@ -12,4 +12,4 @@ section.row-0
         = f.button class: 'classbutton btn btn-primary btn-block btn-lg' do
           i.fa.fa-check  Change my password
 
-        .text-center = link_to 'Go back to the login page', new_user_session_url
+        .text-center = link_to 'Go back to the login page', new_user_session_path

--- a/app/views/devise/passwords/new.html.slim
+++ b/app/views/devise/passwords/new.html.slim
@@ -9,4 +9,4 @@ section.row-0
         = f.button class: 'classbutton btn btn-primary btn-block btn-lg' do
           i.fa.fa-check  Reset password
 
-        .text-center = link_to 'Go back to the login page', new_user_session_url, class: 'btn btn-link'
+        .text-center = link_to 'Go back to the login page', new_user_session_path, class: 'btn btn-link'

--- a/app/views/devise/registrations/new.html.slim
+++ b/app/views/devise/registrations/new.html.slim
@@ -20,4 +20,4 @@ section.sign-up class=(@have_users ? '' : 'first-user')
           - else
             | Create admin
         - if @have_users
-          .text-center = link_to 'I already have an account. Login.', new_user_session_url, class: 'btn btn-link'
+          .text-center = link_to 'I already have an account. Login.', new_user_session_path, class: 'btn btn-link'

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -16,7 +16,7 @@ section.row-0
         .row
           - if signup_enabled?
             .col-sm-6.create-new-account
-              = link_to 'Create a new account', new_user_registration_url, class: 'btn btn-link'
+              = link_to 'Create a new account', new_user_registration_path, class: 'btn btn-link'
             .col-sm-6.forgot-password
               = link_to "I forgot my password", new_user_password_path, class: 'btn btn-link'
           - elsif !Portus::LDAP.enabled?

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -14,7 +14,7 @@
     .hidden-xs
       = user_image_tag(current_user.email)
 
-      = link_to edit_user_registration_url, class: 'nav-a' do
+      = link_to edit_user_registration_path, class: 'nav-a' do
         span.username = current_user.username
-    = link_to destroy_user_session_url, method: :delete, class: 'btn btn-default', id: 'logout' do
+    = link_to destroy_user_session_path, method: :delete, class: 'btn btn-default', id: 'logout' do
       i.fa.fa-sign-out


### PR DESCRIPTION
The _url methods should only be used when the full path (+ hostname, etc.) is
needed. This is usually only the case for things like emails and views that are
to be accessed from outside the web app. This can usually be workarounded
through NGinx and similar tools, but it's better to have this behavior even
without such tools.

Fixes #677

Signed-off-by: Miquel Sabaté Solà <mikisabate@gmail.com>