### PR TITLE
Better Sub-URI handling & configurable config-local.yml path

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,6 @@
 # This file is used by Rack-based servers to start the application.
 
 require ::File.expand_path("../config/environment", __FILE__)
-run Rails.application
+map Rails.application.config.relative_url_root || "/" do
+  run Rails.application
+end

--- a/config/initializers/config.rb
+++ b/config/initializers/config.rb
@@ -1,4 +1,4 @@
 default    = File.join(Rails.root, "config", "config.yml")
-local      = File.join(Rails.root, "config", "config-local.yml")
+local      = ENV["PORTUS_LOCAL_CONFIG_PATH"] || File.join(Rails.root, "config", "config-local.yml")
 cfg        = Portus::Config.new(default, local)
 APP_CONFIG = cfg.fetch

--- a/lib/tasks/info.rake
+++ b/lib/tasks/info.rake
@@ -3,7 +3,7 @@ namespace :portus do
   task info: :environment do
     puts "\nPortus version: #{Version.value}"
     default = File.join(Rails.root, "config", "config.yml")
-    local   = File.join(Rails.root, "config", "config-local.yml")
+    local   = ENV["PORTUS_LOCAL_CONFIG_PATH"] || File.join(Rails.root, "config", "config-local.yml")
     cfg     = Portus::Config.new(default, local)
     puts "Portus has evaluated the following configuration:\n#{cfg}"
   end


### PR DESCRIPTION
Hi,

Would you mind to add these changes? Both are falling back gracefully and therefore shouldn't break anything.

First change improves Sub-URI compatibility with non-passenger setups: you just set `RAILS_RELATIVE_URL_ROOT` environment variable to something like `/portus` and app server starts to serve Portus from subdirectory.

Second change adds ability to set custom path to `config-local.yml` file by setting `PORTUS_LOCAL_CONFIG_PATH` environment variable. This is helpful when setting up on Kubernetes where it's not possible to mount just single file to container, but directory.