### PR TITLE
config/initializers: don't use mkmf

### DIFF
--- a/config/initializers/version.rb
+++ b/config/initializers/version.rb
@@ -1,14 +1,18 @@
-require 'mkmf'
-  
 # Version module
 # Makes the app version available to the application itself
 # Needs the git executable for all git operations
 module Version
-  git = find_executable('git')
-  BRANCH = git ? `git symbolic-ref HEAD 2>/dev/null | cut -d"/" -f 3  2>/dev/null`.chomp : nil
-  COMMIT = git ? `git log --pretty=format:'%h' -n 1 2>/dev/null`.chomp : nil
-  TAG = git ? `git tag --points-at $(git rev-parse HEAD) 2>/dev/null`.chomp : nil
-  
+  # Returns true if git is in the system, false otherwise.
+  def self.git?
+    paths = ENV["PATH"].split(":")
+    paths.each { |p| return true if File.executable?(File.join(p, "git")) }
+    false
+  end
+
+  BRANCH = Version.git? ? `git symbolic-ref HEAD 2>/dev/null | cut -d"/" -f 3  2>/dev/null`.chomp : nil
+  COMMIT = Version.git? ? `git log --pretty=format:'%h' -n 1 2>/dev/null`.chomp : nil
+  TAG    = Version.git? ? `git tag --points-at $(git rev-parse HEAD) 2>/dev/null`.chomp : nil
+
   # Version.value returns the app version
   # Priority: git tag > git branch/commit > VERSION file
   def self.value


### PR DESCRIPTION
To determine whether "git" is on the system, we used the mkmf library. This has
turned out to not be the best option because then a "mkmf.log" file is always
generated.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>