### PR TITLE
Upgrading ethon and typhoeus

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,10 @@ gem "redcarpet"
 gem "font-awesome-rails"
 gem "bootstrap-typeahead-rails"
 gem "rails_stdout_logging", "~> 0.0.5", group: [:development, :staging, :production]
-gem "typhoeus"
+
+# Pinning these specific versions because that's what we have on OBS.
+gem "ethon", "~> 0.9.0"
+gem "typhoeus", "~> 1.0.2"
 
 # Used to store application tokens. This is already a Rails depedency. However
 # better safe than sorry...

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,7 +113,7 @@ GEM
       excon (>= 0.38.0)
       json
     erubis (2.7.0)
-    ethon (0.8.1)
+    ethon (0.9.0)
       ffi (>= 1.3.0)
     excon (0.49.0)
     execjs (2.2.2)
@@ -357,8 +357,8 @@ GEM
       polyglot (~> 0.3)
     turbolinks (2.5.3)
       coffee-rails
-    typhoeus (1.0.1)
-      ethon (>= 0.8.0)
+    typhoeus (1.0.2)
+      ethon (>= 0.9.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (2.7.2)
@@ -407,6 +407,7 @@ DEPENDENCIES
   database_cleaner
   devise
   docker-api (~> 1.28.0)
+  ethon (~> 0.9.0)
   factory_girl_rails
   ffaker
   font-awesome-rails
@@ -445,7 +446,7 @@ DEPENDENCIES
   thor
   timecop
   turbolinks
-  typhoeus
+  typhoeus (~> 1.0.2)
   uglifier
   vcr
   web-console (~> 2.1.3)


### PR DESCRIPTION
This change has been done because these are the versions that we have
on OBS, and they should be fine.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>