### PR TITLE
namespace: convert to downcase first on make_valid

### DIFF
--- a/app/models/namespace.rb
+++ b/app/models/namespace.rb
@@ -96,7 +96,12 @@ class Namespace < ActiveRecord::Base
   def self.make_valid(name)
     return name if name =~ NAME_REGEXP
 
-    # First of all we strip extra characters from the beginning and end.
+    # One common case is LDAP and case sensitivity. With this in mind, try to
+    # downcase everything and see if now it's fine.
+    name = name.downcase
+    return name if name =~ NAME_REGEXP
+
+    # Let's strip extra characters from the beginning and end.
     first = name.index(/[a-z0-9]/)
     return nil if first.nil?
     last = name.rindex(/[a-z0-9]/)

--- a/spec/models/namespace_spec.rb
+++ b/spec/models/namespace_spec.rb
@@ -180,6 +180,10 @@ describe Namespace do
       expect(Namespace.make_valid("ma_s")).to eq "ma_s"
       expect(Namespace.make_valid("!lol!")).to eq "lol"
       expect(Namespace.make_valid("!lol!name")).to eq "lol_name"
+      expect(Namespace.make_valid("Miquel.Sabate")).to eq "miquel.sabate"
+      expect(Namespace.make_valid("Miquel.Sabate.")).to eq "miquel.sabate"
+      expect(Namespace.make_valid("M")).to eq "m"
+      expect(Namespace.make_valid("_M_")).to eq "m"
     end
   end
 end


### PR DESCRIPTION
One usual pain point that can be solved in `make_valid` is that lots of times
the problem is with the case. Since upper case is not accepted in namespace
names, then it will be converted weirdly. Because of this, from now on the
first thing that `make_valid` will do if the name doesn't match right away, is
to convert the name to downcase. With this commit then, something like `Miquel`
will be converted to `miquel`, instead of `_iquel`, which makes more sense.

See #965

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>