### PR TITLE
Allow the FQDN to be specified through config

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,7 +32,7 @@ class ApplicationController < ActionController::Base
     {}.tap do |fix|
       fix[:ssl]                                = check_ssl
       fix[:secret_key_base]                    = secrets.secret_key_base == "CHANGE_ME"
-      fix[:secret_machine_fqdn]                = secrets.machine_fqdn.nil?
+      fix[:secret_machine_fqdn]                = fqdn.blank?
       fix[:secret_encryption_private_key_path] = secrets.encryption_private_key_path.nil?
       fix[:secret_portus_password]             = secrets.portus_password.nil?
       fix

--- a/app/views/errors/500.html.erb
+++ b/app/views/errors/500.html.erb
@@ -23,7 +23,7 @@
       <% if Rails.env.production? %>
         Set <i>PORTUS_MACHINE_FQDN</i> environment variable.
       <% else %>
-        Set <i>machine_fqdn</i> in <i>config/secrets.yml</i>.
+        Set <i>machine_fqdn</i> in <i>config/secrets.yml</i> or <i>config/config-local.yml</i>.
       <% end %>
     <% end %>
     <% if @fix[:secret_encryption_private_key_path] %>

--- a/app/views/errors/show.html.erb
+++ b/app/views/errors/show.html.erb
@@ -46,7 +46,7 @@
                 <% if Rails.env.production? %>
                   Set <i>PORTUS_MACHINE_FQDN</i> environment variable.
                 <% else %>
-                  Set <i>machine_fqdn</i> in <i>config/secrets.yml</i>.
+                  Set <i>machine_fqdn</i> in <i>config/secrets.yml</i> or <i>config/config-local.yml</i>.
                 <% end %>
               <% end %>
               <% if @fix[:secret_encryption_private_key_path] %>

--- a/config/config.yml
+++ b/config/config.yml
@@ -91,3 +91,8 @@ check_ssl_usage:
 # See: https://github.com/SUSE/Portus/issues/510
 jwt_expiration_time:
   value: "5.minutes"
+
+# The FQDN of the machine where Portus is being deployed. The default is kept
+# empty to make sure that backwards-compatibility is not broken.
+machine_fqdn:
+  value: ""

--- a/config/initializers/config.rb
+++ b/config/initializers/config.rb
@@ -2,3 +2,12 @@ default    = File.join(Rails.root, "config", "config.yml")
 local      = ENV["PORTUS_LOCAL_CONFIG_PATH"] || File.join(Rails.root, "config", "config-local.yml")
 cfg        = Portus::Config.new(default, local)
 APP_CONFIG = cfg.fetch
+
+# This method consumes the value of the FQDN from the app config if possible
+# (as implement in Portus v2.1.x). Otherwise, it falls back to the current way
+# of fetching it.
+def fqdn
+  mconf = APP_CONFIG["machine_fqdn"]
+  return Rails.application.secrets.machine_fqdn if mconf.nil? || mconf["value"].blank?
+  mconf["value"]
+end

--- a/config/initializers/mailer_url_options.rb
+++ b/config/initializers/mailer_url_options.rb
@@ -1,13 +1,13 @@
 # If you're on staging/production, then you must be using SSL. Otherwise, if
 # you're on development mode and you have set your own FQDN, then we assume
 # that SSL is in place too. Otherwise, SSL is not setup.
-if !Rails.env.development? || !ENV["PORTUS_MACHINE_FQDN"].nil?
+if !Rails.env.development? || !ENV["PORTUS_USE_SSL"].nil?
   protocol = "https://"
 else
   protocol = "http://"
 end
 
-host = Rails.application.secrets.machine_fqdn
+host = fqdn
 ActionMailer::Base.default_url_options[:host]     = host
 ActionMailer::Base.default_url_options[:protocol] = protocol
 

--- a/lib/portus/jwt_token.rb
+++ b/lib/portus/jwt_token.rb
@@ -29,7 +29,7 @@ module Portus
     # specification.
     def claim
       @claim ||= {}.tap do |hash|
-        hash[:iss]    = Rails.application.secrets.machine_fqdn
+        hash[:iss]    = fqdn
         hash[:sub]    = @account
         hash[:aud]    = @service
         hash[:iat]    = issued_at

--- a/packaging/suse/portusctl/templates/config-local.yml.erb
+++ b/packaging/suse/portusctl/templates/config-local.yml.erb
@@ -76,3 +76,7 @@ first_user_admin:
 # By default require ssl to be enabled when running on production
 check_ssl_usage:
   enabled: <%= @options["secure"] %>
+
+# The FQDN of the machine where Portus is being deployed.
+machine_fqdn:
+  value: <%= HOSTNAME %>

--- a/spec/controllers/errors_controller_spec.rb
+++ b/spec/controllers/errors_controller_spec.rb
@@ -6,7 +6,7 @@ describe ErrorsController do
       before :all do
         secrets = Rails.application.secrets
         @secret_key_base = secrets.secret_key_base
-        @secret_machine_fqdn = secrets.machine_fqdn
+        @secret_machine_fqdn = fqdn
         @secret_encryption_private_key_path = secrets.encryption_private_key_path
         @secret_portus_password = secrets.portus_password
       end

--- a/spec/lib/portus/jwt_token_spec.rb
+++ b/spec/lib/portus/jwt_token_spec.rb
@@ -56,7 +56,7 @@ describe Portus::JwtToken do
     describe "basic fields" do
       describe ":iss" do
         it "is set to portus fqdn" do
-          expect(subject.claim[:iss]).to eq Rails.application.secrets.machine_fqdn
+          expect(subject.claim[:iss]).to eq fqdn
         end
       end
 


### PR DESCRIPTION
This is something in between to what we have on the `v2.0` branch and the
`master` branch. This way we have the behavior from `master` while not breaking
what we had in previous patch-level releases.

This commit is largely based on 984671662ade8c105f019b1ee108b71ef87a9821 in the
`master` branch.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>