### PR TITLE
Add optional fields to token response

### DIFF
--- a/lib/portus/jwt_token.rb
+++ b/lib/portus/jwt_token.rb
@@ -18,7 +18,11 @@ module Portus
     # response.
     def encoded_hash
       headers = { "kid" => JwtToken.kid(private_key) }
-      { token: JWT.encode(claim.deep_stringify_keys, private_key, "RS256", headers) }.freeze
+      {
+        token:      JWT.encode(claim.deep_stringify_keys, private_key, "RS256", headers),
+        expires_in: expiration_time,
+        issued_at:  Time.zone.at(issued_at).to_datetime.rfc3339
+      }.freeze
     end
 
     # Returns a hash containing the "Claim" set as described in the


### PR DESCRIPTION
The fields are [mentioned in the spec](https://github.com/docker/distribution/blob/master/docs/spec/auth/token.md#token-response-fields).
They might be useful for clients that want to cache tokens for reuse.