### PR TITLE
Support multiple scope parameters in a token request

### DIFF
--- a/app/controllers/api/v2/tokens_controller.rb
+++ b/app/controllers/api/v2/tokens_controller.rb
@@ -20,13 +20,13 @@ class Api::V2::TokensController < Api::BaseController
   # Returns the token that the docker client should use in order to perform
   # operation into the private registry.
   def show
+    authenticate_user! if request.headers["Authorization"]
     registry = Registry.find_by(hostname: params[:service])
-    raise RegistryNotHandled, "Cannot find registry #{params[:service]}" if registry.nil?
 
-    auth_scope = authorize_scopes(registry)
-    authenticate_user! if auth_scope.nil?
+    auth_scopes = []
+    auth_scopes = authorize_scopes(registry) unless registry.nil?
 
-    token = Portus::JwtToken.new(params[:account], params[:service], auth_scope)
+    token = Portus::JwtToken.new(params[:account], params[:service], auth_scopes)
     logger.tagged("jwt_token", "claim") { logger.debug token.claim }
     render json: token.encoded_hash
   end
@@ -39,37 +39,47 @@ class Api::V2::TokensController < Api::BaseController
   #
   # If no scope was specified, this is a login request and it just returns nil.
   def authorize_scopes(registry)
-    return unless params[:scope]
+    scopes =  Array(Rack::Utils.parse_query(request.query_string)["scope"])
+    return if scopes.empty?
+
+    auth_scopes = {}
 
     # First try to fetch the requested scopes and the handler. If no scopes
     # were successfully given, respond with a 401.
-    auth_scope, scopes = scope_handler(registry, params[:scope])
-    raise Pundit::NotAuthorizedError, "No scopes to handle" if scopes.empty?
-
     scopes.each do |scope|
-      # It will try to check if the current user is authorized to access the
-      # scope given in this iteration. If everything is fine, then nothing will
-      # happen, otherwise there are two possible exceptions that can be raised:
-      #
-      #   - NoMethodError: the targeted resource does not handle the scope that
-      #     is being checked. It will raise a ScopeNotHandled.
-      #   - Pundit::NotAuthorizedError: the targeted resource unauthorized the
-      #     given user for the scope that is being checked. In this case this
-      #     scope gets removed from `auth_scope.actions`.
-      begin
-        authorize auth_scope.resource, "#{scope}?".to_sym
-      rescue NoMethodError, Pundit::NotAuthorizedError
-        logger.debug "scope #{scope} not handled/authorized, removing from actions"
-        auth_scope.actions.delete_if { |a| a == scope }
+      auth_scope, actions = scope_handler(registry, scope)
+
+      actions.each do |action|
+        # It will try to check if the current user is authorized to access the
+        # scope given in this iteration. If everything is fine, then nothing will
+        # happen, otherwise there are two possible exceptions that can be raised:
+        #
+        #   - NoMethodError: the targeted resource does not handle the scope that
+        #     is being checked. It will raise a ScopeNotHandled.
+        #   - Pundit::NotAuthorizedError: the targeted resource unauthorized the
+        #     given user for the scope that is being checked. In this case this
+        #     scope gets removed from `auth_scope.actions`.
+        begin
+          authorize auth_scope.resource, "#{action}?".to_sym
+        rescue NoMethodError, Pundit::NotAuthorizedError, Portus::AuthScope::ResourceNotFound
+          logger.debug "action #{action} not handled/authorized, removing from actions"
+          auth_scope.actions.delete_if { |a| a == action }
+        end
+      end
+
+      next if auth_scope.actions.empty?
+      # if there is already a similar scope (type and resource name),
+      # we combine them into one:
+      # e.g. scope=repository:busybox:push&scope=repository:busybox:pull
+      #      -> access=>[{:type=>"repository", :name=>"busybox", :actions=>["push", "pull"]}
+      k = [auth_scope.resource_type,  auth_scope.resource_name]
+      if auth_scopes[k]
+        auth_scopes[k].actions.concat(auth_scope.actions).uniq!
+      else
+        auth_scopes[k] = auth_scope
       end
     end
-
-    # If auth_scope.actions is empty, it means that the previous loop
-    # unauthorized all the requested scopes for the current user. Therefore
-    # respond with a 401. Otherwise, return the resulting auth_scope.
-    msg = "None of the given scopes were authorized for the current user"
-    raise Pundit::NotAuthorizedError, msg if auth_scope.actions.empty?
-    auth_scope
+    auth_scopes.values
   end
 
   # From the given scope string, try to fetch a scope handler class for it.

--- a/lib/portus/jwt_token.rb
+++ b/lib/portus/jwt_token.rb
@@ -6,12 +6,12 @@ module Portus
   #
   class JwtToken
     # The constructor takes the query parameters as specified in the
-    # specification. The given scope is assumed to have already been processed
+    # specification. The given scopes are assumed to have already been processed
     # by the caller with the authorized scopes.
-    def initialize(account, service, scope)
+    def initialize(account, service, scopes)
       @account = account
       @service = service
-      @scope   = scope
+      @scopes   = scopes
     end
 
     # Returns a hash containing the encoded token, ready to be sent as a JSON
@@ -32,7 +32,7 @@ module Portus
         hash[:nbf]    = issued_at - 5.seconds
         hash[:exp]    = issued_at + expiration_time
         hash[:jti]    = jwt_id
-        hash[:access] = authorized_access if @scope
+        hash[:access] = authorized_access if @scopes
       end
     end
 
@@ -56,11 +56,13 @@ module Portus
 
     # Returns an array with the authorized actions hash.
     def authorized_access
-      [{
-        type:    @scope.resource_type,
-        name:    @scope.resource_name,
-        actions: @scope.actions
-      }]
+      @scopes.map do |scope|
+        {
+          type:    scope.resource_type,
+          name:    scope.resource_name,
+          actions: scope.actions
+        }
+      end
     end
 
     # Returns a (hopefully) unique id for the JWT token.

--- a/spec/lib/portus/jwt_token_spec.rb
+++ b/spec/lib/portus/jwt_token_spec.rb
@@ -21,7 +21,7 @@ describe Portus::JwtToken do
   end
 
   describe "#encoded_token" do
-    subject { described_class.new("jlhawn", "registry.docker.com", scope) }
+    subject { described_class.new("jlhawn", "registry.docker.com", [scope]) }
 
     it "calls JWT#encode with claim with stringified_keys" do
       expect(JWT).to receive(:encode).with(
@@ -51,7 +51,7 @@ describe Portus::JwtToken do
   end
 
   describe "#claim" do
-    subject { described_class.new("jlhawn", "registry.docker.com", scope) }
+    subject { described_class.new("jlhawn", "registry.docker.com", [scope]) }
 
     describe "basic fields" do
       describe ":iss" do


### PR DESCRIPTION
While testing Portus as an authorisation server for a private docker registry I ran into occasional authentication errors especially when pushing to repositories that don't exist yet.

The error I'm seeing from the docker client is "authentication required" and after re-trying for 1-2 times it always works.
Example:
```
$> docker push 192.168.163.129:5000/busybox
The push refers to a repository [192.168.163.129:5000/busybox]
5f70bf18a086: Preparing
2c84284818d1: Preparing
unauthorized: authentication required
$> docker push 192.168.163.129:5000/busybox
The push refers to a repository [192.168.163.129:5000/busybox]
5f70bf18a086: Pushed
2c84284818d1: Pushed
latest: digest: sha256:9176b113ee7620cb59f5df4c8afa86e990529e3ca328fe15cbc499eeb64bedfd size: 711
5f70bf18a086: Layer already exists
2c84284818d1: Layer already exists
v2: digest: sha256:9176b113ee7620cb59f5df4c8afa86e990529e3ca328fe15cbc499eeb64bedfd size: 711
```
When this authentication errors happens the registry shows the error:
```
registry_1 | time="2016-02-15T14:53:14Z" level=warning msg="error authorizing context: insufficient scope" ...
```
Looking at the Portus rails logs, the problem is that the token request from the docker client contains multiple scope query parameters:
```
Started GET "/v2/token?account=d062284&scope=repository%3Abusybox%3Apush%2Cpull&scope=repository%3Ad062284%2Fbusybox%3Apull&service=192.168.163.129%3A5000"
```
So the docker client (version 1.10.0) for some reason requests `[push,pull]` and `[pull]` actions for the same repository in one token request. The problem here is that the query parsing from rails mangles this and only the last scope parameter gets populated into `params[:scope]`. Unfortunately the last parameter often only contains the `[pull]` action.

Quoting the [official distribution spec] (https://github.com/docker/distribution/blob/master/docs/spec/auth/token.md) having multiple scope query parameters is valid:
>  This query parameter should be specified multiple times if there is more than one scope entry from the WWW-Authenticate header.

So this commit changes the token controller to support multiple scope parameters.

In the process I also had to change the controller to not raise `401 Unauthorised` on authorisation errors which is also explicitly discouraged by the official spec:
> If the client only has a subset of the requested access it **must not be considered an error** as it is not the responsibility of the token server to indicate authorization errors as part of this workflow

This is repeated in the [token specification] (https://github.com/docker/distribution/blob/master/docs/spec/auth/jwt.md):
> The token server should not return errors when the user does not have the requested authorization. Instead, the returned token should indicate whatever of the requested scope the client does have (the intersection of requested and granted access).

So with this change Portus only returns a `401 Unauthorized` on **authentication** errors. I manually checked that this in line with what the official registry does.

