### PR TITLE
hide hidden teams and make them unaccessible

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -14,7 +14,7 @@ class TeamsController < ApplicationController
   # GET /teams/1
   # GET /teams/1.json
   def show
-    raise ActiveRecord::RecordNotFound if @team.name.starts_with?("portus_global_team_")
+    raise ActiveRecord::RecordNotFound if @team.hidden?
 
     authorize @team
     @team_users = @team.team_users.enabled.page(params[:users_page]).per(10)

--- a/app/policies/team_policy.rb
+++ b/app/policies/team_policy.rb
@@ -15,7 +15,10 @@ class TeamPolicy
     user.admin? || @team.owners.exists?(user.id)
   end
 
-  alias_method :update?,    :owner?
+  def update?
+    !@team.hidden? && owner?
+  end
+
   alias_method :show?,      :member?
   alias_method :typeahead?, :owner?
 

--- a/app/views/admin/teams/index.html.slim
+++ b/app/views/admin/teams/index.html.slim
@@ -9,15 +9,13 @@
           col.col-5
           col.col-20
           col.col-20
-          col.col-10
-          col.col-15
-          col.col-15
+          col.col-20
+          col.col-20
         thead
           tr
             th
             th Team
             th Role
-            th Hidden
             th Number of members
             th Number of namespaces
         tbody#teams

--- a/app/views/namespaces/show.html.slim
+++ b/app/views/namespaces/show.html.slim
@@ -65,7 +65,7 @@
           'Namespace:
           strong
             = @namespace.clean_name
-        - unless @namespace.global?
+        - unless @namespace.global? || @namespace.team.hidden?
           .clearfix
             h6.label.label-info#team-label
               | <span>Belongs to: </span>

--- a/app/views/teams/_team.html.slim
+++ b/app/views/teams/_team.html.slim
@@ -2,8 +2,5 @@ tr
   td.table-icon= team_scope_icon(team)
   td= link_to team.name, team
   td= role_within_team(team)
-  - if current_page?(url_for admin_teams_path)
-    td
-      i.fa.fa-lg class="fa-toggle-#{team.hidden? ? 'on': 'off'}"
   td= team.users.enabled.count
   td= team.namespaces.count

--- a/spec/controllers/teams_controller_spec.rb
+++ b/spec/controllers/teams_controller_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe TeamsController, type: :controller do
       expect(response.status).to eq 401
     end
 
-    it "drops requests to a hidden global team" do
+    it "drops requests to a hidden team" do
       sign_in owner
 
       expect { get :show, id: hidden_team.id }.to raise_error(ActiveRecord::RecordNotFound)
@@ -137,6 +137,14 @@ RSpec.describe TeamsController, type: :controller do
       patch :update, id: team.id, team: { name:        "new name",
                                           description: "new description" }, format: "js"
       expect(response.status).to eq(200)
+    end
+
+    it "does not allow a hidden team to be changed" do
+      sign_in owner
+
+      patch :update, id: hidden_team.id, team: { name:        "new name",
+                                                 description: "new description" }, format: "js"
+      expect(response.status).to eq(401)
     end
   end
 


### PR DESCRIPTION
Links to hidden teams are not shown anymore. Furthermore, editing hidden
teams is prohibited by both users and admins.

Fixes #970

Signed-off-by: Thomas Hipp <thipp@suse.de>