### PR TITLE
remove source_url from schema.rb

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -93,7 +93,6 @@ ActiveRecord::Schema.define(version: 20151215152138) do
     t.integer  "namespace_id", limit: 4
     t.datetime "created_at",                            null: false
     t.datetime "updated_at",                            null: false
-    t.string   "source_url",   limit: 255, default: "", null: false
   end
 
   add_index "repositories", ["name", "namespace_id"], name: "index_repositories_on_name_and_namespace_id", unique: true, using: :btree


### PR DESCRIPTION
I think this slipped in by accident. There is no migration for this in the master branch. It seems this has is origins in this commit https://github.com/SUSE/Portus/commit/c822bb0d636cc6088e7804bf78bea0f6eec5b6ae which is part of the hackday_13 branch