### PR TITLE
create activity on successful action

### DIFF
--- a/app/controllers/concerns/change_name_description.rb
+++ b/app/controllers/concerns/change_name_description.rb
@@ -10,14 +10,8 @@ module ChangeNameDescription
     old_description = object.description
     old_name = object.name
 
-    if !new_description.nil? && old_description != new_description
-      object.update(description: new_description)
-      create_activity(object, symbol, "description", old_description, new_description)
-    end
-
-    return if old_name == new_name || new_name.blank?
-    object.update(name: new_name)
-    create_activity(object, symbol, "name", old_name, new_name)
+    change_description(object, symbol, old_description, new_description)
+    change_name(object, symbol, old_name, new_name)
   end
 
   private
@@ -28,5 +22,18 @@ module ChangeNameDescription
                                   owner:      current_user,
                                   recipient:  object,
                                   parameters: { old: old_value, new: new_value }
+  end
+
+  # Change description and track activity if successful.
+  def change_description(object, symbol, old_description, new_description)
+    return if new_description.nil? || old_description == new_description ||
+        !object.update(description: new_description)
+    create_activity(object, symbol, "description", old_description, new_description)
+  end
+
+  # Change name and track activity if successful.
+  def change_name(object, symbol, old_name, new_name)
+    return if old_name == new_name || new_name.blank? || !object.update(name: new_name)
+    create_activity(object, symbol, "name", old_name, new_name)
   end
 end

--- a/spec/controllers/teams_controller_spec.rb
+++ b/spec/controllers/teams_controller_spec.rb
@@ -236,5 +236,13 @@ RSpec.describe TeamsController, type: :controller do
       expect(team_name_activity.parameters[:old]).to eq(old_name)
       expect(team_name_activity.parameters[:new]).to eq("new name")
     end
+
+    it "does not track activity if team name exists" do
+      team2 = create(:team, owners: [owner])
+      expect do
+        team_attributes = { name: team2.name, description: team.description }
+        patch :update, id: team.id, team: team_attributes, format: "js"
+      end.not_to change(PublicActivity::Activity, :count)
+    end
   end
 end


### PR DESCRIPTION
Check whether the update was successful before creating an activity.
This prevents misleading activities.

Fixes #909

Signed-off-by: Thomas Hipp <thipp@suse.com>