### PR TITLE
Change error message on openSSL's errors

### DIFF
--- a/app/models/registry.rb
+++ b/app/models/registry.rb
@@ -91,12 +91,10 @@ class Registry < ActiveRecord::Base
       else
         msg = "Error: not using SSL, but the given registry does use SSL."
       end
-    rescue OpenSSL::SSL::SSLError
-      if use_ssl
-        msg = "Error: using SSL, but the given registry is not using SSL."
-      else
-        msg = "Error: there's something wrong with your SSL configuration."
-      end
+    rescue OpenSSL::SSL::SSLError => e
+      msg = "SSL error while communicating with the registry, check the server " \
+        "logs for more details."
+      logger.error(e)
     rescue StandardError => e
       # We don't know what went wrong :/
       logger.info "Registry not reachable: #{e.inspect}"

--- a/spec/models/registry_spec.rb
+++ b/spec/models/registry_spec.rb
@@ -106,6 +106,7 @@ RSpec.describe Registry, type: :model do
     end
   end
 
+  # rubocop: disable Metrics/LineLength
   describe "#reachable" do
     it "returns the proper message for each scenario" do
       [
@@ -116,8 +117,8 @@ RSpec.describe Registry, type: :model do
         [Net::OpenTimeout, true, true, /connection timed out/],
         [Net::HTTPBadResponse, true, true, /wrong with your SSL configuration/],
         [Net::HTTPBadResponse, true, false, /Error: not using SSL/],
-        [OpenSSL::SSL::SSLError, true, true, /Error: using SSL/],
-        [OpenSSL::SSL::SSLError, true, false, /wrong with your SSL configuration/],
+        [OpenSSL::SSL::SSLError, true, true, /SSL error while communicating with the registry, check the server logs for more details./],
+        [OpenSSL::SSL::SSLError, true, false, /SSL error while communicating with the registry, check the server logs for more details./],
         [StandardError, true, true, /something went wrong/]
       ].each do |cs|
         rr = RegistryReachable.new(cs.first, cs[1], cs[2])
@@ -125,6 +126,7 @@ RSpec.describe Registry, type: :model do
       end
     end
   end
+  # rubocop: enable Metrics/LineLength
 
   describe "#get_tag_from_manifest" do
     it "returns a tag on success" do


### PR DESCRIPTION
Do not try to be smart when validating a registry connection using SSL.
Let's just provide a generic error and log the exception into the logs.

This is going to help with issues like #504