### PR TITLE
Fix when either the image_id or the digest are nil

### DIFF
--- a/app/views/repositories/show.html.slim
+++ b/app/views/repositories/show.html.slim
@@ -56,7 +56,7 @@
                       = t.name
                   td= tag.first.author.username
                   td
-                    - if tag.first.image_id.empty?
+                    - if tag.first.image_id.blank?
                       = "-"
                     - else
                       span[title="sha256:#{tag.first.image_id}"]
@@ -70,7 +70,7 @@
                       = t.name
                 td= tag.first.author.username
                 td
-                  - if tag.first.image_id.empty?
+                  - if tag.first.image_id.blank?
                     = "-"
                   - else
                     span[title="sha256:#{tag.first.image_id}"]

--- a/spec/features/repositories_spec.rb
+++ b/spec/features/repositories_spec.rb
@@ -59,5 +59,12 @@ feature "Repositories support" do
         expectations[idx - 1].each { |tag| expect(row.text.include?(tag)).to be_truthy }
       end
     end
+
+    scenario "it works if both the digest and the image_id are blank", js: true do
+      create(:tag, author: user, repository: repository, digest: nil, image_id: nil)
+      create(:tag, author: user, repository: repository, digest: "nonblank", image_id: nil)
+
+      visit repository_path(repository)
+    end
   end
 end


### PR DESCRIPTION
There was an exception raised when a tag with either a nil digest or a nil
image_id was to be rendered.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>