### PR TITLE
Introduce the `display_name` option 

### DIFF
--- a/app/assets/javascripts/profile.coffee
+++ b/app/assets/javascripts/profile.coffee
@@ -1,9 +1,22 @@
 
 jQuery ->
   email = $('#user_email').val()
+  display = $('#user_display_name').val()
+
   $('#user_email').keyup ->
     val = $('#user_email').val()
-    if val == email || val == ''
+    dname = $('#user_display_name').val()
+
+    if dname == display && (val == email || val == '')
+      $('#edit_user.profile .btn').attr('disabled', 'disabled')
+    else
+      $('#edit_user.profile .btn').removeAttr('disabled')
+
+  $('#user_display_name').keyup ->
+    val = $('#user_display_name').val()
+    em = $('#user_email').val()
+
+    if val == display && (em == email || em == '')
       $('#edit_user.profile .btn').attr('disabled', 'disabled')
     else
       $('#edit_user.profile .btn').removeAttr('disabled')

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -31,7 +31,7 @@ class Admin::UsersController < Admin::BaseController
   def update
     return if @user.nil?
 
-    attr = params.require(:user).permit([:email])
+    attr = params.require(:user).permit([:email, :display_name])
 
     if @user.update_attributes(attr)
       redirect_to admin_users_path, notice: "User updated successfully"

--- a/app/controllers/auth/registrations_controller.rb
+++ b/app/controllers/auth/registrations_controller.rb
@@ -41,7 +41,7 @@ class Auth::RegistrationsController < Devise::RegistrationsController
       sign_in(current_user, bypass: true) if succ
       succ
     else
-      current_user.update_without_password(params.require(:user).permit(:email))
+      current_user.update_without_password(params.require(:user).permit(:email, :display_name))
     end
 
     if success

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,9 +21,11 @@
 #  ldap_name              :string(255)
 #  failed_attempts        :integer          default("0")
 #  locked_at              :datetime
+#  display_name           :string(255)
 #
 # Indexes
 #
+#  index_users_on_display_name          (display_name) UNIQUE
 #  index_users_on_email                 (email) UNIQUE
 #  index_users_on_ldap_name             (ldap_name) UNIQUE
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
@@ -75,6 +77,12 @@ class User < ActiveRecord::Base
   # Returns true if the current user is the Portus user.
   def portus?
     username == "portus"
+  end
+
+  # Returns the username to be displayed.
+  def display_username
+    return username unless APP_CONFIG.enabled?("display_name")
+    display_name.blank? ? username : display_name
   end
 
   # This method will be called automatically once a user is created. It will

--- a/app/views/admin/users/edit.html.slim
+++ b/app/views/admin/users/edit.html.slim
@@ -8,6 +8,12 @@
         .col-md-7
           = f.email_field(:email, class: 'form-control', required: true, autofocus: true)
 
+      - if APP_CONFIG.enabled?("display_name")
+        .form-group
+          = f.label :display_name, {class: 'control-label col-md-2'}
+          .col-md-7
+            = f.text_field(:display_name, class: 'form-control')
+
       .form-group
         .col-md-offset-2.col-md-7
           = f.submit('Update', class: 'btn btn-primary')

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -27,10 +27,10 @@
           - @users.each do |user|
             tr[id="user_#{user.id}"]
               - if user == current_user
-                td= user.username
+                td= user.display_username
               - else
                 td
-                  = link_to user.username, edit_admin_user_path(user), { title: "Edit user '#{user.username}'" }
+                  = link_to user.display_username, edit_admin_user_path(user), { title: "Edit user '#{user.display_username}'" }
               td= user.email
               td.admin-btn
                 - if current_user.id == user.id

--- a/app/views/comments/_comment.html.slim
+++ b/app/views/comments/_comment.html.slim
@@ -8,7 +8,7 @@
       .panel-heading
         h5
           strong
-            = comment.author.username
+            = comment.author.display_username
           '  commented
           = activity_time_tag comment.updated_at
           '  ago

--- a/app/views/devise/registrations/edit.html.slim
+++ b/app/views/devise/registrations/edit.html.slim
@@ -15,7 +15,14 @@
                 = f.label :email
               - else
                 = f.label :email, "Email", class: "control-label", title: "This profile is not complete. You need to provide an email first"
-              = f.text_field(:email, class: 'form-control', required: true, autofocus: true)
+              = f.email_field(:email, class: 'form-control', required: true, autofocus: true)
+
+          - if APP_CONFIG.enabled?("display_name")
+            .form-group
+              .field
+                = f.label :display_name
+                = f.text_field(:display_name, class: 'form-control')
+
           .form-group
             .actions
               = f.submit('Update', class: 'btn btn-primary', disabled: true)

--- a/app/views/public_activity/application_token/_create.csv.slim
+++ b/app/views/public_activity/application_token/_create.csv.slim
@@ -1,1 +1,1 @@
-= CSV.generate_line(["application token", "#{activity.parameters[:application]}", "create", "-", activity.owner.username, activity.created_at, "-"])
+= CSV.generate_line(["application token", "#{activity.parameters[:application]}", "create", "-", activity.owner.display_username, activity.created_at, "-"])

--- a/app/views/public_activity/application_token/_create.html.slim
+++ b/app/views/public_activity/application_token/_create.html.slim
@@ -7,7 +7,7 @@ li
     .description
       h6
         strong
-          = activity.owner.username
+          = activity.owner.display_username
           |  created a token for the "
           em= activity.parameters[:application]
           | " application

--- a/app/views/public_activity/application_token/_destroy.csv.slim
+++ b/app/views/public_activity/application_token/_destroy.csv.slim
@@ -1,1 +1,1 @@
-= CSV.generate_line(["application token", "#{activity.parameters[:application]}", "destroy", "-", activity.owner.username, activity.created_at, "-"])
+= CSV.generate_line(["application token", "#{activity.parameters[:application]}", "destroy", "-", activity.owner.display_username, activity.created_at, "-"])

--- a/app/views/public_activity/application_token/_destroy.html.slim
+++ b/app/views/public_activity/application_token/_destroy.html.slim
@@ -7,7 +7,7 @@ li
     .description
       h6
         strong
-          = activity.owner.username
+          = activity.owner.display_username
           |  removed the token of "
           em= activity.parameters[:application]
           | " application

--- a/app/views/public_activity/namespace/_change_namespace_description.csv.slim
+++ b/app/views/public_activity/namespace/_change_namespace_description.csv.slim
@@ -2,7 +2,7 @@
                      activity.trackable.name,
                      'change the description of the namespace',
                      activity.recipient.name,
-                     activity.owner.username,
+                     activity.owner.display_username,
                      activity.created_at,
                      "from #{activity.parameters[:old_description]} to \
                      #{activity.parameters[:new_description]}"])

--- a/app/views/public_activity/namespace/_change_namespace_description.html.slim
+++ b/app/views/public_activity/namespace/_change_namespace_description.html.slim
@@ -8,10 +8,10 @@ li
       h6
         - if activity.parameters[:new].blank?
           strong
-            = "#{activity.owner.username} deleted the description of the namespace "
+            = "#{activity.owner.display_username} deleted the description of the namespace "
         - else
           strong
-            = "#{activity.owner.username} edited the description of the namespace "
+            = "#{activity.owner.display_username} edited the description of the namespace "
         = link_to activity.trackable.name, activity.trackable
       small
         i.fa.fa-clock-o

--- a/app/views/public_activity/namespace/_create.csv.slim
+++ b/app/views/public_activity/namespace/_create.csv.slim
@@ -1,1 +1,1 @@
-= CSV.generate_line(['namespace', activity.trackable.name, 'create', '-', activity.owner.username, activity.created_at, "owned by team #{activity.trackable.team.name}"])
+= CSV.generate_line(['namespace', activity.trackable.name, 'create', '-', activity.owner.display_username, activity.created_at, "owned by team #{activity.trackable.team.name}"])

--- a/app/views/public_activity/namespace/_create.html.slim
+++ b/app/views/public_activity/namespace/_create.html.slim
@@ -7,7 +7,7 @@ li
     .description
       h6
         strong
-          = "#{activity.owner.username} created the "
+          = "#{activity.owner.display_username} created the "
         = link_to activity.trackable.name , activity.trackable
         = " namespace under the "
         = link_to activity.trackable.team.name, activity.trackable.team

--- a/app/views/public_activity/namespace/_delete.html.slim
+++ b/app/views/public_activity/namespace/_delete.html.slim
@@ -7,7 +7,7 @@ li
     .description
       h6
         strong
-          = " #{activity.owner.username} deleted "
+          = " #{activity.owner.display_username} deleted "
         - if activity.parameters[:repository_name]
           = link_to activity.trackable.clean_name, activity.trackable
           = " / #{activity.parameters[:repository_name]}"

--- a/app/views/public_activity/namespace/_private.csv.slim
+++ b/app/views/public_activity/namespace/_private.csv.slim
@@ -1,1 +1,1 @@
-= CSV.generate_line(['namespace', activity.trackable.name, 'make private', '-', activity.owner.username, activity.created_at, '-'])
+= CSV.generate_line(['namespace', activity.trackable.name, 'make private', '-', activity.owner.display_username, activity.created_at, '-'])

--- a/app/views/public_activity/namespace/_private.html.slim
+++ b/app/views/public_activity/namespace/_private.html.slim
@@ -7,7 +7,7 @@ li
     .description
       h6
         strong
-          = "#{activity.owner.username} set the "
+          = "#{activity.owner.display_username} set the "
         = link_to activity.trackable.name, activity.trackable
         = " namespace as private"
       small

--- a/app/views/public_activity/namespace/_public.csv.slim
+++ b/app/views/public_activity/namespace/_public.csv.slim
@@ -1,1 +1,1 @@
-= CSV.generate_line(['namespace', activity.trackable.name, 'make public', '-', activity.owner.username, activity.created_at, '-'])
+= CSV.generate_line(['namespace', activity.trackable.name, 'make public', '-', activity.owner.display_username, activity.created_at, '-'])

--- a/app/views/public_activity/namespace/_public.html.slim
+++ b/app/views/public_activity/namespace/_public.html.slim
@@ -7,7 +7,7 @@ li
     .description
       h6
         strong
-          = "#{activity.owner.username} set the "
+          = "#{activity.owner.display_username} set the "
         = link_to activity.trackable.name, activity.trackable
         = " namespace as public"
       small

--- a/app/views/public_activity/repository/_delete.csv.slim
+++ b/app/views/public_activity/repository/_delete.csv.slim
@@ -1,9 +1,9 @@
 - unless activity.trackable.nil?
   - if activity.recipient.nil?
     - if activity.parameters[:tag_name].nil?
-      = CSV.generate_line(['repository', "#{activity.trackable.namespace.global? ?  activity.trackable.namespace.registry.hostname : activity.trackable.namespace.name}/#{activity.trackable.name}", 'delete tag', '-', activity.owner.username, activity.created_at, "-"])
+      = CSV.generate_line(['repository', "#{activity.trackable.namespace.global? ?  activity.trackable.namespace.registry.hostname : activity.trackable.namespace.name}/#{activity.trackable.name}", 'delete tag', '-', activity.owner.display_username, activity.created_at, "-"])
     - else
       = CSV.generate_line(['repository',
-          "#{activity.trackable.namespace.global? ?  activity.trackable.namespace.registry.hostname : activity.trackable.namespace.name}/#{activity.trackable.name}:#{activity.parameters[:tag_name]}", 'delete tag', '-', activity.owner.username, activity.created_at, "-"])
+          "#{activity.trackable.namespace.global? ?  activity.trackable.namespace.registry.hostname : activity.trackable.namespace.name}/#{activity.trackable.name}:#{activity.parameters[:tag_name]}", 'delete tag', '-', activity.owner.display_username, activity.created_at, "-"])
   - else
-    = CSV.generate_line(['repository', "#{activity.trackable.namespace.global?  ? activity.trackable.namespace.registry.hostname : activity.trackable.namespace.name}/#{activity.trackable.name}:#{activity.recipient.name}", 'delete tag', '-', activity.owner.username, activity.created_at, "-"])
+    = CSV.generate_line(['repository', "#{activity.trackable.namespace.global?  ? activity.trackable.namespace.registry.hostname : activity.trackable.namespace.name}/#{activity.trackable.name}:#{activity.recipient.name}", 'delete tag', '-', activity.owner.display_username, activity.created_at, "-"])

--- a/app/views/public_activity/repository/_push.csv.slim
+++ b/app/views/public_activity/repository/_push.csv.slim
@@ -1,8 +1,8 @@
 - unless activity.trackable.nil?
   - if activity.recipient.nil?
     - if activity.parameters[:tag_name].nil?
-      = CSV.generate_line(['repository', "#{activity.trackable.namespace.global? ? activity.trackable.namespace.registry.hostname : activity.trackable.namespace.name}/#{activity.trackable.name}", 'push tag', '-', activity.owner.username, activity.created_at, "-"])
+      = CSV.generate_line(['repository', "#{activity.trackable.namespace.global? ? activity.trackable.namespace.registry.hostname : activity.trackable.namespace.name}/#{activity.trackable.name}", 'push tag', '-', activity.owner.display_username, activity.created_at, "-"])
     - else
-      = CSV.generate_line(['repository', "#{activity.trackable.namespace.global? ? activity.trackable.namespace.registry.hostname : activity.trackable.namespace.name}/#{activity.trackable.name}:#{activity.parameters[:tag_name]}", 'push tag', '-', activity.owner.username, activity.created_at, "-"])
+      = CSV.generate_line(['repository', "#{activity.trackable.namespace.global? ? activity.trackable.namespace.registry.hostname : activity.trackable.namespace.name}/#{activity.trackable.name}:#{activity.parameters[:tag_name]}", 'push tag', '-', activity.owner.display_username, activity.created_at, "-"])
   - else
-    = CSV.generate_line(['repository', "#{activity.trackable.namespace.global? ? activity.trackable.namespace.registry.hostname : activity.trackable.namespace.name}/#{activity.trackable.name}:#{activity.recipient.name}", 'push tag', '-', activity.owner.username, activity.created_at, "-"])
+    = CSV.generate_line(['repository', "#{activity.trackable.namespace.global? ? activity.trackable.namespace.registry.hostname : activity.trackable.namespace.name}/#{activity.trackable.name}:#{activity.recipient.name}", 'push tag', '-', activity.owner.display_username, activity.created_at, "-"])

--- a/app/views/public_activity/team/_add_member.csv.slim
+++ b/app/views/public_activity/team/_add_member.csv.slim
@@ -1,1 +1,1 @@
-= CSV.generate_line(['team', activity.trackable.name, 'add member', activity.recipient.username, activity.owner.username, activity.created_at, "role #{activity.parameters[:role]}"])
+= CSV.generate_line(['team', activity.trackable.name, 'add member', activity.recipient.display_username, activity.owner.display_username, activity.created_at, "role #{activity.parameters[:role]}"])

--- a/app/views/public_activity/team/_add_member.html.slim
+++ b/app/views/public_activity/team/_add_member.html.slim
@@ -7,7 +7,7 @@ li
     .description
       h6
         strong
-          = "#{activity.owner.username} added user #{activity.recipient.username} "
+          = "#{activity.owner.display_username} added user #{activity.recipient.display_username} "
         = "with role #{activity.parameters[:role]} to the "
         = link_to activity.trackable.name, activity.trackable
         |  team

--- a/app/views/public_activity/team/_change_member_role.csv.slim
+++ b/app/views/public_activity/team/_change_member_role.csv.slim
@@ -1,8 +1,8 @@
 = CSV.generate_line(['team',
                       activity.trackable.name,
                       'change member role',
-                      activity.recipient.username,
-                      activity.owner.username,
+                      activity.recipient.display_username,
+                      activity.owner.display_username,
                       activity.created_at,
                       "from #{activity.parameters[:old_role]} to \
                       #{activity.parameters[:new_role]}"])

--- a/app/views/public_activity/team/_change_member_role.html.slim
+++ b/app/views/public_activity/team/_change_member_role.html.slim
@@ -8,9 +8,9 @@ li
       h6
         strong
           - if activity.owner == activity.recipient
-            = "#{activity.owner.username} changed its role "
+            = "#{activity.owner.display_username} changed its role "
           - else
-            = "#{activity.owner.username} changed role of user #{activity.recipient.username} "
+            = "#{activity.owner.display_username} changed role of user #{activity.recipient.display_username} "
         = "from #{activity.parameters[:old_role]} to #{activity.parameters[:new_role]} "
         = "within the team "
         = link_to activity.trackable.name, activity.trackable

--- a/app/views/public_activity/team/_change_team_description.csv.slim
+++ b/app/views/public_activity/team/_change_team_description.csv.slim
@@ -2,7 +2,7 @@
                      activity.trackable.name,
                      'change the description of the team',
                      activity.recipient.name,
-                     activity.owner.username,
+                     activity.owner.display_username,
                      activity.created_at,
                      "from #{activity.parameters[:old_description]} to \
                      #{activity.parameters[:new_description]}"])

--- a/app/views/public_activity/team/_change_team_description.html.slim
+++ b/app/views/public_activity/team/_change_team_description.html.slim
@@ -8,10 +8,10 @@ li
       h6
         - if activity.parameters[:new].blank?
           strong
-            ="#{activity.owner.username} deleted the description of the team "
+            ="#{activity.owner.display_username} deleted the description of the team "
         - else
           strong
-            = "#{activity.owner.username} edited the description of the team "
+            = "#{activity.owner.display_username} edited the description of the team "
         =  link_to activity.trackable.name, activity.trackable
       small
         i.fa.fa-clock-o

--- a/app/views/public_activity/team/_change_team_name.csv.slim
+++ b/app/views/public_activity/team/_change_team_name.csv.slim
@@ -2,7 +2,7 @@
                      activity.trackable.name,
                      'change the name of the team',
                      activity.recipient.name,
-                     activity.owner.username,
+                     activity.owner.display_username,
                      activity.created_at,
                      "from #{activity.parameters[:old_name]} to \
                      #{activity.parameters[:new_name]}"])

--- a/app/views/public_activity/team/_change_team_name.html.slim
+++ b/app/views/public_activity/team/_change_team_name.html.slim
@@ -7,7 +7,7 @@ li
     .description
       h6
         strong
-          = "#{activity.owner.username} renamed the team #{activity.parameters[:old]} to "
+          = "#{activity.owner.display_username} renamed the team #{activity.parameters[:old]} to "
         =  link_to activity.parameters[:new], activity.trackable
       small
         i.fa.fa-clock-o

--- a/app/views/public_activity/team/_create.csv.slim
+++ b/app/views/public_activity/team/_create.csv.slim
@@ -1,1 +1,1 @@
-= CSV.generate_line(['team', activity.trackable.name, 'create', '-', activity.owner.username, activity.created_at, '-'])
+= CSV.generate_line(['team', activity.trackable.name, 'create', '-', activity.owner.display_username, activity.created_at, '-'])

--- a/app/views/public_activity/team/_create.html.slim
+++ b/app/views/public_activity/team/_create.html.slim
@@ -7,7 +7,7 @@ li
     .description
       h6
         strong
-          = "#{activity.owner.username} created team "
+          = "#{activity.owner.display_username} created team "
         = link_to activity.trackable.name, activity.trackable
       small
         i.fa.fa-clock-o

--- a/app/views/public_activity/team/_remove_member.csv.slim
+++ b/app/views/public_activity/team/_remove_member.csv.slim
@@ -1,1 +1,1 @@
-= CSV.generate_line(['team', activity.trackable.name, 'remove member', activity.recipient.username, activity.owner.username, activity.created_at, "role #{activity.parameters[:role]}"])
+= CSV.generate_line(['team', activity.trackable.name, 'remove member', activity.recipient.display_username, activity.owner.display_username, activity.created_at, "role #{activity.parameters[:role]}"])

--- a/app/views/public_activity/team/_remove_member.html.slim
+++ b/app/views/public_activity/team/_remove_member.html.slim
@@ -8,9 +8,9 @@ li
       h6
         strong
           - if activity.owner == activity.recipient
-            = "#{activity.owner.username} removed itself "
+            = "#{activity.owner.display_username} removed itself "
           - else
-            = "#{activity.owner.username} removed user #{activity.recipient.username} "
+            = "#{activity.owner.display_username} removed user #{activity.recipient.display_username} "
         = "from the "
         = link_to activity.trackable.name, activity.trackable
         |  team

--- a/app/views/repositories/show.html.slim
+++ b/app/views/repositories/show.html.slim
@@ -54,7 +54,7 @@
                   td
                     .label.label-success
                       = t.name
-                  td= tag.first.author.username
+                  td= tag.first.author.display_username
                   td
                     - if tag.first.image_id.blank?
                       = "-"
@@ -68,7 +68,7 @@
                   - tag.each do |t|
                     .label.label-success
                       = t.name
-                td= tag.first.author.username
+                td= tag.first.author.display_username
                 td
                   - if tag.first.image_id.blank?
                     = "-"

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -16,6 +16,6 @@
         = user_image_tag(current_user.email)
 
         = link_to edit_user_registration_path, class: 'nav-a' do
-          span.username = current_user.username
+          span.username = current_user.display_username
       = link_to destroy_user_session_path, method: :delete, class: 'topbar btn btn-default', id: 'logout' do
         i.fa.fa-sign-out

--- a/app/views/team_users/_team_user.html.slim
+++ b/app/views/team_users/_team_user.html.slim
@@ -1,6 +1,6 @@
 tr id="team_user_#{team_user.id}"
   td.table-icon= team_user_role_icon(team_user)
-  td= team_user.user.username
+  td= team_user.user.display_username
   td
     .role= team_user.role.titleize
     .collapse id="change_role_team_user_#{team_user.id}"

--- a/config/config.yml
+++ b/config/config.yml
@@ -117,3 +117,9 @@ jwt_expiration_time:
 # The FQDN of the machine where Portus is being deployed.
 machine_fqdn:
   value: "portus.test.lan"
+
+# Allow users to have different display names on the web site. This will
+# **not** be the username used by `docker login`. It defaults to false because
+# it might confuse users that are not fully aware of it.
+display_name:
+  enabled: false

--- a/db/migrate/20160531151718_add_display_name_to_users.rb
+++ b/db/migrate/20160531151718_add_display_name_to_users.rb
@@ -1,0 +1,6 @@
+class AddDisplayNameToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :display_name, :string, default: nil
+    add_index :users, :display_name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160502140301) do
+ActiveRecord::Schema.define(version: 20160531151718) do
 
   create_table "activities", force: :cascade do |t|
     t.integer  "trackable_id",   limit: 4
@@ -165,8 +165,10 @@ ActiveRecord::Schema.define(version: 20160502140301) do
     t.string   "ldap_name",              limit: 255
     t.integer  "failed_attempts",        limit: 4,   default: 0
     t.datetime "locked_at"
+    t.string   "display_name",           limit: 255
   end
 
+  add_index "users", ["display_name"], name: "index_users_on_display_name", unique: true, using: :btree
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
   add_index "users", ["ldap_name"], name: "index_users_on_ldap_name", unique: true, using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree

--- a/packaging/suse/portusctl/lib/cli.rb
+++ b/packaging/suse/portusctl/lib/cli.rb
@@ -117,6 +117,12 @@ Looks for the following required certificate files in the specified folder:
     type:    :boolean,
     default: true
 
+  # Display name
+  option "display-name-enable",
+    desc:    "Enable users to set a display name",
+    type:    :boolean,
+    default: false
+
   option "delete-enable",
     desc:    "Enable delete support. Only do this if your registry is 2.4 or higher",
     type:    :boolean,

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 feature "Dashboard page" do
   let!(:registry) { create(:registry) }
-  let!(:user) { create(:admin) }
+  let!(:user) { create(:admin, display_name: "docker-gangsta") }
   let!(:team) { create(:team, owners: [user]) }
   let!(:namespace) { create(:namespace, team: team) }
   let!(:repository) { create(:repository, namespace: namespace) }
@@ -49,6 +49,16 @@ feature "Dashboard page" do
       expect(page).not_to have_content("#{personal_namespace.name}/#{personal_repository.name}")
       expect(page).not_to have_content("#{namespace.name}/#{repository.name}")
       expect(page).not_to have_content("#{public_namespace.name}/#{public_repository.name}")
+    end
+  end
+
+  describe "Display name", focus: true do
+    scenario "Shows the display name of the user when needed" do
+      visit authenticated_root_path
+      expect(page).not_to have_content("docker-gangsta")
+      APP_CONFIG["display_name"] = { "enabled" => true }
+      visit authenticated_root_path
+      expect(page).to have_content("docker-gangsta")
     end
   end
 end

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -52,7 +52,7 @@ feature "Dashboard page" do
     end
   end
 
-  describe "Display name", focus: true do
+  describe "Display name" do
     scenario "Shows the display name of the user when needed" do
       visit authenticated_root_path
       expect(page).not_to have_content("docker-gangsta")

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -21,9 +21,11 @@
 #  ldap_name              :string(255)
 #  failed_attempts        :integer          default("0")
 #  locked_at              :datetime
+#  display_name           :string(255)
 #
 # Indexes
 #
+#  index_users_on_display_name          (display_name) UNIQUE
 #  index_users_on_email                 (email) UNIQUE
 #  index_users_on_ldap_name             (ldap_name) UNIQUE
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
@@ -242,6 +244,21 @@ describe User do
       # the factory uses appication's name as plain token
       create(:application_token, application: "bad", user: user)
       expect(user.application_token_valid?("good")).to be false
+    end
+  end
+
+  describe "#display_username" do
+    let(:user)  { build(:user, username: "user", display_name: "display") }
+    let(:user2) { build(:user, username: "user") }
+
+    it "returns the username of the feature is disabled" do
+      expect(user.display_username).to eq user.username
+    end
+
+    it "returns the username/display_name if the feature is enabled" do
+      APP_CONFIG["display_name"] = { "enabled" => true }
+      expect(user2.display_username).to eq user.username
+      expect(user.display_username).to eq user.display_name
     end
   end
 end


### PR DESCRIPTION
From now on, users will be able to introduce a "display name". This display
name will be the one shown on the website. The main goal of this feature is to
allow users to see names on the website that are more familiar to them (e.g.
users coming from LDAP but that have an "ugly" username there).

Notice that this "display name" is only used on the web site, not in the
`docker login` procedure. Because of this, and because it might confuse people,
this configuration option is disabled by default.

Fixes #699