### PR TITLE
fix markdown multi line code

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -29,7 +29,8 @@ module ApplicationHelper
   def markdown(text)
     extensions = {
       superscript:                  true,
-      disable_indented_code_blocks: true
+      disable_indented_code_blocks: true,
+      fenced_code_blocks:           true
     }
     render_options = {
       filter_html:         true,


### PR DESCRIPTION
Multi line code blocks are now displayed correctly.

Fixes #875

Signed-off-by: Thomas Hipp <thipp@suse.com>