### PR TITLE
suse: wrap crono with the exec command

### DIFF
--- a/packaging/suse/bin/portus_crono
+++ b/packaging/suse/bin/portus_crono
@@ -5,5 +5,5 @@ export RAILS_ENV=production
 bundle="/srv/Portus/vendor/bundle/ruby/2.1.0/bin/bundler.ruby2.1"
 export GEM_PATH=/srv/Portus/vendor/bundle/ruby/2.1.0/
 pushd /srv/Portus
-$bundle exec crono
+exec $bundle exec crono
 


### PR DESCRIPTION
This way signals sent to bash are properly propagated to crono.

bnc#976113

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>