### PR TITLE
Activity messages now fill all the horizontal space available

### DIFF
--- a/app/assets/stylesheets/activities.scss
+++ b/app/assets/stylesheets/activities.scss
@@ -8,6 +8,10 @@
   border-left: 1px solid $gray-light;
   margin-left: 2em;
   margin-top: -15px;
+  .activitie-container {
+    display: flex;
+    overflow: hidden;
+  }
   img {
     border-radius: 100%;
     border: 4px solid $gray-light;
@@ -31,16 +35,29 @@
     }
     .description {
       background: $white;
-      max-width: 400px;
+      width: 100%;
+      margin-right: 0;
+      margin-top: 0;
       h6 {
         margin: 0;
+      }
+      a {
+        @media (max-width: 767px) {
+          max-width: 15rem;
+        }
+        max-width: 20rem;
+        vertical-align: bottom;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        display: inline-block;
       }
     }
     .activity-type {
       border-radius: 100%;
       background: red;
-      height: 40px;
-      width: 40px;
+      height: 4rem;
+      flex: 0 0 4rem;
       text-align: center;
       i.fa {
         font-size: 1.5em;

--- a/app/views/public_activity/application_token/_create.html.slim
+++ b/app/views/public_activity/application_token/_create.html.slim
@@ -1,15 +1,16 @@
 li
-  .activity-type.application-token-created
-    i.fa.fa-key
-  .user-image
-    = user_image_tag(activity.owner.email)
-  .description
-    h6
-      strong
-        = activity.owner.username
-        |  created a token for the "
-        em= activity.parameters[:application]
-        | " application
-    small
-      i.fa.fa-clock-o
-      = activity_time_tag activity.created_at
+  .activitie-container
+    .activity-type.application-token-created
+      i.fa.fa-key
+    .user-image
+      = user_image_tag(activity.owner.email)
+    .description
+      h6
+        strong
+          = activity.owner.username
+          |  created a token for the "
+          em= activity.parameters[:application]
+          | " application
+      small
+        i.fa.fa-clock-o
+        = activity_time_tag activity.created_at

--- a/app/views/public_activity/application_token/_destroy.html.slim
+++ b/app/views/public_activity/application_token/_destroy.html.slim
@@ -1,15 +1,16 @@
 li
-  .activity-type.application-token-destroyed
-    i.fa.fa-key
-  .user-image
-    = user_image_tag(activity.owner.email)
-  .description
-    h6
-      strong
-        = activity.owner.username
-        |  removed the token of "
-        em= activity.parameters[:application]
-        | " application
-    small
-      i.fa.fa-clock-o
-      = activity_time_tag activity.created_at
+  .activitie-container
+    .activity-type.application-token-destroyed
+      i.fa.fa-key
+    .user-image
+      = user_image_tag(activity.owner.email)
+    .description
+      h6
+        strong
+          = activity.owner.username
+          |  removed the token of "
+          em= activity.parameters[:application]
+          | " application
+      small
+        i.fa.fa-clock-o
+        = activity_time_tag activity.created_at

--- a/app/views/public_activity/namespace/_change_namespace_description.html.slim
+++ b/app/views/public_activity/namespace/_change_namespace_description.html.slim
@@ -1,17 +1,18 @@
 li
-  .activity-type.change-description
-    i.fa.fa-list-alt
-  .user-image
-    = user_image_tag(activity.owner.email)
-  .description
-    h6
-      - if activity.parameters[:new].blank?
-        strong
-          = "#{activity.owner.username} deleted the description of the namespace "
-      - else
-        strong
-          = "#{activity.owner.username} edited the description of the namespace "
-      = link_to activity.trackable.name, activity.trackable
-    small
-      i.fa.fa-clock-o
-      = activity_time_tag activity.created_at
+  .activitie-container
+    .activity-type.change-description
+      i.fa.fa-list-alt
+    .user-image
+      = user_image_tag(activity.owner.email)
+    .description
+      h6
+        - if activity.parameters[:new].blank?
+          strong
+            = "#{activity.owner.username} deleted the description of the namespace "
+        - else
+          strong
+            = "#{activity.owner.username} edited the description of the namespace "
+        = link_to activity.trackable.name, activity.trackable
+      small
+        i.fa.fa-clock-o
+        = activity_time_tag activity.created_at

--- a/app/views/public_activity/namespace/_create.html.slim
+++ b/app/views/public_activity/namespace/_create.html.slim
@@ -1,16 +1,17 @@
 li
-  .activity-type.create-namespace
-    i.fa.fa-ship
-  .user-image
-    = user_image_tag(activity.owner.email)
-  .description
-    h6
-      strong
-        = "#{activity.owner.username} created the "
-      = link_to activity.trackable.name, activity.trackable
-      = " namespace under the "
-      = link_to activity.trackable.team.name, activity.trackable.team
-      = " team"
-    small
-      i.fa.fa-clock-o
-      = activity_time_tag activity.created_at
+  .activitie-container
+    .activity-type.create-namespace
+      i.fa.fa-ship
+    .user-image
+      = user_image_tag(activity.owner.email)
+    .description
+      h6
+        strong
+          = "#{activity.owner.username} created the "
+        = link_to activity.trackable.name , activity.trackable
+        = " namespace under the "
+        = link_to activity.trackable.team.name, activity.trackable.team
+        = " team"
+      small
+        i.fa.fa-clock-o
+        = activity_time_tag activity.created_at

--- a/app/views/public_activity/namespace/_private.html.slim
+++ b/app/views/public_activity/namespace/_private.html.slim
@@ -1,14 +1,15 @@
 li
-  .activity-type.change-namespace-visibility
-    i.fa.fa-lock
-  .user-image
-    = user_image_tag(activity.owner.email)
-  .description
-    h6
-      strong
-        = "#{activity.owner.username} set the "
-      = link_to activity.trackable.name, activity.trackable
-      = " namespace as private"
-    small
-      i.fa.fa-clock-o
-      = activity_time_tag activity.created_at
+  .activitie-container
+    .activity-type.change-namespace-visibility
+      i.fa.fa-lock
+    .user-image
+      = user_image_tag(activity.owner.email)
+    .description
+      h6
+        strong
+          = "#{activity.owner.username} set the "
+        = link_to activity.trackable.name, activity.trackable
+        = " namespace as private"
+      small
+        i.fa.fa-clock-o
+        = activity_time_tag activity.created_at

--- a/app/views/public_activity/namespace/_public.html.slim
+++ b/app/views/public_activity/namespace/_public.html.slim
@@ -1,14 +1,15 @@
 li
-  .activity-type.change-namespace-visibility
-    i.fa.fa-unlock
-  .user-image
-    = user_image_tag(activity.owner.email)
-  .description
-    h6
-      strong
-        = "#{activity.owner.username} set the "
-      = link_to activity.trackable.name, activity.trackable
-      = " namespace as public"
-    small
-      i.fa.fa-clock-o
-      = activity_time_tag activity.created_at
+  .activitie-container
+    .activity-type.change-namespace-visibility
+      i.fa.fa-unlock
+    .user-image
+      = user_image_tag(activity.owner.email)
+    .description
+      h6
+        strong
+          = "#{activity.owner.username} set the "
+        = link_to activity.trackable.name, activity.trackable
+        = " namespace as public"
+      small
+        i.fa.fa-clock-o
+        = activity_time_tag activity.created_at

--- a/app/views/public_activity/repository/_push.html.slim
+++ b/app/views/public_activity/repository/_push.html.slim
@@ -1,11 +1,12 @@
 li
-  .activity-type.repo-pushed
-    i.fa.fa-forward.fa-fw
-  .user-image
-    = user_image_tag(activity.owner.email)
-  .description
-    h6
-      = render_push_activity(activity)
-    small
-      i.fa.fa-clock-o
-      = activity_time_tag activity.created_at
+  .activitie-container
+    .activity-type.repo-pushed
+      i.fa.fa-forward.fa-fw
+    .user-image
+      = user_image_tag(activity.owner.email)
+    .description
+      h6
+        = render_push_activity(activity)
+      small
+        i.fa.fa-clock-o
+        = activity_time_tag activity.created_at

--- a/app/views/public_activity/team/_add_member.html.slim
+++ b/app/views/public_activity/team/_add_member.html.slim
@@ -1,15 +1,16 @@
 li
-  .activity-type.add-member-team
-    i.fa.fa-user-plus
-  .user-image
-    = user_image_tag(activity.owner.email)
-  .description
-    h6
-      strong
-        = "#{activity.owner.username} added user #{activity.recipient.username} "
-      = "with role #{activity.parameters[:role]} to the "
-      = link_to activity.trackable.name, activity.trackable
-      |  team
-    small
-      i.fa.fa-clock-o
-      = activity_time_tag activity.created_at
+  .activitie-container
+    .activity-type.add-member-team
+      i.fa.fa-user-plus
+    .user-image
+      = user_image_tag(activity.owner.email)
+    .description
+      h6
+        strong
+          = "#{activity.owner.username} added user #{activity.recipient.username} "
+        = "with role #{activity.parameters[:role]} to the "
+        = link_to activity.trackable.name, activity.trackable
+        |  team
+      small
+        i.fa.fa-clock-o
+        = activity_time_tag activity.created_at

--- a/app/views/public_activity/team/_change_member_role.html.slim
+++ b/app/views/public_activity/team/_change_member_role.html.slim
@@ -1,18 +1,19 @@
 li
-  .activity-type.change-role
-    i.fa.fa-user
-  .user-image
-    = user_image_tag(activity.owner.email)
-  .description
-    h6
-      strong
-        - if activity.owner == activity.recipient
-          = "#{activity.owner.username} changed its role "
-        - else
-          = "#{activity.owner.username} changed role of user #{activity.recipient.username} "
-      = "from #{activity.parameters[:old_role]} to #{activity.parameters[:new_role]} "
-      = "within the team "
-      = link_to activity.trackable.name, activity.trackable
-    small
-      i.fa.fa-clock-o
-      = activity_time_tag activity.created_at
+  .activitie-container
+    .activity-type.change-role
+      i.fa.fa-user
+    .user-image
+      = user_image_tag(activity.owner.email)
+    .description
+      h6
+        strong
+          - if activity.owner == activity.recipient
+            = "#{activity.owner.username} changed its role "
+          - else
+            = "#{activity.owner.username} changed role of user #{activity.recipient.username} "
+        = "from #{activity.parameters[:old_role]} to #{activity.parameters[:new_role]} "
+        = "within the team "
+        = link_to activity.trackable.name, activity.trackable
+      small
+        i.fa.fa-clock-o
+        = activity_time_tag activity.created_at

--- a/app/views/public_activity/team/_change_team_description.html.slim
+++ b/app/views/public_activity/team/_change_team_description.html.slim
@@ -1,17 +1,18 @@
 li
-  .activity-type.change-description
-    i.fa.fa-list-alt
-  .user-image
-    = user_image_tag(activity.owner.email)
-  .description
-    h6
-      - if activity.parameters[:new].blank?
-        strong
-          ="#{activity.owner.username} deleted the description of the team "
-      - else
-        strong
-          = "#{activity.owner.username} edited the description of the team "
-      =  link_to activity.trackable.name, activity.trackable
-    small
-      i.fa.fa-clock-o
-      = activity_time_tag activity.created_at
+  .activitie-container
+    .activity-type.change-description
+      i.fa.fa-list-alt
+    .user-image
+      = user_image_tag(activity.owner.email)
+    .description
+      h6
+        - if activity.parameters[:new].blank?
+          strong
+            ="#{activity.owner.username} deleted the description of the team "
+        - else
+          strong
+            = "#{activity.owner.username} edited the description of the team "
+        =  link_to activity.trackable.name, activity.trackable
+      small
+        i.fa.fa-clock-o
+        = activity_time_tag activity.created_at

--- a/app/views/public_activity/team/_change_team_name.html.slim
+++ b/app/views/public_activity/team/_change_team_name.html.slim
@@ -1,13 +1,14 @@
 li
-  .activity-type.change-name
-    i.fa.fa-list-alt
-  .user-image
-    = user_image_tag(activity.owner.email)
-  .description
-    h6
-      strong
-        = "#{activity.owner.username} renamed the team #{activity.parameters[:old]} to "
-      =  link_to activity.parameters[:new], activity.trackable
-    small
-      i.fa.fa-clock-o
-      = activity_time_tag activity.created_at
+  .activitie-container
+    .activity-type.change-name
+      i.fa.fa-list-alt
+    .user-image
+      = user_image_tag(activity.owner.email)
+    .description
+      h6
+        strong
+          = "#{activity.owner.username} renamed the team #{activity.parameters[:old]} to "
+        =  link_to activity.parameters[:new], activity.trackable
+      small
+        i.fa.fa-clock-o
+        = activity_time_tag activity.created_at

--- a/app/views/public_activity/team/_create.html.slim
+++ b/app/views/public_activity/team/_create.html.slim
@@ -1,13 +1,14 @@
 li
-  .activity-type.team-created
-    i.fa.fa-users
-  .user-image
-    = user_image_tag(activity.owner.email)
-  .description
-    h6
-      strong
-        = "#{activity.owner.username} created team "
-      = link_to activity.trackable.name, activity.trackable
-    small
-      i.fa.fa-clock-o
-      = activity_time_tag activity.created_at
+  .activitie-container
+    .activity-type.team-created
+      i.fa.fa-users
+    .user-image
+      = user_image_tag(activity.owner.email)
+    .description
+      h6
+        strong
+          = "#{activity.owner.username} created team "
+        = link_to activity.trackable.name, activity.trackable
+      small
+        i.fa.fa-clock-o
+        = activity_time_tag activity.created_at

--- a/app/views/public_activity/team/_remove_member.html.slim
+++ b/app/views/public_activity/team/_remove_member.html.slim
@@ -1,18 +1,19 @@
 li
-  .activity-type.remove-member-team
-    i.fa.fa-user-times
-  .user-image
-    = user_image_tag(activity.owner.email)
-  .description
-    h6
-      strong
-        - if activity.owner == activity.recipient
-          = "#{activity.owner.username} removed itself "
-        - else
-          = "#{activity.owner.username} removed user #{activity.recipient.username} "
-      = "from the "
-      = link_to activity.trackable.name, activity.trackable
-      |  team
-    small
-      i.fa.fa-clock-o
-      = activity_time_tag activity.created_at
+  .activitie-container
+    .activity-type.remove-member-team
+      i.fa.fa-user-times
+    .user-image
+      = user_image_tag(activity.owner.email)
+    .description
+      h6
+        strong
+          - if activity.owner == activity.recipient
+            = "#{activity.owner.username} removed itself "
+          - else
+            = "#{activity.owner.username} removed user #{activity.recipient.username} "
+        = "from the "
+        = link_to activity.trackable.name, activity.trackable
+        |  team
+      small
+        i.fa.fa-clock-o
+        = activity_time_tag activity.created_at


### PR DESCRIPTION
Fixes: #487 

Large screen:
![screenshot-localhost 5000 2016-03-06 01-37-23](https://cloud.githubusercontent.com/assets/2891076/13552339/5de32a1e-e33d-11e5-87a2-d7a0a6e40a7b.png)

Medium screen:
![screenshot-localhost 5000 2016-03-06 01-38-13](https://cloud.githubusercontent.com/assets/2891076/13552341/5fb06ffa-e33d-11e5-9af9-be8367a939fa.png)

Small screen:
![screenshot-localhost 5000 2016-03-06 01-38-41](https://cloud.githubusercontent.com/assets/2891076/13552342/6168504c-e33d-11e5-9cec-21408ef2a2f6.png)

When the namespace, for example, is too large, the div with the description exceeds the Recent Activities div:
![screenshot-localhost 5000 2016-03-06 01-58-43](https://cloud.githubusercontent.com/assets/2891076/13552379/003e2c40-e33f-11e5-80df-b060227fbfc3.png)

So I added `overflow: hidden` for avoid this layout break (see small screenshot). But I think that is better set a max length to these names.

Signed-off-by: Matheus Fernandes <matheus.souza.fernandes@gmail.com>