### PR TITLE
Dockerimage: add phantomjs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,15 @@ WORKDIR /portus
 COPY Gemfile* ./
 RUN bundle install --retry=3
 
+# Install phantomjs, this is required for testing and development purposes
+# There are no official deb packages for it, hence we built it inside of the
+# open build service.
+RUN echo "deb http://download.opensuse.org/repositories/home:/flavio_castelli:/phantomjs/Debian_8.0/ ./" >> /etc/apt/sources.list
+RUN wget http://download.opensuse.org/repositories/home:/flavio_castelli:/phantomjs/Debian_8.0/Release.key && \
+  apt-key add Release.key && \
+  rm Release.key
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends phantomjs && \
+    rm -rf /var/lib/apt/lists/*
+
 ADD . .


### PR DESCRIPTION
Add the phantomjs to the Portus Docker image. Needless to say this image
is used for testing and development purposes, it's not meant for
production usage. Hence it makes sense to have all the tools actually
needed at development time.