### PR TITLE
webhooks: handle delete events

### DIFF
--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -85,6 +85,12 @@ class Webhook < ActiveRecord::Base
     hydra.run
   end
 
+  # Handle a delete event from the registry. All enabled webhooks of the provided
+  # namespace are triggered in parallel.
+  def self.handle_delete_event(event)
+    handle_push_event(event)
+  end
+
   # host returns the host part of the URL. This is useful when wanting a pretty
   # representation of a webhook.
   def host


### PR DESCRIPTION
Webhooks should handle delete events just like they do push events since
they are not doing anything special.

Fixes #958

Signed-off-by: Thomas Hipp <thipp@suse.de>