### PR TITLE
hide alert box instead of closing it

### DIFF
--- a/app/views/shared/_notification.html.slim
+++ b/app/views/shared/_notification.html.slim
@@ -1,6 +1,6 @@
 #alert[class="#{messages && messages.first ? '' : 'collapse'}"]
   .alert.alert-dismissible.fade.in.text-left[class="alert-#{alert}"]
-    button.close data-dismiss="alert" type="button"
+    button.close class="alert-hide" type="button"
       span aria-hidden="true" &times;
       span.sr-only Close
     .alert-message

--- a/vendor/assets/javascripts/lifeitup_layout.js
+++ b/vendor/assets/javascripts/lifeitup_layout.js
@@ -119,4 +119,7 @@ function open_mobile_menu () {
   }
 }
 
-
+// Hide alert box instead of closing it
+$(document).on('click', '.alert-hide', function() {
+  $(this).parent().parent().fadeOut();
+});


### PR DESCRIPTION
After closing an alert box, it is removed from the DOM, and won't show
unless the page is refreshed. This fix hides the alert box instead of
closing it.

Signed-off-by: Thomas Hipp <thipp@suse.com>