### PR TITLE
Search improvements

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -30,3 +30,4 @@
 @import 'comments';
 @import 'repositories';
 @import 'responsive-utilities';
+@import 'search';

--- a/app/assets/stylesheets/search.scss
+++ b/app/assets/stylesheets/search.scss
@@ -1,0 +1,44 @@
+.search {
+  .category-panel {
+    .result-counter {
+      float: right;
+      background-color: $primary-colour;
+      border-radius: 0.5rem;
+      padding: 0 0.5rem;
+      font-weight: bold;
+      color: $white;
+      :hover {
+        background-color: $primary-colour;
+      }
+    }
+    .nav-pills {
+      .category {
+        border-radius: 0;
+        :hover {
+          border-radius: 0;
+          background-color: lighten($gray-light, 15);
+        }
+      }
+      .active-cetegory {
+        background-color: lighten($gray-light, 15);
+        border-left: 0.5rem solid $primary-colour;
+      }
+    }
+    .nav-tabs {
+      .category {
+        border: 1px solid $gray-light;
+        border-bottom: 0;
+        border-top: 0.5rem solid $gray-light;
+        border-radius: 0.5rem 0.5rem 0 0;
+        background-color: lighten($gray-light, 15);
+      }
+      .active-cetegory {
+        border-top: 0.5rem solid $primary-colour;
+        background-color: $white;
+      }
+      .result-counter {
+        margin-left: 1rem;
+      }
+    }
+  }
+}

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -2,5 +2,7 @@ class SearchController < ApplicationController
   def index
     search = params[:search].split(":").first
     @repositories = policy_scope(Repository).search(search)
+    @teams = policy_scope(Team).search(search)
+    @namespaces = policy_scope(Namespace).search(search)
   end
 end

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -1,0 +1,5 @@
+module SearchHelper
+  def build_search_category_url(params, category)
+    "#{search_index_path}?utf8=#{params[:utf8]}&search=#{params[:search]}&type=#{category}"
+  end
+end

--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -22,6 +22,11 @@
 
 class Namespace < ActiveRecord::Base
   include PublicActivity::Common
+  include SearchCop
+
+  search_scope :search do
+    attributes :name, :description
+  end
 
   # This regexp is extracted from the reference package of Docker Distribution
   # and it matches a valid namespace name.

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -16,6 +16,11 @@
 
 class Team < ActiveRecord::Base
   include PublicActivity::Common
+  include SearchCop
+
+  search_scope :search do
+    attributes :name, :description
+  end
 
   # Returns all the teams that are not special. By special team we mean:
   #   - It's the global namespace (see: Registry#create_namespaces!).

--- a/app/views/search/_desktop_categories.html.slim
+++ b/app/views/search/_desktop_categories.html.slim
@@ -1,0 +1,13 @@
+ul.nav.nav-pills.nav-stacked
+  li[class="category #{params[:type] == "repositories" ? 'active-cetegory' : ''}"]
+    a href="#{build_search_category_url params, 'repositories'}"
+      | Repositories
+      span.result-counter = @repositories.count
+  li[class="category #{params[:type] == "namespaces" ? 'active-cetegory' : ''}"]
+    a href="#{build_search_category_url params, 'namespaces'}"
+      | Namespaces
+      span.result-counter = @namespaces.count
+  li[class="category #{params[:type] == "teams" ? 'active-cetegory' : ''}"]
+    a href="#{build_search_category_url params, 'teams'}"
+      | Teams
+      span.result-counter = @teams.count

--- a/app/views/search/_mobile_categories.html.slim
+++ b/app/views/search/_mobile_categories.html.slim
@@ -1,0 +1,13 @@
+ul.nav.nav-tabs
+  li[class="category #{params[:type] == "repositories" ? 'active-cetegory' : ''}"]
+    a href="#{build_search_category_url params, 'repositories'}"
+      | Repositories
+      span.result-counter = @repositories.count
+  li[class="category #{params[:type] == "namespaces" ? 'active-cetegory' : ''}"]
+    a href="#{build_search_category_url params, 'namespaces'}"
+      | Namespaces
+      span.result-counter = @namespaces.count
+  li[class="category #{params[:type] == "teams" ? 'active-cetegory' : ''}"]
+    a href="#{build_search_category_url params, 'teams'}"
+      | Teams
+      span.result-counter = @teams.count

--- a/app/views/search/_namespaces.html.slim
+++ b/app/views/search/_namespaces.html.slim
@@ -1,0 +1,21 @@
+- if @namespaces.empty?
+  p No match found.
+- else
+  .table-responsive
+    table.table.table-stripped.table-hover
+      thead
+        tr
+          th Name
+          th Repositories
+          th Webhooks
+          th Created at
+      tbody
+        - @namespaces.each do |namespace|
+          tr id="namespace_#{namespace.id}"
+            td= link_to namespace.clean_name, namespace
+            td= namespace.repositories.count
+            - if current_user.admin? || namespace.team.users.include?(current_user)
+              td= link_to namespace.webhooks.count, namespace_webhooks_path(namespace)
+            - else
+              td= namespace.webhooks.count
+            td= time_tag namespace.created_at

--- a/app/views/search/_repositories.html.slim
+++ b/app/views/search/_repositories.html.slim
@@ -1,0 +1,16 @@
+- if @repositories.empty?
+  p No match found.
+- else
+  .table-responsive
+    table.table.table-striped.table-hover
+      thead
+        tr
+          th Namespace
+          th Repository
+          th Updated at
+      tbody
+        - @repositories.each do |repository|
+          tr
+            td= link_to repository.namespace.clean_name, repository.namespace
+            td= link_to repository.name, repository
+            td= time_tag repository.updated_at

--- a/app/views/search/_teams.html.slim
+++ b/app/views/search/_teams.html.slim
@@ -1,0 +1,18 @@
+- if @teams.empty?
+  p No match found.
+- else
+  .table-responsive
+    table.table.table-striped.table-hover
+      thead
+        tr
+          th
+          th Team
+          th Number of members
+          th Number of namespaces
+      tbody#teams
+        - @teams.each do |team|
+          tr
+            td.table-icon= team_scope_icon(team)
+            td= link_to team.name, team
+            td= team.users.enabled.count
+            td= team.namespaces.count

--- a/app/views/search/index.html.slim
+++ b/app/views/search/index.html.slim
@@ -1,18 +1,18 @@
 .panel.panel-default
   .panel-heading
     h5 Search results
-  .panel-body
-    - if @repositories.empty?
-      p No match found.
-    - else
-      .table-responsive
-        table.table.table-striped.table-hover
-          thead
-            tr
-              th Namespace
-              th Repository
-          tbody
-            - @repositories.each do |repository|
-              tr
-                td= link_to repository.namespace.clean_name, repository.namespace
-                td= link_to repository.name, repository
+  .panel-body.search
+    .row
+      .col-xs-12.col-md-4.col-lg-3.category-panel
+          .hidden-xs
+            = render template: "search/_desktop_categories.html.slim"
+          .visible-xs
+            = render template: "search/_mobile_categories.html.slim"
+      .col-xs-12.col-md-8.col-lg-9.search.search-result
+        - case params[:type]
+          - when 'repositories'
+          = render template: "search/_repositories.html.slim"
+          -when 'namespaces'
+          = render template: "search/_namespaces.html.slim"
+          -when 'teams'
+          = render template: "search/_teams.html.slim"

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -7,7 +7,8 @@
   .search-header.hidden-xs
     .header-search-form
       = form_tag search_index_path, method: 'get', class: 'navbar-form' do
-        = search_field_tag 'search', params[:search], class: 'form-control search-field', placeholder: 'Search repository'
+        = search_field_tag 'search', params[:search], class: 'form-control search-field', placeholder: 'Search'
+        = hidden_field_tag 'type', 'repositories'
         button[type="submit" class="btn btn-default"]
           i.fa.fa-search
   .button-container

--- a/app/views/shared/_search.html.slim
+++ b/app/views/shared/_search.html.slim
@@ -2,7 +2,8 @@
   .col-xs-12.visible-xs
     = form_tag search_index_path, method: 'get', class: 'input-group shared-search' do
       .input-group.shared-search
-        = search_field_tag 'search', params[:search], class: 'form-control', placeholder: 'Search repository'
+        = search_field_tag 'search', params[:search], class: 'form-control', placeholder: 'Search'
+        = hidden_field_tag 'type', 'repositories'
         span.input-group-btn
           button.btn.btn-default
             i.fa.fa-search

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.describe SearchHelper, type: :helper do
+
+  describe "build_search_category_url" do
+    it "returns true if current user is an owner of the team" do
+      expected = "#{search_index_path}?utf8=✓&search=&type=repositories"
+      params = { utf8: "✓", search: "" }
+      expect(helper.build_search_category_url(params, "repositories")).to eq expected
+    end
+  end
+end


### PR DESCRIPTION
Fixes: #753 

In this PR I updated the search feature to search through Teams and Namespaces too! So, I added a category menuto filter by repository, team and namespace.

![screenshot-localhost 5000 2016-06-14 00-06-26](https://cloud.githubusercontent.com/assets/2891076/16030178/310523f4-31c5-11e6-93ec-e8984ae6d8cd.png)
![screenshot-localhost 5000 2016-06-14 00-06-54](https://cloud.githubusercontent.com/assets/2891076/16030179/32c8b78c-31c5-11e6-8667-17883be700d1.png)

The repository search result table is the same as before, I only added "updated_at" column. Then I show in this print a empty result :)

![screenshot-localhost 5000 2016-06-14 00-07-13](https://cloud.githubusercontent.com/assets/2891076/16030181/362396fe-31c5-11e6-97ba-61861093b40b.png)

And in small screens:

![screencapture 1](https://cloud.githubusercontent.com/assets/2891076/16030182/38e3a884-31c5-11e6-84c8-3761fec180b5.png)

