### PR TITLE
add option to disable change of visibility

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ inherit_from:
 
 # TODO: (mssola) only the LDAP class and portusctl require this.
 Metrics/ClassLength:
-  Max: 160
+  Max: 162
 
 # TODO: (mssola) Some methods are offending this cop. In the SUSE's style guide
 # the approach is to use Rubocop's default value. In the near future I will

--- a/app/controllers/namespaces_controller.rb
+++ b/app/controllers/namespaces_controller.rb
@@ -84,6 +84,16 @@ class NamespacesController < ApplicationController
     # Update the visibility if needed
     return if params[:visibility] == @namespace.visibility
 
+    # Check whether or not the user may change the visibility of his/her
+    # personal namespace. Admins of course may do whatever they want.
+    if !current_user.admin? && !APP_CONFIG.enabled?("user_change_visibility") && \
+        @namespace == current_user.namespace
+      respond_to do |format|
+        format.js { respond_with nil, status: :unauthorized }
+      end
+      return
+    end
+
     return unless @namespace.update_attributes(visibility: params[:visibility])
     @namespace.create_activity :change_visibility,
       owner:      current_user,

--- a/app/helpers/namespaces_helper.rb
+++ b/app/helpers/namespaces_helper.rb
@@ -3,6 +3,10 @@ module NamespacesHelper
     current_user.admin? || owner?(namespace)
   end
 
+  def can_change_visibility?(namespace)
+    current_user.admin? || (owner?(namespace) && APP_CONFIG.enabled?("user_change_visibility"))
+  end
+
   def owner?(namespace)
     namespace.team.owners.exists?(current_user.id)
   end

--- a/app/views/namespaces/_namespace.html.slim
+++ b/app/views/namespaces/_namespace.html.slim
@@ -12,7 +12,7 @@ tr id="namespace_#{namespace.id}"
         a.btn[
           id="private"
           class=(namespace.visibility_private? ? "btn-primary" : "btn-default")
-          class=("disabled" if !can_manage_namespace?(namespace))
+          class=("disabled" if !can_change_visibility?(namespace))
           title=(!namespace.global? ? "Team members can pull images from this namespace" : "The global namespace cannot be private")
           data-remote="true"
           data-method="put"
@@ -23,7 +23,7 @@ tr id="namespace_#{namespace.id}"
       a.btn[
         id="protected"
         class=(namespace.visibility_protected? ? "btn-primary" : "btn-default")
-        class=("disabled" if !can_manage_namespace?(namespace))
+        class=("disabled" if !can_change_visibility?(namespace))
         title="Logged-in users can pull images from this namespace"
         data-remote="true"
         data-method="put"
@@ -34,7 +34,7 @@ tr id="namespace_#{namespace.id}"
       a.btn[
         id="public"
         class=(namespace.visibility_public? ? "btn-primary" : "btn-default")
-        class=("disabled" if !can_manage_namespace?(namespace))
+        class=("disabled" if !can_change_visibility?(namespace))
         title="Anyone can pull images from this namespace"
         data-remote="true"
         data-method="put"

--- a/config/config.yml
+++ b/config/config.yml
@@ -123,3 +123,8 @@ machine_fqdn:
 # it might confuse users that are not fully aware of it.
 display_name:
   enabled: false
+
+# Allow users to change the visibility or their personal namespace. If this is
+# disabled, only an admin will be able to change this. It defaults to true.
+user_change_visibility:
+  enabled: true

--- a/packaging/suse/portusctl/lib/cli.rb
+++ b/packaging/suse/portusctl/lib/cli.rb
@@ -128,6 +128,11 @@ Looks for the following required certificate files in the specified folder:
     type:    :boolean,
     default: false
 
+  option "user-change-visibility-enable",
+    desc:    "Allow users to change the visibility of their personal namespace",
+    type:    :boolean,
+    default: true
+
   def setup
     ensure_root
     check_setup_flags options


### PR DESCRIPTION
There is a new option 'user_change_visibility' which allows users to
change the visibility of their personal namespace. If this is option is
disabled, only admins can perform this change. This option is enabled by
default and therefore doesn't change the current behavior.

This commit is part of issue #676.

Signed-off-by: Thomas Hipp <thipp@suse.de>