### PR TITLE
compose: fix a typo on an environment variable

### DIFF
--- a/compose/docker-compose.yml.template
+++ b/compose/docker-compose.yml.template
@@ -2,7 +2,7 @@ web:
   build: .
   command: puma -b tcp://0.0.0.0:3000 -w 3
   environment:
-    - PORTUS_MACHINE_FQDN=EXTERNAL_IP
+    - PORTUS_MACHINE_FQDN_VALUE=EXTERNAL_IP
     - PORTUS_DB_HOST=portus_db_1
   volumes:
     - .:/portus


### PR DESCRIPTION
This way fixing a regression in which users couldn't login with the compose
setup.

Signed-off-by: Miquel Sabaté Solà <mikisabate@gmail.com>