### PR TITLE
Distribution 2.4 now provides the tag on the notification

### DIFF
--- a/app/models/registry.rb
+++ b/app/models/registry.rb
@@ -107,6 +107,13 @@ class Registry < ActiveRecord::Base
 
   # Fetch the tag being pushed through the given target object.
   def get_tag_from_target(namespace, repo, target)
+    # Since Docker Distribution 2.4 the registry finally sends the tag, so we
+    # don't have to perform requests afterwards.
+    return target["tag"] unless target["tag"].blank?
+
+    # Tough luck, we should now perform requests to fetch the tag. Note that
+    # depending on the Manifest version we have to do one thing or another
+    # because they expose different information.
     case target["mediaType"]
     when "application/vnd.docker.distribution.manifest.v1+json",
       "application/vnd.docker.distribution.manifest.v1+prettyjws"

--- a/spec/models/registry_spec.rb
+++ b/spec/models/registry_spec.rb
@@ -34,8 +34,9 @@ class RegistryMock < Registry
     o
   end
 
-  def get_tag_from_target_test(namespace, repo, mtype, digest)
+  def get_tag_from_target_test(namespace, repo, mtype, digest, tag = nil)
     target = { "mediaType" => mtype, "repository" => repo, "digest" => digest }
+    target["tag"] = tag unless tag.nil?
     get_tag_from_target(namespace, repo, target)
   end
 end
@@ -215,6 +216,15 @@ describe Registry, type: :model do
       expect(Rails.logger).to receive(:info).with(/Reason: unsupported media type "a"/)
 
       mock.get_tag_from_target_test(nil, "busybox", "a", "sha:1234")
+    end
+
+    it "fetches the tag from the target if it exists", focus: true do
+      mock = RegistryMock.new(false)
+
+      # We leave everything empty to show that if the tag is provided, we pick
+      # it, regardless of any other information.
+      ret  = mock.get_tag_from_target_test(nil, "", "", "", "0.1")
+      expect(ret).to eq "0.1"
     end
   end
 end


### PR DESCRIPTION
Since commit afe2bdd1c5194ac85a59adf1fdd14c9da054356e of docker distribution,
the registry now sends a `tag` key inside of `target` on each notification.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>