### PR TITLE
automate portus release

### DIFF
--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+bundle version 2>/dev/null
+if [ $? != 0 ];then
+  echo "bundler is not installed. Please install it."
+  exit -1
+fi
 cd $(dirname $0)
 
 if [ $TRAVIS_BRANCH ];then

--- a/packaging/suse/release/.gitignore
+++ b/packaging/suse/release/.gitignore
@@ -1,0 +1,1 @@
+project.xml

--- a/packaging/suse/release/README
+++ b/packaging/suse/release/README
@@ -1,0 +1,8 @@
+release.sh automates the creation of a project in the open suse build service
+for a new release and it copies all the dependencies.
+
+To be more specific, it creates a subproject in Virtualization:containers:Portus
+and it copies all packages. Then, it will set the version in the spec file and
+get the tarball for that specific version (it assumes you have tagged git)
+
+

--- a/packaging/suse/release/project.xml.template
+++ b/packaging/suse/release/project.xml.template
@@ -1,0 +1,22 @@
+<project name="Virtualization:containers:Portus:Release:__RELEASE__">
+  <title>__RELEASE__ Release</title>
+  <description></description>
+  <person userid="flavio_castelli" role="maintainer"/>
+  <person userid="jordimassaguerpla" role="maintainer"/>
+  <repository name="openSUSE_Leap_42.1">
+    <path project="openSUSE:Leap:42.1" repository="standard"/>
+    <arch>x86_64</arch>
+  </repository>
+  <repository name="openSUSE_13.2">
+    <path project="openSUSE:13.2" repository="standard"/>
+    <arch>x86_64</arch>
+  </repository>
+  <repository name="images">
+    <arch>x86_64</arch>
+  </repository>
+  <repository name="SLE_12">
+    <path project="SUSE:SLE-12:GA" repository="standard"/>
+    <arch>x86_64</arch>
+  </repository>
+</project>
+

--- a/packaging/suse/release/release.sh
+++ b/packaging/suse/release/release.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+set -ex
+cd $(dirname $0)
+
+usage_and_exit() {
+  echo "usage $0 X.Y.Z"
+  echo "Where X.Y.Z is the new release number"
+  exit -1
+}
+
+if [ $# != 1 ];then
+  usage_and_exit
+fi
+if [ $1 == "help" ];then
+  usage_and_exit
+fi
+if [ $1 == "-h" ];then
+  usage_and_exit
+fi
+if [[ ! "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]];then
+ usage_and_exit
+fi 
+
+RELEASE=$1
+MAJOR_VERSION=$(echo $RELEASE | rev | cut -d. -f1 --complement | rev)
+BRANCH="v$MAJOR_VERSION"
+ORIG_PROJECT=Virtualization:containers:Portus
+DEST_PROJECT=$ORIG_PROJECT:Release:$RELEASE
+API=https://api.opensuse.org
+OSC="osc -A $API"
+
+echo "Setting release $RELEASE in project config template"
+sed -e "s/__RELEASE__/$RELEASE/g" project.xml.template > project.xml
+
+echo "Creating new subproject $DEST_PROJECT"
+$OSC meta prj $DEST_PROJECT --file=project.xml
+
+echo "Copying packages to the new project"
+for package in $($OSC ls $ORIG_PROJECT );do $OSC copypac -e $ORIG_PROJECT $package $DEST_PROJECT; done
+
+echo "Checking out Portus package"
+DIR=/tmp/$0/$RANDOM
+mkdir -p $DIR
+pushd $DIR
+$OSC checkout $DEST_PROJECT Portus
+
+echo "Setting version in _service file"
+cd $DEST_PROJECT/Portus
+sed -e "s/master.tar.gz/$RELEASE.tar.gz/g" -i _service
+
+echo "Getting tarball"
+$OSC service run
+
+echo "Generate spec file"
+mv _service\:download_url\:$RELEASE.tar.gz $RELEASE.tar.gz
+tar zxvf $RELEASE.tar.gz
+cd Portus-$RELEASE/packaging/suse
+TRAVIS_COMMIT=$RELEASE TRAVIS_BRANCH=$BRANCH ./make_spec.sh
+cd -
+cp Portus-$RELEASE/packaging/suse/Portus.spec .
+
+echo "Setting version $RELEASE in spec file"
+sed -e "s/%define branch master/%define branch $RELEASE/g" -i Portus.spec
+sed -e "s/Version: .*/Version:        $RELEASE/g" -i Portus.spec
+
+echo "Commiting new project"
+$OSC commit -m "set release to $RELEASE"
+
+echo "Cleaning..."
+rm -rf $DIR
+popd
+
+


### PR DESCRIPTION
This commit adds a "release.sh" script that will release portus in the
build service.

It assumes you will have already tagged and update the VERSION file, as
well as updated the CHANGELOG (see http://port.us.org/docs/how_we_release.html)

It includes a small fix in the make_spec.sh that checks for bundler

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>