### PR TITLE
Removed the usage of ldap_name and relax username

### DIFF
--- a/app/controllers/auth/registrations_controller.rb
+++ b/app/controllers/auth/registrations_controller.rb
@@ -2,6 +2,7 @@ class Auth::RegistrationsController < Devise::RegistrationsController
   layout "authentication", except: :edit
 
   include CheckLDAP
+  include SessionFlash
 
   before_action :check_signup, only: [:new, :create]
   before_action :check_admin, only: [:new, :create]
@@ -20,7 +21,7 @@ class Auth::RegistrationsController < Devise::RegistrationsController
 
     resource.save
     if resource.persisted?
-      set_flash_message :notice, :signed_up
+      session_flash(resource, :signed_up)
       sign_up(resource_name, resource)
       respond_with resource, location: after_sign_up_path_for(resource), float: true
     else

--- a/app/controllers/auth/sessions_controller.rb
+++ b/app/controllers/auth/sessions_controller.rb
@@ -1,4 +1,6 @@
 class Auth::SessionsController < Devise::SessionsController
+  include SessionFlash
+
   layout "authentication"
 
   # Re-implementing. The logic is: if there is already a user that can log in
@@ -23,7 +25,13 @@ class Auth::SessionsController < Devise::SessionsController
 
   def create
     super
-    flash[:notice] = nil
+
+    if ::Portus::LDAP.enabled? && session[:first_login]
+      session[:first_login] = nil
+      session_flash(current_user, nil)
+    else
+      flash[:notice] = nil
+    end
   end
 
   def destroy

--- a/app/controllers/concerns/session_flash.rb
+++ b/app/controllers/concerns/session_flash.rb
@@ -1,0 +1,33 @@
+# SessionFlash adds the `session_flash` method which deals with flashy messages
+# on signup/login, while notifying users about their personal namespace.
+module SessionFlash
+  extend ActiveSupport::Concern
+
+  # Sets the flash object accordingly for the given authenticated user. The
+  # method is the Devise method to be used for greeting the user (e.g.
+  # `:signed_up`). If method is nil, then a generic greeting will be set. This
+  # method also notifies users about their personal namespace (and whether it
+  # changed or not).
+  def session_flash(user, method)
+    # First of all we've got a greeting.
+    if method.nil?
+      flash[:notice] = "Welcome!"
+    else
+      set_flash_message :notice, method unless method.nil?
+    end
+
+    # This will happen for the first user, which is the admin that has to
+    # configure the registry.
+    return if user.namespace.nil?
+
+    # Now inform the user
+    ns = user.namespace.name
+    str = " Your personal namespace is '#{ns}'"
+    if user.username == ns
+      str += "."
+    else
+      str += " (your username was not a valid Docker namespace, so we had to tweak it)."
+    end
+    flash[:notice] << str
+  end
+end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -7,7 +7,7 @@ class DashboardController < ApplicationController
 
     # The personal namespace could not exist, that happens when portus
     # does not have a registry associated yet (right after the initial setup)
-    personal_namespace = Namespace.find_by(name: current_user.username)
+    personal_namespace = current_user.namespace
     @personal_repositories = personal_namespace ? personal_namespace.repositories : []
 
     @stars = current_user.stars.order("updated_at desc")

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,12 +22,13 @@
 #  failed_attempts        :integer          default("0")
 #  locked_at              :datetime
 #  display_name           :string(255)
+#  namespace_id           :integer
 #
 # Indexes
 #
 #  index_users_on_display_name          (display_name) UNIQUE
 #  index_users_on_email                 (email) UNIQUE
-#  index_users_on_ldap_name             (ldap_name) UNIQUE
+#  index_users_on_namespace_id          (namespace_id)
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
 #  index_users_on_username              (username) UNIQUE
 #
@@ -36,22 +37,14 @@ class User < ActiveRecord::Base
   devise :database_authenticatable, :registerable, :lockable,
          :recoverable, :rememberable, :trackable, :validatable, authentication_keys: [:username]
 
-  USERNAME_CHARS  = "a-z0-9"
-  USERNAME_FORMAT = /\A[#{USERNAME_CHARS}]{4,30}\Z/
-
   APPLICATION_TOKENS_MAX = 5
 
-  validates :username, presence: true, uniqueness: true,
-    format: {
-      with:    USERNAME_FORMAT,
-      message: "only lower case alphanumeric characters are allowed. "\
-        "Minimum 4 characters, maximum 30."
-    }
-
   # Actions performed before/after create.
+  validates :username, presence: true, uniqueness: true
   validate :private_namespace_and_team_available, on: :create
   after_create :create_personal_namespace!
 
+  belongs_to :namespace
   has_many :team_users
   has_many :teams, through: :team_users
   has_many :stars
@@ -64,14 +57,24 @@ class User < ActiveRecord::Base
   # Special method used by Devise to require an email on signup. This is always
   # true except for LDAP.
   def email_required?
-    !(Portus::LDAP.enabled? && !ldap_name.nil?)
+    !(Portus::LDAP.enabled? && email.blank?)
   end
 
   # It adds an error if the username clashes with either a namespace or a team.
   def private_namespace_and_team_available
-    return unless Namespace.exists?(name: username) || Team.exists?(name: username)
-    errors.add(:username, "'#{username}' cannot be used: there's either a "\
-      "namespace or a team named like this.")
+    ns = Namespace.make_valid(username)
+
+    if ns.nil?
+      errors.add(:username, "'#{username}' cannot be transformed into a " \
+        "valid namespace name")
+    elsif Namespace.exists?(name: ns)
+      clar = (ns != username) ? " (modified so it's valid)" : ""
+      errors.add(:username, "cannot be used: there is already a namespace " \
+        "named '#{ns}'#{clar}")
+    elsif Team.exists?(name: username)
+      errors.add(:username, "cannot be used: there is already a team named " \
+        "like this")
+    end
   end
 
   # Returns true if the current user is the Portus user.
@@ -92,8 +95,11 @@ class User < ActiveRecord::Base
     # the registry is not configured yet, we cannot create the namespace
     return unless Registry.any?
 
-    # Leave early if the namespace already exists.
-    ns = Namespace.find_by(name: username)
+    # Leave early if the namespace already exists. This is fine because the
+    # `private_namespace_and_team_available` method has already checked that
+    # the name of the namespace is fine and that it doesn't clash.
+    namespace_name = Namespace.make_valid(username)
+    ns = Namespace.find_by(name: namespace_name)
     return ns if ns
 
     # Note that this shouldn't be a problem since the User controller will make
@@ -101,21 +107,18 @@ class User < ActiveRecord::Base
     team = Team.create!(name: username, owners: [self], hidden: true)
 
     default_description = "This personal namespace belongs to #{username}."
-    Namespace.find_or_create_by!(
+    namespace = Namespace.find_or_create_by!(
       team:        team,
-      name:        username,
+      name:        namespace_name,
       description: default_description,
       registry:    Registry.get # TODO: fix once we handle more registries
     )
+    update_attributes(namespace: namespace)
   end
 
   # Find the user that can be guessed from the given push event.
   def self.find_from_event(event)
-    if Portus::LDAP.enabled?
-      actor = User.find_by(ldap_name: event["actor"]["name"])
-    else
-      actor = User.find_by(username: event["actor"]["name"])
-    end
+    actor = User.find_by(username: event["actor"]["name"])
     logger.error "Cannot find user #{event["actor"]["name"]}" if actor.nil?
     actor
   end

--- a/app/views/devise/registrations/edit.html.slim
+++ b/app/views/devise/registrations/edit.html.slim
@@ -78,8 +78,8 @@
                       any affiliations with any team will be lost.
                   = submit_tag('Disable', class: 'btn btn-primary')
 
-  - if current_user.email?
-    - if current_user.ldap_name.nil?
+  - unless ::Portus::LDAP.enabled?
+    - if current_user.email?
       .col-sm-6
         .panel.panel-default
           .panel-heading

--- a/db/migrate/20160510153011_add_namespace_id_to_users.rb
+++ b/db/migrate/20160510153011_add_namespace_id_to_users.rb
@@ -1,0 +1,5 @@
+class AddNamespaceIdToUsers < ActiveRecord::Migration
+  def change
+    add_reference :users, :namespace, index: true, foreign_key: true, default: nil
+  end
+end

--- a/db/migrate/20160526105216_remove_index_on_ldap_users.rb
+++ b/db/migrate/20160526105216_remove_index_on_ldap_users.rb
@@ -1,0 +1,5 @@
+class RemoveIndexOnLdapUsers < ActiveRecord::Migration
+  def change
+    remove_index "users", name: "index_users_on_ldap_name"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -165,12 +165,13 @@ ActiveRecord::Schema.define(version: 20160531151718) do
     t.string   "ldap_name",              limit: 255
     t.integer  "failed_attempts",        limit: 4,   default: 0
     t.datetime "locked_at"
+    t.integer  "namespace_id",           limit: 4
     t.string   "display_name",           limit: 255
   end
 
   add_index "users", ["display_name"], name: "index_users_on_display_name", unique: true, using: :btree
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
-  add_index "users", ["ldap_name"], name: "index_users_on_ldap_name", unique: true, using: :btree
+  add_index "users", ["namespace_id"], name: "index_users_on_namespace_id", using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   add_index "users", ["username"], name: "index_users_on_username", unique: true, using: :btree
 
@@ -217,6 +218,7 @@ ActiveRecord::Schema.define(version: 20160531151718) do
   add_foreign_key "comments", "repositories"
   add_foreign_key "stars", "repositories"
   add_foreign_key "stars", "users"
+  add_foreign_key "users", "namespaces"
   add_foreign_key "webhook_deliveries", "webhooks"
   add_foreign_key "webhook_headers", "webhooks"
   add_foreign_key "webhooks", "namespaces"

--- a/lib/portus/ldap.rb
+++ b/lib/portus/ldap.rb
@@ -32,13 +32,9 @@ module Portus
       if @ldap
         # Try to bind to the LDAP server. If there's any failure, the
         # authentication process will fail without going to the any other
-        # strategy.
-        if @ldap.bind_as(bind_options)
-          user = find_or_create_user!
-          user.valid? ? success!(user) : fail!(user.errors.full_messages.join(","))
-        else
-          fail!(:ldap_bind_failed)
-        end
+        # strategy. Otherwise, login the current user into Portus (and create
+        # it if it doesn't exist).
+        @ldap.bind_as(bind_options) ? portus_login! : fail!(:ldap_bind_failed)
       else
         # rubocop:disable Style/SignalException
         fail(:ldap_failed)
@@ -148,53 +144,37 @@ module Portus
       params[:user] = { username: user, password: pass }
     end
 
-    # Retrieve the given user as an LDAP user. If it doesn't exist, create it
-    # with the parameters given in the form.
-    def find_or_create_user!
-      user = User.find_by(ldap_name: username)
-
-      # The user does not exist in Portus yet, let's create it. If it does
-      # not match a valid username, it will be transformed into a proper one.
-      unless user
-        ldap_name = username.dup
-        if User::USERNAME_FORMAT.match(ldap_name)
-          name = ldap_name
-        else
-          name = ldap_name.gsub(/[^#{User::USERNAME_CHARS}]/, "")
-        end
-
-        # This is to check that no clashes occur. This is quite improbable to
-        # happen, since it would mean that the name contains characters like
-        # "$", "!", etc. We also check that the name is longer than 4
-        # (requirement from Docker).
-        if name.length < 4 || User.exists?(username: name)
-          name = generate_random_name(name)
-        end
-
-        user = User.create(
-          username:  name,
-          email:     guess_email,
-          password:  password,
-          admin:     !User.not_portus.any?,
-          ldap_name: ldap_name
-        )
+    # Fetch the user assumed from `params` and log it. If the user does not
+    # exist yet, it will be created and the `session[:first_login]` value will
+    # be set to true, so the sessions controller can act accordingly.
+    def portus_login!
+      user, created = find_or_create_user!
+      if user.valid?
+        session[:first_login] = true if created
+        success!(user)
+      else
+        fail!(user.errors.full_messages.join(","))
       end
-      user
     end
 
-    # It generates a new name that doesn't clash with any of the existing ones.
-    def generate_random_name(name)
-      # Even if the name has just one character, adding a number of at least
-      # three digits would make the name valid.
-      offset = name.length < 4 ? 100 : 0
+    # Retrieve the given user as an LDAP user. If it doesn't exist, create it
+    # with the parameters given in the form. Returns two objects: the user
+    # object and a boolean set to true if the returned user was just created.
+    def find_or_create_user!
+      user = User.find_by(username: username)
+      created = false
 
-      10.times do
-        nn = "#{name}#{Random.rand(offset + 101)}"
-        return nn unless User.exists?(username: nn)
+      # The user does not exist in Portus yet, let's create it.
+      unless user
+        user = User.create(
+          username: username,
+          email:    guess_email,
+          password: password,
+          admin:    !User.not_portus.any?
+        )
+        created = user.persisted?
       end
-
-      # We have not been able to generate a new name, let's raise an exception.
-      fail!(:random_generation_failed)
+      [user, created]
     end
 
     # If the "ldap.guess_email" option is enabled, try to guess the email for

--- a/spec/api/v2/token_spec.rb
+++ b/spec/api/v2/token_spec.rb
@@ -1,9 +1,7 @@
 require "rails_helper"
 
 describe "/v2/token" do
-
   describe "get token" do
-
     def parse_token(body)
       token = JSON.parse(body)["token"]
       JWT.decode(token, nil, false, leeway: 2)[0]
@@ -156,10 +154,8 @@ describe "/v2/token" do
         # Check that the user has actually been registered.
         ldapuser = User.find_by(username: "ldapuser")
         expect(ldapuser.username).to eq "ldapuser"
-        expect(ldapuser.ldap_name).to eq "ldapuser"
         expect(ldapuser.valid_password?("12341234")).to be true
       end
-
     end
 
     context "as valid user" do
@@ -222,7 +218,7 @@ describe "/v2/token" do
 
       context "repository scope" do
         it "delegates authentication to the Namespace policy" do
-          personal_namespace = Namespace.find_by(name: user.username)
+          personal_namespace = user.namespace
           expect_any_instance_of(Api::V2::TokensController).to receive(:authorize)
             .with(personal_namespace, :push?)
           expect_any_instance_of(Api::V2::TokensController).to receive(:authorize)

--- a/spec/controllers/auth/registrations_controller_spec.rb
+++ b/spec/controllers/auth/registrations_controller_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 describe Auth::RegistrationsController do
-
   let(:valid_session) { {} }
 
   describe "POST #create" do

--- a/spec/controllers/auth/sessions_controller_spec.rb
+++ b/spec/controllers/auth/sessions_controller_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+describe Auth::SessionsController do
+  describe "POST #create" do
+    before :each do
+      request.env["devise.mapping"] = Devise.mappings[:user]
+      APP_CONFIG["signup"] = { "enabled" => true }
+      APP_CONFIG["ldap"] = { "enabled" => true }
+    end
+
+    it "sets the session hash on LDAP when it's the first time", focus: true do
+      create(:registry)
+
+      # Warden magic
+      user = build(:user)
+      allow(request.env["warden"]).to receive(:authenticate!).and_return(user)
+      allow(controller).to receive(:current_user).and_return(user)
+
+      # So we test the special case of login that is really a signup.
+      session[:first_login] = true
+      post :create, session: {
+        "username" => "user",
+        "email"    => "user@test.com"
+      }
+
+      expect(flash["notice"]).to eq(
+        "Welcome! Your personal namespace is '#{user.username}'.")
+    end
+  end
+end

--- a/spec/controllers/namespaces_controller_spec.rb
+++ b/spec/controllers/namespaces_controller_spec.rb
@@ -31,7 +31,7 @@ describe NamespacesController do
     it "assigns all namespaces as @namespaces" do
       get :index, {}, valid_session
       expect(assigns(:special_namespaces)).to match_array(
-        [Namespace.find_by(name: user.username), Namespace.find_by(global: true)])
+        [user.namespace, Namespace.find_by(global: true)])
       expect(assigns(:namespaces).ids).to be_empty
     end
 

--- a/spec/features/application_spec.rb
+++ b/spec/features/application_spec.rb
@@ -13,7 +13,7 @@ feature "Global application" do
 
     it "redirects properly for accounts without email", js: true do
       APP_CONFIG["ldap"] = { "enabled" => true }
-      incomplete = create(:user, email: "", ldap_name: "user")
+      incomplete = create(:user, email: "")
       login_as incomplete, scope: :user
 
       visit root_path

--- a/spec/features/auth/signup_feature_spec.rb
+++ b/spec/features/auth/signup_feature_spec.rb
@@ -53,6 +53,26 @@ feature "Signup feature" do
     click_button("Create account")
     expect(page).to have_content("Recent activities")
     expect(page).to have_content("Repositories")
+    expect(page).to have_content("Welcome! You have signed up successfully. "\
+                                 "Your personal namespace is '#{user.username}'.")
+    expect(current_url).to eq root_url
+  end
+
+  scenario "As a guest I am able to signup with a weird username" do
+    username = user.username + "!"
+
+    expect(page).to_not have_content("Create admin")
+    fill_in "user_username", with: username
+    fill_in "user_email", with: user.email
+    fill_in "user_password", with: user.password
+    fill_in "user_password_confirmation", with: user.password
+    click_button("Create account")
+    expect(page).to have_content("Recent activities")
+    expect(page).to have_content("Repositories")
+    expect(page).to have_content("Welcome! You have signed up successfully. "\
+                                 "Your personal namespace is '#{user.username}' " \
+                                 "(your username was not a valid Docker namespace, "\
+                                 "so we had to tweak it).")
     expect(current_url).to eq root_url
   end
 

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -8,7 +8,7 @@ feature "Dashboard page" do
   let!(:repository) { create(:repository, namespace: namespace) }
   let!(:starred_repo) { create(:repository, namespace: namespace) }
   let!(:star) { create(:star, user: user, repository: starred_repo) }
-  let!(:personal_namespace) { Namespace.find_by(name: user.username) }
+  let!(:personal_namespace) { user.namespace }
   let!(:personal_repository) { create(:repository, namespace: personal_namespace) }
 
   let!(:another_user) { create(:admin) }

--- a/spec/integration/login_spec.rb
+++ b/spec/integration/login_spec.rb
@@ -20,6 +20,10 @@ integration "Login" do
 
     # Invalid password.
     expect { login(name, password + "o", email) }.to raise_error(LoginError)
+
+    create_user("mc!", email, password, true)
+    expect { login(name, password, email) }.not_to raise_error
+
   end
 
   it "allows users to push images with multiple tags" do

--- a/spec/lib/portus/ldap_spec.rb
+++ b/spec/lib/portus/ldap_spec.rb
@@ -36,12 +36,13 @@ end
 
 class LdapMock < Portus::LDAP
   attr_reader :params, :user, :last_symbol
-  attr_accessor :bind_result
+  attr_accessor :bind_result, :session
 
   def initialize(params)
     @params = { user: params }
     @bind_result = true
     @last_symbol = :ok
+    @session = {}
   end
 
   def load_configuration_test
@@ -54,10 +55,6 @@ class LdapMock < Portus::LDAP
 
   def find_or_create_user_test!
     find_or_create_user!
-  end
-
-  def generate_random_name_test(name)
-    generate_random_name(name)
   end
 
   def success!(user)
@@ -221,41 +218,35 @@ describe Portus::LDAP do
     end
 
     it "the ldap user could be located" do
-      user = create(:user, ldap_name: "name")
+      user = create(:user, username: "name")
       lm = LdapMock.new(username: "name", password: "1234")
-      ret = lm.find_or_create_user_test!
+      ret, created = lm.find_or_create_user_test!
       expect(ret.id).to eq user.id
+      expect(created).to be_falsey
     end
 
     it "creates a new ldap user" do
       lm = LdapMock.new(username: "name", password: "12341234")
-      lm.find_or_create_user_test!
+      _, created = lm.find_or_create_user_test!
 
       expect(User.count).to eq 1
-      expect(User.find_by(ldap_name: "name")).to_not be nil
+      expect(User.find_by(username: "name")).to_not be nil
+      expect(created).to be_truthy
     end
 
     it "creates a new ldap user even if it has weird characters" do
+      # Remember that this will create a new admin, so it has its consequences
+      # on the expected values in this test.
+      create(:registry)
+
       lm = LdapMock.new(username: "name!o", password: "12341234")
-      lm.find_or_create_user_test!
-
-      expect(User.count).to eq 1
-      user = User.find_by(ldap_name: "name!o")
-      expect(user.username).to eq "nameo"
-      expect(user.ldap_name).to eq "name!o"
-      expect(user.admin?).to be_truthy
-    end
-
-    it "creates a new ldap user with a new username if it clashes" do
-      create(:admin, username: "name")
-      lm = LdapMock.new(username: "name", password: "12341234")
-      lm.find_or_create_user_test!
+      _, created = lm.find_or_create_user_test!
 
       expect(User.count).to eq 2
-      created = User.find_by(ldap_name: "name")
-      expect(created.username).to_not eq "name"
-      expect(created.username.start_with?("name")).to be_truthy
-      expect(created.admin?).to be_falsey
+      user = User.find_by(username: "name!o")
+      expect(user.username).to eq "name!o"
+      expect(user.namespace.name).to eq "name_o"
+      expect(created).to be_truthy
     end
 
     it "allows multiple users to have no email setup" do
@@ -268,34 +259,6 @@ describe Portus::LDAP do
       lm.find_or_create_user_test!
 
       expect(User.count).to eq 2
-    end
-  end
-
-  describe "#generate_random_name" do
-    it "creates a random name" do
-      lm = LdapMock.new(nil)
-      name = lm.generate_random_name_test("name")
-      expect(name).to_not eq "name"
-      expect(name.start_with?("name")).to be_truthy
-    end
-
-    it "generates a name that is large enough" do
-      lm = LdapMock.new(nil)
-      name = lm.generate_random_name_test("n")
-      expect(name).to_not eq "n"
-      expect(name.start_with?("n")).to be_truthy
-    end
-
-    it "raises an exception if it fails" do
-      # Let's make sure that there will be a clash.
-      create(:user, username: "name")
-      101.times do |i|
-        create(:user, username: "name#{i}")
-      end
-
-      lm = LdapMock.new(nil)
-      lm.generate_random_name_test("name")
-      expect(lm.last_symbol).to be :random_generation_failed
     end
   end
 

--- a/spec/models/namespace_spec.rb
+++ b/spec/models/namespace_spec.rb
@@ -128,4 +128,28 @@ describe Namespace do
       end
     end
   end
+
+  describe "make_valid" do
+    it "does nothing on already valid names" do
+      ["name", "a", "a_a", "45", "n4", "h2o", "flavio.castelli"].each do |name|
+        expect(Namespace.make_valid(name)).to eq name
+      end
+    end
+
+    it "returns nil if the name cannot be changed" do
+      ["", ".", "_", "-", "!!!!"].each do |name|
+        expect(Namespace.make_valid(name)).to be_nil
+      end
+    end
+
+    it "changes invalid names that can be saved" do
+      expect(Namespace.make_valid("_name")).to eq "name"
+      expect(Namespace.make_valid("name_")).to eq "name"
+      expect(Namespace.make_valid("___name_-aa__")).to eq "name_aa"
+      expect(Namespace.make_valid("_ma._.n")).to eq "ma_n"
+      expect(Namespace.make_valid("ma_s")).to eq "ma_s"
+      expect(Namespace.make_valid("!lol!")).to eq "lol"
+      expect(Namespace.make_valid("!lol!name")).to eq "lol_name"
+    end
+  end
 end

--- a/spec/models/registry_spec.rb
+++ b/spec/models/registry_spec.rb
@@ -106,9 +106,7 @@ describe Registry, type: :model do
       expect(Namespace.count).to be(0)
 
       create(:registry)
-      User.all.each do |user|
-        expect(Namespace.find_by(name: user.username)).not_to be(nil)
-      end
+      User.all.each { |user| expect(user.namespace).not_to be(nil) }
     end
 
     it "#create_namespaces!" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -22,12 +22,13 @@
 #  failed_attempts        :integer          default("0")
 #  locked_at              :datetime
 #  display_name           :string(255)
+#  namespace_id           :integer
 #
 # Indexes
 #
 #  index_users_on_display_name          (display_name) UNIQUE
 #  index_users_on_email                 (email) UNIQUE
-#  index_users_on_ldap_name             (ldap_name) UNIQUE
+#  index_users_on_namespace_id          (namespace_id)
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
 #  index_users_on_username              (username) UNIQUE
 #
@@ -41,23 +42,65 @@ describe User do
   it { should validate_uniqueness_of(:username) }
   it { should allow_value("test1", "1test").for(:username) }
 
-  it "should block user creation when the private namespace is not available" do
-    name = "coolname"
-    team = create(:team, owners: [subject])
-    create(:namespace, team: team, name: name)
-    user = build(:user, username: name)
-    expect(user.save).to be false
-    expect(user.errors.size).to eq(1)
-    expect(user.errors.first)
-      .to match_array([:username, "'coolname' cannot be used: there's either a namespace or " \
-        "a team named like this."])
+  describe "#private_namespace_and_team_available" do
+    it "adds an error if the username cannot produce a valid namespace" do
+      user = build(:user, username: "!!!!!")
+      expect(user.save).to be false
+      expect(user.errors.size).to eq(1)
+      expect(user.errors.first)
+        .to match_array([:username, "'!!!!!' cannot be transformed into a " \
+          "valid namespace name"])
+    end
+
+    it "adds an error if the namespace name clashes" do
+      name = "coolname"
+      team = create(:team, owners: [subject])
+      create(:namespace, team: team, name: name)
+
+      user = build(:user, username: name)
+      expect(user.save).to be false
+      expect(user.errors.size).to eq(1)
+      expect(user.errors.first)
+        .to match_array([:username, "cannot be used: there is already a " \
+          "namespace named 'coolname'"])
+
+      user = build(:user, username: name + "_")
+      expect(user.save).to be false
+      expect(user.errors.size).to eq(1)
+      expect(user.errors.first)
+        .to match_array([:username, "cannot be used: there is already a " \
+          "namespace named 'coolname' (modified so it's valid)"])
+    end
+
+    it "adds an error if there's a team named like that" do
+      name = "coolname"
+      team = create(:team, name: name, owners: [subject])
+      create(:namespace, team: team, name: "somethingelse")
+
+      user = build(:user, username: name)
+      expect(user.save).to be false
+      expect(user.errors.size).to eq(1)
+      expect(user.errors.first)
+        .to match_array([:username, "cannot be used: there is already a " \
+          "team named like this"])
+    end
+
+    it "works beautifully if everything was fine" do
+      name = "coolname"
+      team = create(:team, owners: [subject])
+      create(:namespace, team: team, name: "somethingelse")
+
+      user = build(:user, username: name)
+      expect(user.save).to be_truthy
+      expect(user.errors).to be_empty
+    end
   end
 
   it "#email_required?" do
     expect(subject.email_required?).to be true
 
     APP_CONFIG["ldap"] = { "enabled" => true }
-    incomplete = create(:user, email: "", ldap_name: "user")
+    incomplete = create(:user, email: "")
 
     expect(subject.email_required?).to be true
     expect(incomplete.email_required?).to be false
@@ -67,27 +110,19 @@ describe User do
     create(:registry)
     expect(Namespace.find_by(name: "test")).to be nil
 
-    create(:user, username: "test")
-    expect(Namespace.find_by(name: "test")).to_not be nil
+    user2 = create(:user, username: "test")
+    namespace = Namespace.find_by(name: "test")
+    expect(namespace).to_not be nil
+    expect(user2.namespace.id).to eq namespace.id
   end
 
   describe ".find_from_event" do
-    let!(:user)   { create(:user, username: "username001", ldap_name: "user@domain.com") }
+    let!(:user)   { create(:user, username: "username001") }
 
-    context "LDAP is enabled" do
-      it "find user by ldap_name" do
-        APP_CONFIG["ldap"] = { "enabled" => true }
-        event = { "actor" => { "name" => "user@domain.com" } }
-        expect(User.find_from_event(event)).not_to be_nil
-      end
-    end
-
-    context "LDAP is disabled" do
-      it "find user by username" do
-        APP_CONFIG["ldap"] = { "enabled" => false }
-        event = { "actor" => { "name" => "username001" } }
-        expect(User.find_from_event(event)).not_to be_nil
-      end
+    it "find user by username" do
+      APP_CONFIG["ldap"] = { "enabled" => false }
+      event = { "actor" => { "name" => "username001" } }
+      expect(User.find_from_event(event)).not_to be_nil
     end
   end
 
@@ -119,6 +154,12 @@ describe User do
         TeamUser.find_by!(user: subject, team: team)
         expect(team.owners).to include(subject)
         expect(team).to be_hidden
+      end
+
+      it "creates a namespace with the modified username" do
+        user = build(:user, username: "name_")
+        expect(user.save).to be_truthy
+        Namespace.find_by!(name: "name")
       end
     end
   end


### PR DESCRIPTION
This has been done in two steps:

1. First of all I've introduced the `namespace_id` column to the `users`
   table. This means that from now own there is no mapping from users and their
   personal namespaces through the `username` column, from now on it's done with
   a plain SQL foreign key.
2. From the previous step, we get that restricting the username is no longer
   needed. Instead, the format of the username has been greatly relaxed, so the
   only concerns are:
    - It is unique in the DB.
    - We can produce a namespace for it. If the username is not a valid
      namespace name, then the resulting namespace will have its name altered
      so it can be valid. If it cannot be valid, then user creation will fail
      (which is very unlikely: this only happens in cases like "?" or something
       like that).

Fixes #732
Fixes #736

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>