### PR TITLE
use `enabled?` for nested options

### DIFF
--- a/lib/portus/config.rb
+++ b/lib/portus/config.rb
@@ -39,13 +39,20 @@ module Portus
     # Add the `enabled?` method to the given object. The `enabled?` method is
     # a convenient method that checks whether a specific feature is enabled or
     # not. This method takes advantage of the convention that each feature has
-    # the "enabled" key inside of it. If this key exists in the checked
-    # feature, and it's set to true, then this method will return true. It
-    # returns false otherwise.
+    # the "enabled" key inside of it. This also works for nested options by
+    # separating the nodes with a period, e.g. `enabled?("foo.bar")`. If this
+    # key exists in the checked feature, and it's set to true, then this method
+    # will return true. It returns false otherwise.
     def add_enabled(obj)
       obj.define_singleton_method(:enabled?) do |feature|
-        return false if !self[feature] || self[feature].empty?
-        self[feature]["enabled"].eql?(true)
+        objs = feature.split(".")
+        if objs.length == 2
+          return false if !self[objs[0]][objs[1]] || self[objs[0]][objs[1]].empty?
+          self[objs[0]][objs[1]]["enabled"].eql?(true)
+        else
+          return false if !self[feature] || self[feature].empty?
+          self[feature]["enabled"].eql?(true)
+        end
       end
       obj
     end

--- a/spec/fixtures/config.yml
+++ b/spec/fixtures/config.yml
@@ -10,3 +10,7 @@ ldap:
     enabled: false
     bind_dn: ""
     password: "mypassword"
+
+email:
+  smtp:
+    enabled: true

--- a/spec/lib/portus/config_spec.rb
+++ b/spec/lib/portus/config_spec.rb
@@ -88,4 +88,9 @@ describe Portus::Config do
     fetched["ldap"]["authentication"]["password"] = "****"
     expect(fetched).to eq(evaled)
   end
+
+  it "works for nested options" do
+    cfg = get_config("config.yml", "").fetch
+    expect(cfg.enabled?("email.smtp")).to be true
+  end
 end


### PR DESCRIPTION
Allow the use of `enabled?` for nested options in the config file. Nodes
are separated with a period and only work for up to 2 nodes at the
moment.

Example:
`APP_CONFIG.enabled?("foo.bar")` instead of
`APP_CONFIG["foo"]["bar"]["enabled"].eql?(true)`

Signed-off-by: Thomas Hipp <thipp@suse.de>