### PR TITLE
Added links to the new mailing list

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -49,4 +49,8 @@ documentation. If you want to contribute directly to this documentation page,
 you might want to open up a new pull request against the
 [gh-pages](https://github.com/SUSE/Portus/tree/gh-pages) branch.
 
+For any other doubt that you may have regarding our documentation or anything
+about Portus in general, feel free to say something in our [mailing
+list](https://groups.google.com/forum/#!forum/portus-dev).
+
 ##### Thanks for your support!

--- a/index.html
+++ b/index.html
@@ -7,8 +7,9 @@ layout: default
     <h2 class="text-uppercase wow fadeInUp" data-wow-delay="100ms" lang="en">Claim control of your</h2>
     <h1 class="text-uppercase wow fadeInUp" data-wow-delay="100ms" lang="en">Docker images</h1>
     <hr class="wow zoomIn img-responsive" data-wow-delay="500ms">
-    <a href="https://github.com/SUSE/Portus" class="btn btn-primary wow fadeInUp" data-wow-delay="700ms" lang="en">View on GitHub</a>
     <a href="#" data-linkto="try-portus" class="smoothScroll btn btn-primary wow fadeInUp" data-wow-delay="900ms" lang="en">Try out Portus</a>
+    <a href="https://github.com/SUSE/Portus" class="btn btn-primary wow fadeInUp" data-wow-delay="700ms" lang="en">View on GitHub</a>
+    <a href="https://groups.google.com/forum/#!forum/portus-dev" class="btn btn-primary wow fadeInUp" data-wow-delay="700ms" lang="en">Mailing list</a>
   </div>
 </section>
 <section id="what-is-portus" class="text-center fixit-container">
@@ -120,6 +121,6 @@ layout: default
 <section id="feedback" class="text-center">
   <div class="container-flui">
     <h3 class="wow fadeInUp" lang="en">Feedback, comments, contributions?</h3>
-    <p class="wow fadeInUp"><span lang="en">Open an</span> <a href='https://github.com/SUSE/Portus/issues' lang="en"> issue</a> <span lang="en">or subscribe to the</span> <a href='http://lists.suse.com/mailman/listinfo/containers'>containers@lists.suse.com</a> <span lang="en">mailing list.</span></p>
+    <p class="wow fadeInUp"><span lang="en">Open an</span> <a href='https://github.com/SUSE/Portus/issues' lang="en"> issue</a> <span lang="en">or subscribe to the</span> <a href='https://groups.google.com/forum/#!forum/portus-dev'>Portus mailing list</a> <span lang="en">mailing list.</span> </p>
   </div>
 </section>


### PR DESCRIPTION
I've also re-arranged the buttons from the index page: the first one is the
"Try out Portus" button which just jumps to a section; and the other two are
just fancy links (github and mailing list).

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>