### PR TITLE
[packaging] require net-tools

### DIFF
--- a/packaging/suse/Portus.spec.in
+++ b/packaging/suse/Portus.spec.in
@@ -34,6 +34,7 @@ Group:          System/Management
 
 Requires:       ruby >= 2.1
 Requires:       timezone
+Requires:       net-tools
 %if 0%{?suse_version} >= 1210
 BuildRequires: systemd-rpm-macros
 %endif


### PR DESCRIPTION
we use "hostname" in the portusctl script, and that requires the package
net-tools to be installed.

If you try to run it on a SLES container, net-tools is not there by
default.