### PR TITLE
rename Portus to portus

### DIFF
--- a/packaging/suse/Portus.spec.in
+++ b/packaging/suse/Portus.spec.in
@@ -15,7 +15,7 @@
 # Please submit bugfixes or comments via http://bugs.opensuse.org/
 #
 
-Name:           Portus
+Name:           portus
 
 # When you release a new version, set Version and branch accordingly.
 # For example:
@@ -43,6 +43,10 @@ BuildRequires:  ruby-macros >= 5
 Requires:       rubygem-passenger-apache2
 %{?systemd_requires}
 Provides:       Portus = %{version}
+Obsoletes:      Portus < %{version}
+# Portus-20151120162040 was accidentaly released when it should have been Portus-2.0
+# This is the reason why we are obsoleting it
+Obsoletes:      Portus = 20151120162040
 # javascript engine to build assets
 BuildRequires:  nodejs
 


### PR DESCRIPTION
This is a fix in order to obsolete Portus-20151120162040 that got
accidentally pushed instead of Portus-2.0

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>