### PR TITLE
rubocop: disable the Lint/UnneededDisable cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,6 +22,13 @@ Style/ClassAndModuleChildren:
 Style/Documentation:
   Enabled: false
 
+# NOTE: (mssola) In versions of Ruby higher than 2.1.x, we get
+# Lint/ShadowedException in some cases where in 2.1.x it complains if we remove
+# such guards. Therefore, we have to disable this cop until we update the
+# version of Ruby to be officially supported.
+Lint/UnneededDisable:
+  Enabled: false
+
 Rails:
   Enabled: true
 


### PR DESCRIPTION
As I've realized in Travis CI, there are some inconsistencies on the
Lint/ShadowedException cop across Ruby versions. Because of this, we have to
disable the Lint/UnneededDisable cop.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>