### PR TITLE
crono: update digests when creating tags

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -137,8 +137,16 @@ class Repository < ActiveRecord::Base
     to_be_created_tags = repo["tags"] - tags
     to_be_deleted_tags = tags - repo["tags"]
 
+    client = Registry.get.client
     to_be_created_tags.each do |tag|
-      Tag.create!(name: tag, repository: repository, author: portus)
+      # Try to fetch the manifest digest of the tag.
+      begin
+        digest = client.manifest(name, tag, true)
+      rescue
+        digest = ""
+      end
+
+      Tag.create!(name: tag, repository: repository, author: portus, digest: digest)
       logger.tagged("catalog") { logger.info "Created the tag '#{tag}'." }
     end
 

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -392,6 +392,10 @@ describe Repository do
     let!(:tag2)        { create(:tag, name: "tag2", repository: repo2) }
     let!(:tag3)        { create(:tag, name: "tag3", repository: repo2) }
 
+    before :each do
+      allow_any_instance_of(Portus::RegistryClient).to receive(:manifest).and_return("digest")
+    end
+
     it "adds and deletes tags accordingly" do
       # Removes the existing tag and adds two.
       repo = { "name" => "#{namespace.name}/repo1", "tags" => ["latest", "0.1"] }
@@ -417,6 +421,7 @@ describe Repository do
       repo = Repository.create_or_update!(repo)
       expect(repo.name).to eq "busybox"
       expect(repo.tags.map(&:name).sort).to match_array(["0.1", "latest"])
+      expect(repo.tags.map(&:digest).uniq).to match_array(["digest"])
 
       # Trying to create a repo into an unknown namespace.
       repo = { "name" => "unknown/repo1", "tags" => ["latest", "0.1"] }


### PR DESCRIPTION
In this commit the CatalogJob task will also update the manifest digests of
the tags that are to be created.

See #822

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>