### PR TITLE
Don't allow access to the hidden global team

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -14,6 +14,8 @@ class TeamsController < ApplicationController
   # GET /teams/1
   # GET /teams/1.json
   def show
+    raise ActiveRecord::RecordNotFound if @team.name.starts_with?("portus_global_team_")
+
     authorize @team
     @team_users = @team.team_users.enabled.page(params[:users_page]).per(10)
     @team_namespaces = @team.namespaces.page(params[:namespaces_page]).per(15)

--- a/app/views/namespaces/show.html.slim
+++ b/app/views/namespaces/show.html.slim
@@ -43,9 +43,10 @@
       'Namespace:
       strong
         = @namespace.clean_name
-    h6.label.label-info
-      | <span>Belongs to: </span>
-      = link_to "#{@namespace.team.name}", @namespace.team
+    - unless @namespace.global?
+      h6.label.label-info
+        | <span>Belongs to: </span>
+        = link_to "#{@namespace.team.name}", @namespace.team
   .panel-body
     .table-responsive
       table.table.table-stripped.table-hover

--- a/spec/controllers/teams_controller_spec.rb
+++ b/spec/controllers/teams_controller_spec.rb
@@ -13,6 +13,11 @@ RSpec.describe TeamsController, type: :controller do
 
   let(:owner) { create(:user) }
   let(:team) { create(:team, description: "short test description", owners: [owner]) }
+  let(:hidden_team) do
+    create(:team, name: "portus_global_team_1",
+           description: "short test description", owners: [owner],
+           hidden: true)
+  end
 
   describe "GET #show" do
 
@@ -40,6 +45,12 @@ RSpec.describe TeamsController, type: :controller do
       get :show, id: team.id
 
       expect(response.status).to eq 401
+    end
+
+    it "drops requests to a hidden global team" do
+      sign_in owner
+
+      expect { get :show, id: hidden_team.id }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it "does not display disabled users" do


### PR DESCRIPTION
The link to the global team is now hidden. If a user tries to access it
anyway, the user is presented with a 404 error.

Fixes #658

Signed-off-by: Thomas Hipp <thipp@suse.com>