### PR TITLE
Add the Image ID in the repositories#show page

### DIFF
--- a/app/models/registry.rb
+++ b/app/models/registry.rb
@@ -179,7 +179,8 @@ class Registry < ActiveRecord::Base
   #
   # Returns the name of the tag if found, nil otherwise.
   def get_tag_from_manifest(target)
-    client.manifest(target["repository"], target["digest"])["tag"]
+    _, _, manifest = client.manifest(target["repository"], target["digest"])
+    manifest["tag"]
   end
 
   # Create the global namespace for this registry and create the personal

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -9,6 +9,7 @@
 #  updated_at    :datetime         not null
 #  user_id       :integer
 #  digest        :string(255)
+#  image_id      :string(255)      default("")
 #
 # Indexes
 #

--- a/app/views/repositories/show.html.slim
+++ b/app/views/repositories/show.html.slim
@@ -19,12 +19,14 @@
     .table-responsive.tags
       table.table.table-stripped.table-hover
         col.col-40
-        col.col-40
+        col.col-20
+        col.col-20
         col.col-20
         thead
           tr
             th Tag
             th Author
+            th Image
             th Pushed at
         tbody
           - @tags.each do |tag|
@@ -35,6 +37,12 @@
                     .label.label-success
                       = t.name
                   td= tag.first.author.username
+                  td
+                    - if tag.first.image_id.empty?
+                      = "-"
+                    - else
+                      span[title="sha256:#{tag.first.image_id}"]
+                        = tag.first.image_id[0, 12]
                   td= tag.first.created_at
             - else
               tr
@@ -43,6 +51,12 @@
                     .label.label-success
                       = t.name
                 td= tag.first.author.username
+                td
+                  - if tag.first.image_id.empty?
+                    = "-"
+                  - else
+                    span[title="sha256:#{tag.first.image_id}"]
+                      = tag.first.image_id[0, 12]
                 td= tag.first.created_at
 
 #write_comment_form.collapse

--- a/bin/client.rb
+++ b/bin/client.rb
@@ -46,8 +46,10 @@ when "manifest"
     name, tag = ARGV[1], "latest"
   end
 
-  puts JSON.pretty_generate(registry.client.manifest(name, tag))
-  puts "Manifest digest: #{registry.client.manifest(name, tag, true)}"
+  id, digest, manifest = registry.client.manifest(name, tag)
+  puts "Image ID: #{id} (truncated as in Docker: #{id[0, 12]})"
+  puts "Manifest digest: #{digest}"
+  puts JSON.pretty_generate(manifest)
 when "ping"
   # No registry was found, trying to ping another one.
   if registry.nil?

--- a/db/migrate/20160422075603_add_image_id_to_tag.rb
+++ b/db/migrate/20160422075603_add_image_id_to_tag.rb
@@ -1,0 +1,5 @@
+class AddImageIdToTag < ActiveRecord::Migration
+  def change
+    add_column :tags, :image_id, :string, default: ""
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151215152138) do
+ActiveRecord::Schema.define(version: 20160422075603) do
 
   create_table "activities", force: :cascade do |t|
     t.integer  "trackable_id",   limit: 4
@@ -54,7 +54,7 @@ ActiveRecord::Schema.define(version: 20151215152138) do
   create_table "crono_jobs", force: :cascade do |t|
     t.string   "job_id",            limit: 255, null: false
     t.datetime "last_performed_at"
-    t.boolean  "healthy",           limit: 1
+    t.boolean  "healthy"
     t.datetime "created_at",                    null: false
     t.datetime "updated_at",                    null: false
   end
@@ -66,9 +66,9 @@ ActiveRecord::Schema.define(version: 20151215152138) do
     t.datetime "created_at",                                null: false
     t.datetime "updated_at",                                null: false
     t.integer  "team_id",     limit: 4
-    t.boolean  "public",      limit: 1,     default: false
+    t.boolean  "public",                    default: false
     t.integer  "registry_id", limit: 4,                     null: false
-    t.boolean  "global",      limit: 1,     default: false
+    t.boolean  "global",                    default: false
     t.text     "description", limit: 65535
   end
 
@@ -82,7 +82,7 @@ ActiveRecord::Schema.define(version: 20151215152138) do
     t.string   "hostname",   limit: 255, null: false
     t.datetime "created_at",             null: false
     t.datetime "updated_at",             null: false
-    t.boolean  "use_ssl",    limit: 1
+    t.boolean  "use_ssl"
   end
 
   add_index "registries", ["hostname"], name: "index_registries_on_hostname", unique: true, using: :btree
@@ -116,6 +116,7 @@ ActiveRecord::Schema.define(version: 20151215152138) do
     t.datetime "updated_at",                                   null: false
     t.integer  "user_id",       limit: 4
     t.string   "digest",        limit: 255
+    t.string   "image_id",      limit: 255, default: ""
   end
 
   add_index "tags", ["name", "repository_id"], name: "index_tags_on_name_and_repository_id", unique: true, using: :btree
@@ -137,7 +138,7 @@ ActiveRecord::Schema.define(version: 20151215152138) do
     t.string   "name",        limit: 255
     t.datetime "created_at",                                null: false
     t.datetime "updated_at",                                null: false
-    t.boolean  "hidden",      limit: 1,     default: false
+    t.boolean  "hidden",                    default: false
     t.text     "description", limit: 65535
   end
 
@@ -157,8 +158,8 @@ ActiveRecord::Schema.define(version: 20151215152138) do
     t.string   "last_sign_in_ip",        limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "admin",                  limit: 1,   default: false
-    t.boolean  "enabled",                limit: 1,   default: true
+    t.boolean  "admin",                              default: false
+    t.boolean  "enabled",                            default: true
     t.string   "ldap_name",              limit: 255
     t.integer  "failed_attempts",        limit: 4,   default: 0
     t.datetime "locked_at"

--- a/spec/features/repositories_spec.rb
+++ b/spec/features/repositories_spec.rb
@@ -42,17 +42,20 @@ feature "Repositories support" do
 
     scenario "Groupped tags are handled properly", js: true do
       ["", "", "same", "same", "another", "yet-another"].each_with_index do |digest, idx|
-        create(:tag, name: "tag#{idx}", author: user, repository: repository, digest: digest)
+        create(:tag, name: "tag#{idx}", author: user, repository: repository, digest: digest,
+               image_id: "Image")
       end
 
-      expect = [["tag0"], ["tag1"], ["tag2", "tag3"], ["tag4"], ["tag5"]]
+      expectations = [["tag0"], ["tag1"], ["tag2", "tag3"], ["tag4"], ["tag5"]]
 
       visit repository_path(repository)
       page.all(".tags tr").each_with_index do |row, idx|
+        expect(row.text.include?("Image")).to be_truthy
+
         # Skip the header.
         next if idx == 0
 
-        expect[idx - 1].each { |tag| expect(row.text.include?(tag)).to be_truthy }
+        expectations[idx - 1].each { |tag| expect(row.text.include?(tag)).to be_truthy }
       end
     end
   end

--- a/spec/lib/portus/registry_client_spec.rb
+++ b/spec/lib/portus/registry_client_spec.rb
@@ -199,7 +199,7 @@ describe Portus::RegistryClient do
           username,
           password)
 
-        manifest = registry.manifest(repository, tag)
+        _, _, manifest = registry.manifest(repository, tag)
         expect(manifest["name"]).to eq(repository)
         expect(manifest["tag"]).to eq(tag)
       end

--- a/spec/models/registry_spec.rb
+++ b/spec/models/registry_spec.rb
@@ -41,7 +41,7 @@ class RegistryMock < Registry
       end
     else
       def o.manifest(*_)
-        { "tag" => "latest" }
+        ["id", "digest", { "tag" => "latest" }]
       end
 
       def o.tags(*_)

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -393,7 +393,9 @@ describe Repository do
     let!(:tag3)        { create(:tag, name: "tag3", repository: repo2) }
 
     before :each do
-      allow_any_instance_of(Portus::RegistryClient).to receive(:manifest).and_return("digest")
+      allow_any_instance_of(Portus::RegistryClient).to receive(:manifest).and_return(
+        ["id", "digest", ""])
+      allow(Repository).to receive(:id_and_digest_from_event).and_return(["id", "digest"])
     end
 
     it "adds and deletes tags accordingly" do

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -9,6 +9,7 @@
 #  updated_at    :datetime         not null
 #  user_id       :integer
 #  digest        :string(255)
+#  image_id      :string(255)      default("")
 #
 # Indexes
 #


### PR DESCRIPTION
This is the same Image ID that is shown in the docker client. In order to do
this, a new column has been added to the `tags` table. The registry client has
also been modified to handle all this more gracefully. The image ID being
shown is truncated in the exact same format as in the Docker client. That being
said, users can hover the mouse over the image ID and they'll get the full
image ID.

Fixes #512

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>