### PR TITLE
Handle delete events

### DIFF
--- a/app/models/registry.rb
+++ b/app/models/registry.rb
@@ -64,8 +64,9 @@ class Registry < ActiveRecord::Base
   # returns three values:
   #   - A Namespace object.
   #   - A String containing the name of the repository.
-  #   - A String containing the name of the tag.
-  def get_namespace_from_event(event)
+  #   - A String containing the name of the tag or nil if the `fetch_tag`
+  #     parameter has been set to false.
+  def get_namespace_from_event(event, fetch_tag = true)
     repo = event["target"]["repository"]
     if repo.include?("/")
       namespace_name, repo = repo.split("/", 2)
@@ -79,8 +80,12 @@ class Registry < ActiveRecord::Base
       return
     end
 
-    tag_name = get_tag_from_target(namespace, repo, event["target"])
-    return if tag_name.nil?
+    if fetch_tag
+      tag_name = get_tag_from_target(namespace, repo, event["target"])
+      return if tag_name.nil?
+    else
+      tag_name = nil
+    end
 
     [namespace, repo, tag_name]
   end

--- a/lib/portus/registry_notification.rb
+++ b/lib/portus/registry_notification.rb
@@ -2,24 +2,32 @@ module Portus
   # Handle an event as given by the Registry and processes it so it can be
   # consumed later on.
   class RegistryNotification
+    # An array with the events that a handler has to support.
+    HANDLED_EVENTS = ["push", "delete"].freeze
+
     # Processes the notification data with the given handler. The data is the
     # parsed JSON body as given by the registry. A handler is a class that can
-    # call the `handle_push_event` method. This method receives an `event`
+    # call the `handle_#{event}_event` method. This method receives an `event`
     # object, which is the event object as given by the registry.
     def self.process!(data, handler)
       data["events"].each do |event|
+        Rails.logger.debug "Incoming event:\n#{JSON.pretty_generate(event)}"
         next unless relevant?(event)
-        Rails.logger.info "Handling Push event:\n#{JSON.pretty_generate(event)}"
-        handler.handle_push_event(event)
+
+        action = event["action"]
+        next unless HANDLED_EVENTS.include?(action)
+        Rails.logger.info "Handling '#{action}' event:\n#{JSON.pretty_generate(event)}"
+
+        handler.send("handle_#{action}_event".to_sym, event)
       end
     end
 
     # A relevant event is one that contains the "push" action, and that
     # contains a Manifest v1 object in the target.
     def self.relevant?(event)
-      return false unless event["action"] == "push"
       return false unless event["target"].is_a?(Hash)
-      event["target"]["mediaType"].start_with? "application/vnd.docker.distribution.manifest"
+      return true if event["action"] == "delete"
+      event["target"]["mediaType"].starts_with? "application/vnd.docker.distribution.manifest"
     end
   end
 end

--- a/spec/lib/portus/registry_notification_spec.rb
+++ b/spec/lib/portus/registry_notification_spec.rb
@@ -27,6 +27,32 @@ describe Portus::RegistryNotification do
     }
   end
 
+  let(:delete) do
+    {
+      "id"        => "6d673710-06b5-48b5-a7d9-94cbaacf776b",
+      "timestamp" => "2016-04-13T15:03:39.595901492+02:00",
+      "action"    => "delete",
+      "target"    => {
+        "digest"     => "sha256:03d564cd8008f956c844cd3e52affb49bc0b65e451087a1ac9013c0140c595df",
+        "repository" => "registry"
+      },
+      "request"   => {
+        "id"        => "fae66612-ef48-4157-8994-bd146fbdd951",
+        "addr"      => "127.0.0.1:55452",
+        "host"      => "registry.mssola.cat:5000",
+        "method"    => "DELETE",
+        "useragent" => "Ruby"
+      },
+      "actor"     => {
+        "name" => "portus"
+      },
+      "source"    => {
+        "addr"       => "bucket:5000",
+        "instanceID" => "741bc03b-6ebe-4ffc-b6b1-4b33d5fc2090"
+      }
+    }
+  end
+
   # This is a real even notification as given by docker distribution v2.3
   # rubocop:disable Metrics/LineLength
   let(:version23) do
@@ -62,8 +88,10 @@ describe Portus::RegistryNotification do
 
   it "processes all the relevant events" do
     body["events"] << relevant
+    body["events"] << delete
     body["events"] << version23
     expect(Repository).to receive(:handle_push_event).with(relevant)
+    expect(Repository).to receive(:handle_delete_event).with(delete)
     expect(Repository).to receive(:handle_push_event).with(version23)
     Portus::RegistryNotification.process!(body, Repository)
   end


### PR DESCRIPTION
Whenever a manifest gets deleted, the registry will send a "delete" event to
Portus. In this commit Portus will be able to react to these events
accordingly: remove specified tag if available, and remove the repository if
it's left empty of tags.

Signed-off-by: Miquel Sabaté <msabate@suse.com>