### PR TITLE
update digests when updating tags

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -135,11 +135,14 @@ class Repository < ActiveRecord::Base
     return if actor.nil?
 
     # Get or create the repository as "namespace/repo". If both the repo and
-    # the given tag already exists, return early.
+    # the given tag already exists, update the digest and return early.
     repository = Repository.find_by(namespace: namespace, name: repo)
     if repository.nil?
       repository = Repository.create(namespace: namespace, name: repo)
     elsif repository.tags.exists?(name: tag)
+      # Update digest if the given tag already exists.
+      _, digest = Repository.id_and_digest_from_event(event, repository.full_name)
+      repository.tags.find_by(name: tag).update!(digest: digest)
       return
     end
 

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -93,6 +93,16 @@ describe Repository do
           Repository.add_repo(event, registry.global_namespace, repository_name, tag_name)
         end.to change(PublicActivity::Activity, :count).by(0)
       end
+
+      it "updates the digest of an already existing tag" do
+        event = { "actor" => { "name" => user.username }, "target" => { "digest" => "foo" } }
+        Repository.add_repo(event, registry.global_namespace, repository_name, tag_name)
+        expect(Repository.find_by(name: repository_name).tags.first.digest).to eq("foo")
+
+        event["target"]["digest"] = "bar"
+        Repository.add_repo(event, registry.global_namespace, repository_name, tag_name)
+        expect(Repository.find_by(name: repository_name).tags.first.digest).to eq("bar")
+      end
     end
 
     context "event does not match regexp of manifest" do


### PR DESCRIPTION
If an already existing tag is pushed again, the digest is updated.

Fixes #826

Signed-off-by: Thomas Hipp <thipp@suse.de>