### PR TITLE
Upgrade rails_stdout_logging to 0.0.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem "net-ldap"
 gem "redcarpet"
 gem "font-awesome-rails"
 gem "bootstrap-typeahead-rails"
-gem "rails_stdout_logging", group: [:development, :staging, :production]
+gem "rails_stdout_logging", "~> 0.0.5", group: [:development, :staging, :production]
 
 # Used to store application tokens. This is already a Rails depedency. However
 # better safe than sorry...

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -254,7 +254,7 @@ GEM
       ruby-graphviz (~> 1.2)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
-    rails_stdout_logging (0.0.4)
+    rails_stdout_logging (0.0.5)
     railties (4.2.6)
       actionpack (= 4.2.6)
       activesupport (= 4.2.6)
@@ -423,7 +423,7 @@ DEPENDENCIES
   rack-mini-profiler
   rails (~> 4.2.6)
   rails-erd
-  rails_stdout_logging
+  rails_stdout_logging (~> 0.0.5)
   redcarpet
   rspec-rails
   rubocop


### PR DESCRIPTION
The version 4.2.6 of rails crashes on start.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>