### PR TITLE
Evaluate ERB in config-local.yml

### DIFF
--- a/lib/portus/config.rb
+++ b/lib/portus/config.rb
@@ -17,7 +17,7 @@ module Portus
       local = {}
       if File.file?(@local)
         # Check for bad user input in the local config.yml file.
-        local = YAML.load_file(@local)
+        local = YAML.load(ERB.new(IO.read(@local)).result)
         unless local.is_a?(Hash)
           raise StandardError, "Wrong format for the config-local file!"
         end


### PR DESCRIPTION
Hello,

This change makes it possible to evaluate ERB code in `config-local.yaml`. This is useful if we don't want to store sensitive information, such as SMTP password, in the config file. Instead we can set the environment variable, then change our config to:
```
...
password: "<%= ENV['SMTP_PASSWORD'] %>"
...
```
I took the idea from quite popular `sidekiq` project, so I suppose it should be safe from security point of view.