### PR TITLE
Set proper rails generator defaults

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -25,5 +25,13 @@ module Portus
     config.autoload_paths << Rails.root.join("lib")
     config.autoload_paths << Rails.root.join("app/validators/")
     config.exceptions_app = routes
+
+    config.generators do |g|
+      g.template_engine :slim
+      g.test_framework :rspec
+      g.fixture_replacement :factory_girl
+
+      g.fallbacks[:rspec] = :test_unit
+    end
   end
 end


### PR DESCRIPTION
To avoid the requirement to provide additional flags while using the
builtin rails generators I have added some flags to the application
configuration. Now the generator always uses rspec, slim and
factory_girl by default, and test_unit as a fallback if any generator
doesn't support rspec.

Signed-off-by: Thomas Boerger <tboerger@suse.de>