### PR TITLE
Portus admins are always team owners

### DIFF
--- a/app/views/team_users/create.js.erb
+++ b/app/views/team_users/create.js.erb
@@ -2,7 +2,11 @@
   $('#float-alert p').html("<%= escape_javascript(@team_user.errors.full_messages.join('<br/>')) %>");
 <% else %>
   $("<%= escape_javascript(render @team_user) %>").appendTo("#team_users");
-  $('#float-alert p').html("New user added to the team");
+  <% if @promoted_role %>
+    $('#float-alert p').html("New user added to the team (promoted to owner because it is a Portus admin).");
+  <% else %>
+    $('#float-alert p').html("New user added to the team");
+  <% end %>
   $('#add_team_user_form').fadeOut();
   $('#add_team_user_btn i').addClass("fa-chevron-down")
   $('#add_team_user_btn i').removeClass("fa-chevron-up")

--- a/spec/features/teams_spec.rb
+++ b/spec/features/teams_spec.rb
@@ -104,6 +104,7 @@ feature "Teams support" do
 
   describe "teams#show" do
     let!(:another) { create(:user) }
+    let!(:another_admin) { create(:admin) }
 
     before :each do
       visit team_path(team)
@@ -141,6 +142,20 @@ feature "Teams support" do
 
       expect(page).to have_content("New user added to the team")
       expect(page).to have_content("Contributor")
+    end
+
+    scenario "An admin can only be added as a team owner", js: true do
+      find("#add_team_user_btn").click
+      wait_for_effect_on("#add_team_user_form")
+      find("#team_user_role").select "Contributor"
+      find("#team_user_user").set another_admin.username
+      find("#add_team_user_form .btn").click
+
+      wait_for_ajax
+      wait_for_effect_on("#float-alert")
+
+      expect(page).to have_content("New user added to the team (promoted to")
+      expect(page).to have_content("Owner")
     end
 
     scenario "New team members have to exist on the system", js: true do


### PR DESCRIPTION
This commit forces that whenever a Portus admin gets added into a team, it will
have owner privileges. Moreover, this commit also forbids demoting a Portus
admin from being an owner.

Fixes #977

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>