### PR TITLE
Fix anchor on documentation page

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -18,7 +18,7 @@
     {% include header.html %}
     <div class="container" id="documentation">
       <div class="row">
-        <div class="col-md-9 col-md-offset-3 col-sm-12 col-xs-12">
+        <div class="post-content col-md-9 col-md-offset-3 col-sm-12 col-xs-12">
           <section>
             <div class="row">
               {% include mobile-topics.html %}


### PR DESCRIPTION
In my previous PR I unintentionally removed the anchor links from documentation page, they are back!