### PR TITLE
add activity for moving namespaces

### DIFF
--- a/app/controllers/namespaces_controller.rb
+++ b/app/controllers/namespaces_controller.rb
@@ -59,6 +59,9 @@ class NamespacesController < ApplicationController
     if @team.nil?
       @namespace.errors[:team_id] << "'#{p[:team]}' unknown."
     else
+      @namespace.create_activity :change_team,
+        owner:      current_user,
+        parameters: { old: @namespace.team.id, new: @team.id }
       @namespace.update_attributes(team: @team)
     end
   end

--- a/app/views/public_activity/namespace/_change_team.csv.slim
+++ b/app/views/public_activity/namespace/_change_team.csv.slim
@@ -1,0 +1,1 @@
+= CSV.generate_line(['namespace', activity.trackable.name, 'change team', '-', activity.owner.username, activity.created_at, "owned by team #{activity.trackable.team.name}"])

--- a/app/views/public_activity/namespace/_change_team.html.slim
+++ b/app/views/public_activity/namespace/_change_team.html.slim
@@ -1,0 +1,17 @@
+li
+  .activitie-container
+    .activity-type.change-team
+      i.fa.fa-arrow-right
+    .user-image
+      = user_image_tag(activity.owner.email)
+    .description
+      h6
+        strong
+          = "#{activity.owner.username} moved the "
+        = link_to activity.trackable.name , activity.trackable
+        = " namespace to the "
+        = link_to activity.trackable.team.name, activity.trackable.team
+        = " team"
+      small
+        i.fa.fa-clock-o
+        = activity_time_tag activity.created_at

--- a/spec/controllers/namespaces_controller_spec.rb
+++ b/spec/controllers/namespaces_controller_spec.rb
@@ -334,5 +334,18 @@ describe NamespacesController do
       expect(namespace_description_activity.parameters[:old]).to eq(old_description)
       expect(namespace_description_activity.parameters[:new]).to eq("new description")
     end
+
+    it "tracks change team" do
+      team2 = create(:team)
+      expect do
+        patch :update, id: namespace.id, namespace: { team: team2.name }, format: "js"
+      end.to change(PublicActivity::Activity, :count).by(1)
+      namespace_change_team_activity = PublicActivity::Activity.find_by(
+        key: "namespace.change_team")
+      expect(namespace_change_team_activity.owner).to eq(owner)
+      expect(namespace_change_team_activity.trackable).to eq(namespace)
+      expect(namespace_change_team_activity.parameters[:old]).to eq(team.id)
+      expect(namespace_change_team_activity.parameters[:new]).to eq(team2.id)
+    end
   end
 end


### PR DESCRIPTION
When a namespace is assigned a new team, an activity is created.

Resolves #877

Signed-off-by: Thomas Hipp <thipp@suse.com>