### PR TITLE
Annotate the models, factories and specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ end
 unless ENV["PACKAGING"] && ENV["PACKAGING"] == "yes"
 
   group :development do
+    gem "annotate"
     gem "rails-erd"
     gem "quiet_assets"
     gem "pry-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,9 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.3.8)
+    annotate (2.6.5)
+      activerecord (>= 2.3.0)
+      rake (>= 0.8.7)
     arel (6.0.0)
     ast (2.0.0)
     astrolabe (1.3.0)
@@ -326,6 +329,7 @@ PLATFORMS
 DEPENDENCIES
   active_model_serializers
   active_record_union
+  annotate
   awesome_print
   base32
   bcrypt

--- a/app/models/application_token.rb
+++ b/app/models/application_token.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: application_tokens
+#
+#  id          :integer          not null, primary key
+#  application :string(255)      not null
+#  token_hash  :string(255)      not null
+#  token_salt  :string(255)      not null
+#  user_id     :integer          not null
+#
+
 class ApplicationToken < ActiveRecord::Base
   include PublicActivity::Common
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: comments
+#
+#  id            :integer          not null, primary key
+#  body          :text(65535)
+#  repository_id :integer
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  user_id       :integer
+#
+
 class Comment < ActiveRecord::Base
   include PublicActivity::Common
   belongs_to :repository

--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: namespaces
+#
+#  id          :integer          not null, primary key
+#  name        :string(255)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  team_id     :integer
+#  public      :boolean          default("0")
+#  registry_id :integer          not null
+#  global      :boolean          default("0")
+#  description :text(65535)
+#
+
 class Namespace < ActiveRecord::Base
   include PublicActivity::Common
 

--- a/app/models/registry.rb
+++ b/app/models/registry.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: registries
+#
+#  id         :integer          not null, primary key
+#  name       :string(255)      not null
+#  hostname   :string(255)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  use_ssl    :boolean
+#
+
 # Registry holds data regarding the registries registered in the Portus
 # application.
 #

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: repositories
+#
+#  id           :integer          not null, primary key
+#  name         :string(255)      default(""), not null
+#  namespace_id :integer
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+
 class Repository < ActiveRecord::Base
   include PublicActivity::Common
   include SearchCop

--- a/app/models/star.rb
+++ b/app/models/star.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: stars
+#
+#  id            :integer          not null, primary key
+#  user_id       :integer
+#  repository_id :integer
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
+
 class Star < ActiveRecord::Base
   belongs_to :repository
   belongs_to :user

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: tags
+#
+#  id            :integer          not null, primary key
+#  name          :string(255)      default("latest"), not null
+#  repository_id :integer          not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  user_id       :integer
+#  digest        :string(255)
+#
+
 # A tag as defined by Docker. It belongs to a repository and an author. The
 # name follows the format as defined in registry/api/v2/names.go from Docker's
 # Distribution project. The default name for a tag is "latest".

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: teams
+#
+#  id          :integer          not null, primary key
+#  name        :string(255)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  hidden      :boolean          default("0")
+#  description :text(65535)
+#
+
 class Team < ActiveRecord::Base
   include PublicActivity::Common
 

--- a/app/models/team_user.rb
+++ b/app/models/team_user.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: team_users
+#
+#  id         :integer          not null, primary key
+#  user_id    :integer
+#  team_id    :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  role       :integer          default("0")
+#
+
 # Class describing a member of a team
 #
 # Meaning of the role column:

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,28 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :integer          not null, primary key
+#  username               :string(255)      default(""), not null
+#  email                  :string(255)      default("")
+#  encrypted_password     :string(255)      default(""), not null
+#  reset_password_token   :string(255)
+#  reset_password_sent_at :datetime
+#  remember_created_at    :datetime
+#  sign_in_count          :integer          default("0"), not null
+#  current_sign_in_at     :datetime
+#  last_sign_in_at        :datetime
+#  current_sign_in_ip     :string(255)
+#  last_sign_in_ip        :string(255)
+#  created_at             :datetime
+#  updated_at             :datetime
+#  admin                  :boolean          default("0")
+#  enabled                :boolean          default("1")
+#  ldap_name              :string(255)
+#  failed_attempts        :integer          default("0")
+#  locked_at              :datetime
+#
+
 class User < ActiveRecord::Base
   devise :database_authenticatable, :registerable, :lockable,
          :recoverable, :rememberable, :trackable, :validatable, authentication_keys: [:username]

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: comments
+#
+#  id            :integer          not null, primary key
+#  body          :text(65535)
+#  repository_id :integer
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  user_id       :integer
+#
+
 FactoryGirl.define do
   factory :comment do
     sequence :body do |b|

--- a/spec/factories/namespaces.rb
+++ b/spec/factories/namespaces.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: namespaces
+#
+#  id          :integer          not null, primary key
+#  name        :string(255)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  team_id     :integer
+#  public      :boolean          default("0")
+#  registry_id :integer          not null
+#  global      :boolean          default("0")
+#  description :text(65535)
+#
+
 FactoryGirl.define do
   factory :namespace do
     sequence :name do |n|

--- a/spec/factories/registries.rb
+++ b/spec/factories/registries.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: registries
+#
+#  id         :integer          not null, primary key
+#  name       :string(255)      not null
+#  hostname   :string(255)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  use_ssl    :boolean
+#
+
 FactoryGirl.define do
   factory :registry do
     before(:create) { create(:admin) }

--- a/spec/factories/repositories.rb
+++ b/spec/factories/repositories.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: repositories
+#
+#  id           :integer          not null, primary key
+#  name         :string(255)      default(""), not null
+#  namespace_id :integer
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+
 FactoryGirl.define do
   factory :repository do
     sequence :name do |n|

--- a/spec/models/application_token_spec.rb
+++ b/spec/models/application_token_spec.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: application_tokens
+#
+#  id          :integer          not null, primary key
+#  application :string(255)      not null
+#  token_hash  :string(255)      not null
+#  token_salt  :string(255)      not null
+#  user_id     :integer          not null
+#
+
 require "rails_helper"
 
 describe ApplicationToken do

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: comments
+#
+#  id            :integer          not null, primary key
+#  body          :text(65535)
+#  repository_id :integer
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  user_id       :integer
+#
+
 require "rails_helper"
 
 describe Comment do

--- a/spec/models/namespace_spec.rb
+++ b/spec/models/namespace_spec.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: namespaces
+#
+#  id          :integer          not null, primary key
+#  name        :string(255)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  team_id     :integer
+#  public      :boolean          default("0")
+#  registry_id :integer          not null
+#  global      :boolean          default("0")
+#  description :text(65535)
+#
+
 require "rails_helper"
 
 describe Namespace do

--- a/spec/models/registry_spec.rb
+++ b/spec/models/registry_spec.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: registries
+#
+#  id         :integer          not null, primary key
+#  name       :string(255)      not null
+#  hostname   :string(255)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  use_ssl    :boolean
+#
+
 require "rails_helper"
 
 # Open up Portus::RegistryClient to inspect some attributes.

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: repositories
+#
+#  id           :integer          not null, primary key
+#  name         :string(255)      default(""), not null
+#  namespace_id :integer
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+
 require "rails_helper"
 
 # Auxiliar method to get the URL format used in this spec file.

--- a/spec/models/star_spec.rb
+++ b/spec/models/star_spec.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: stars
+#
+#  id            :integer          not null, primary key
+#  user_id       :integer
+#  repository_id :integer
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
+
 require "rails_helper"
 
 describe Star do

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: tags
+#
+#  id            :integer          not null, primary key
+#  name          :string(255)      default("latest"), not null
+#  repository_id :integer          not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  user_id       :integer
+#  digest        :string(255)
+#
+
 require "rails_helper"
 
 describe Tag do

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: teams
+#
+#  id          :integer          not null, primary key
+#  name        :string(255)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  hidden      :boolean          default("0")
+#  description :text(65535)
+#
+
 require "rails_helper"
 
 describe Team do

--- a/spec/models/team_user_spec.rb
+++ b/spec/models/team_user_spec.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: team_users
+#
+#  id         :integer          not null, primary key
+#  user_id    :integer
+#  team_id    :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  role       :integer          default("0")
+#
+
 require "rails_helper"
 
 describe TeamUser do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,3 +1,28 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :integer          not null, primary key
+#  username               :string(255)      default(""), not null
+#  email                  :string(255)      default("")
+#  encrypted_password     :string(255)      default(""), not null
+#  reset_password_token   :string(255)
+#  reset_password_sent_at :datetime
+#  remember_created_at    :datetime
+#  sign_in_count          :integer          default("0"), not null
+#  current_sign_in_at     :datetime
+#  last_sign_in_at        :datetime
+#  current_sign_in_ip     :string(255)
+#  last_sign_in_ip        :string(255)
+#  created_at             :datetime
+#  updated_at             :datetime
+#  admin                  :boolean          default("0")
+#  enabled                :boolean          default("1")
+#  ldap_name              :string(255)
+#  failed_attempts        :integer          default("0")
+#  locked_at              :datetime
+#
+
 require "rails_helper"
 
 describe User do


### PR DESCRIPTION
In order to make the start for newbies easier I have added the annotate gem
which adds the available columns including some meta information as
documentation to the top of all models, factories and model specs.

Signed-off-by: Thomas Boerger <tboerger@suse.de>