### PR TITLE
New design for documentation menu

### DIFF
--- a/_includes/desktop-topics.html
+++ b/_includes/desktop-topics.html
@@ -1,0 +1,40 @@
+<aside class="hidden-xs hidden-sm content-list">
+  <ul class="topics">
+    <li>Documentation</li>
+    <ul class="subtopics">
+      {% assign docs = (site.docs | sort: 'order') %}
+      {% for subtopic in docs %}
+        <li>
+          <a href="{{ subtopic.url | prepend: site.baseurl }}">
+            {{ subtopic.title }}
+          </a>
+        </li>
+      {% endfor %}
+    </ul>
+    <li>Setups</li>
+    <ul class="subtopics">
+      {% assign setups = (site.setups | sort: 'order') %}
+      {% for subtopic in setups %}
+        <li>
+          <a href="{{ subtopic.url | prepend: site.baseurl }}">
+            {{ subtopic.title }}
+          </a>
+        </li>
+      {% endfor %}
+    </ul>
+    <li>Features</li>
+    <ul class="subtopics">
+      {% assign features = (site.features | sort: 'order') %}
+      {% for subtopic in features %}
+        <li>
+          <a href="{{ subtopic.url | prepend: site.baseurl }}">
+            {{ subtopic.title }}
+          </a>
+        </li>
+      {% endfor %}
+    </ul>
+  </ul>
+  <div class="credits">
+    <div class="text-center" lang="en">Created with <i class='fa fa-heart secondary-colour'></i> by the SUSE team</div>
+  </div>
+</aside>

--- a/_includes/mobile-topics.html
+++ b/_includes/mobile-topics.html
@@ -1,0 +1,39 @@
+<div class="visible-xs visible-sm">
+  <div class="content-bar">
+    <ul class="topics">
+      <li class="dropdown">
+        <button class="dropdown-toggle" type="button" data-toggle="dropdown">Documentation Index
+        <span class="caret"></span></button>
+        <ul class="dropdown-menu">
+          <li class="dropdown-header">Documentation</li>
+          {% assign docs = (site.docs | sort: 'order') %}
+          {% for subtopic in docs %}
+            <li>
+              <a href="{{ subtopic.url | prepend: site.baseurl }}">
+                {{ subtopic.title }}
+              </a>
+            </li>
+          {% endfor %}
+          <li class="dropdown-header">Setups</li>
+          {% assign setups = (site.setups | sort: 'order') %}
+          {% for subtopic in setups %}
+            <li>
+              <a href="{{ subtopic.url | prepend: site.baseurl }}">
+                {{ subtopic.title }}
+              </a>
+            </li>
+          {% endfor %}
+          <li class="dropdown-header">Features</li>
+          {% assign features = (site.features | sort: 'order') %}
+          {% for subtopic in features %}
+            <li>
+              <a href="{{ subtopic.url | prepend: site.baseurl }}">
+                {{ subtopic.title }}
+              </a>
+            </li>
+          {% endfor %}
+        </ul>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -16,57 +16,25 @@
   </head>
   <body>
     {% include header.html %}
-    <div class="container-fluid" id="documentation">
+    <div class="container" id="documentation">
       <div class="row">
-        <aside class="col-xs-3 aside-max">
-          <h4>Documentation</h4>
-          <ul>
-            {% assign docs = (site.docs | sort: 'order') %}
-            {% for d in docs %}
-              <li>
-                <a href="{{ d.url | prepend: site.baseurl }}">
-                  {{ d.title }}
-                </a>
-              </li>
-            {% endfor %}
-          </ul>
-          <h4>Setups</h4>
-          <ul>
-            {% assign setups = (site.setups | sort: 'order') %}
-            {% for s in setups %}
-              <li>
-                <a href="{{ s.url | prepend: site.baseurl }}">
-                  {{ s.title }}
-                </a>
-              </li>
-            {% endfor %}
-          </ul>
-          <h4>Features</h4>
-            <ul>
-            {% assign features = (site.features | sort: 'order') %}
-            {% for f in features %}
-              <li>
-                <a href="{{ f.url | prepend: site.baseurl }}">
-                  {{ f.title }}
-                </a>
-              </li>
-            {% endfor %}
-            </ul>
-        </aside>
-        <div class="col-md-8 col-sm-11 col-xs-11 post-wrapper">
+        <div class="col-md-9 col-md-offset-3 col-sm-12 col-xs-12">
           <section>
+            <div class="row">
+              {% include mobile-topics.html %}
+            </div>
             <div class="row post">
-              <article class="post-content col-md-10">
+              <article>
                 {{ content }}
               </article>
             </div>
           </section>
-
         </div>
       </div>
+      {% include desktop-topics.html %}
+      <div class="visible-xs visible-sm credits">
+        <div class="text-center" lang="en">Created with <i class='fa fa-heart secondary-colour'></i> by the SUSE team</div>
+      </div>
     </div>
-  <footer class="col-xs-3 footer-documentation aside-max">
-    <div class="text-center" lang="en">Created with <i class='fa fa-heart secondary-colour'></i> by the SUSE team</div>
-  </footer>
   </body>
 </html>

--- a/assets/stylesheets/documentation.less
+++ b/assets/stylesheets/documentation.less
@@ -17,16 +17,6 @@ html, body {
     position: fixed;
     top: 0px;
     left: 0px;
-    ul {
-      padding: .2em 1em;
-      li {
-        list-style: disc;
-        list-style-position: inside;
-        a {
-          color: @white;
-        }
-      }
-    }
   }
 
   section:first-of-type {
@@ -98,4 +88,3 @@ footer {
     max-width: 330px;
   }
 }
-

--- a/assets/stylesheets/layout.less
+++ b/assets/stylesheets/layout.less
@@ -169,3 +169,105 @@ body {
   background: @text-selected;
   color: #fff;
 }
+
+.credits {
+  padding-top: 2rem;
+  padding-bottom: 2rem;
+  border-top: 1px solid @portus-users-bg-hover;
+}
+
+aside {
+  .credits {
+    background: lighten(@thirdColour, 2%);
+  }
+}
+
+.content-list {
+  background-color: @gray-darker;
+  height: 100%;
+  width: calc(100vw - 75vw);
+  position: fixed;
+  margin-left: 0;
+  overflow-y: auto;
+
+  .topics {
+    padding: 0 !important;
+    > li {
+      background: lighten(@thirdColour, 1%);
+      list-style: none;
+      padding: 1rem 2rem;
+      text-transform: uppercase;
+      font-family: Roboto,sans-serif;
+      color: @aside-titles;
+    }
+  }
+  .subtopics {
+    padding-bottom: 2rem;
+    padding-top: 1rem;
+    padding-left: 0;
+    > li {
+      list-style: none;
+      padding: 0.3rem;
+      padding-left: 3rem;
+      a {
+        color: @white;
+        &:hover {
+          text-decoration: none;
+        }
+      }
+      &:hover {
+        background-color: lighten(@thirdColour, 3%);
+      }
+    }
+  }
+}
+
+.content-list::-webkit-scrollbar {
+  width: 0.8rem;
+  margin-right: 0.5rem;
+}
+
+.content-list::-webkit-scrollbar-thumb {
+  border-radius: 5px;
+  background-color: darken(@thirdColour, 3%);
+}
+
+.content-bar {
+  margin: 1rem auto 1rem auto;
+  display: table;
+  .topics {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    > li {
+      display: inline-flex;
+      button {
+        border-radius: 0;
+        border: 0;
+        border-bottom: 3px solid @portus-users-bg;
+        background: transparent;
+        padding: 1rem;
+        text-transform: uppercase;
+        text-align: left;
+        margin-left: 1rem;
+        margin-right: 1rem;
+        width: 40rem;
+        span {
+          float: right;
+          margin: 1rem;
+        }
+      }
+    }
+    .dropdown-menu {
+      width: 40rem;
+      margin-left: 1rem;
+      .dropdown-header {
+        color: @portus-users-bg;
+        font-size: 12px;
+        font-weight: bold;
+        text-transform: uppercase;
+        margin-top: 1rem;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Hi :)

@mssola notify me about one bug on "Created with <3 by the SUSE team" documentation menu: 

![image](https://cloud.githubusercontent.com/assets/2891076/16069452/e8e97e4a-32a4-11e6-849a-e848b8b0e17b.png)

Analyzing this problem, I saw other issue: when the screen have a small height (and need not to be too small), the quantity of items on the list overflows the screen, then the user lost a piece of menu.

So I designed a new interface for this documentation menu, with a scrollabe menu and added the "Created with <3 by the SUSE team" at the bottom:

![screencapture 2](https://cloud.githubusercontent.com/assets/2891076/16069477/185e2c84-32a5-11e6-8863-614536356a1b.png)

![screencapture 3](https://cloud.githubusercontent.com/assets/2891076/16069478/19e5dd40-32a5-11e6-8331-ed147870cffe.png)

And in small screen I put the menu in a dropdown:

![screencapture 4](https://cloud.githubusercontent.com/assets/2891076/16069583/f6bc9f9c-32a5-11e6-8aeb-26b3a7d5db65.png)

![screencapture 5](https://cloud.githubusercontent.com/assets/2891076/16069589/fa0fa086-32a5-11e6-9029-166375727889.png)


I hope that you enjoy it! :)
