### PR TITLE
lib/tasks: added the `portus:update_ldap_names` task

### DIFF
--- a/lib/tasks/portus.rake
+++ b/lib/tasks/portus.rake
@@ -134,7 +134,8 @@ HERE
 
   # NOTE: this is only available from 2.0.x -> 2.1.x.
   # TODO: (mssola) prevent in the future to execute this if the version of
-  # Portus is higher than 2.1.x.
+  # Portus is higher than 2.1.x. (should be deprecated in 2.2, and removed later
+  # on).
   desc "Update personal namespaces"
   task update_personal_namespaces: :environment do
     ActiveRecord::Base.transaction do
@@ -142,6 +143,49 @@ HERE
         namespace = Namespace.find_by(name: u.username)
         raise "There is no valid personal namespace for #{u.username}!" if namespace.nil?
         u.update_attributes(namespace: namespace)
+      end
+    end
+  end
+
+  # NOTE: this is only available from 2.0.x -> 2.1.x.
+  # TODO: (mssola) prevent in the future to execute this if the version of
+  # Portus is higher than 2.1.x. (should be deprecated in 2.2, and removed later
+  # on).
+  desc "Update LDAP user names"
+  task update_ldap_names: :environment do
+    unless APP_CONFIG.enabled?("ldap")
+      puts "This only applies to LDAP setups..."
+      exit 0
+    end
+
+    unless ActiveRecord::Base.connection.column_exists?(:users, :ldap_name)
+      puts "The User model does not have :ldap_name. Probably an old version..."
+      exit 0
+    end
+
+    puts "Users to be updated:"
+    count = 0
+    User.all.find_each do |u|
+      if !u.ldap_name.blank? && u.ldap_name != u.username
+        puts "- username: #{u.username}\t<=>\tldapname: #{u.ldap_name}"
+        count += 1
+      end
+    end
+
+    if count == 0
+      puts "None. Doing nothing..."
+      exit 0
+    end
+
+    print "Are you sure that you want to proceed with this ? (y/N) "
+    opt = $stdin.gets.strip
+    exit 0 if opt != "y" && opt != "Y" && opt != "yes"
+
+    ActiveRecord::Base.transaction do
+      User.all.find_each do |u|
+        if !u.ldap_name.blank? && u.ldap_name != u.username
+          u.update_attributes!(username: u.ldap_name)
+        end
       end
     end
   end


### PR DESCRIPTION
This task allows administrators to update usernames with their previous LDAP
names.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>