### PR TITLE
Don't allow usernames to clash with teams

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -47,7 +47,8 @@ describe User do
     expect(user.save).to be false
     expect(user.errors.size).to eq(1)
     expect(user.errors.first)
-      .to match_array([:username, "cannot be used as name for private namespace"])
+      .to match_array([:username, "'coolname' cannot be used: there's either a namespace or " \
+        "a team named like this."])
   end
 
   it "#email_required?" do


### PR DESCRIPTION
Up until now we allowed users to have the same username as some teams. This is
troublesome because then the private team assigned to this user would clash
with the existing one.

In the future we should figure out a way to better handle these hidden teams
(e.g. by creating one with a random name and the reference it on the user row).
For now, in order to not be too disruptive we will disallow creating users with
the same name as an existing team (note that the other way around is also
disallowed).

Fixes #836

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>