### PR TITLE
Deprecated the usage of "x.minutes" strings in configuration values

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,6 +41,5 @@ AllCops:
     - bin/*
     - vendor/**/*
     - tmp/**/*
-    - config/cronotab.rb
     - config/initializers/*
     - config/environments/*

--- a/config/config.yml
+++ b/config/config.yml
@@ -105,14 +105,16 @@ signup:
 check_ssl_usage:
   enabled: true
 
-# Set the expiration time for the JWT Token that Portus uses to authenticate
-# with the registry. Note that this is just a work-around on the fact that the
-# registry does not try to get a new token again after the current one has
-# expired. Once a solution is issued upstream, we can deprecate this option.
+# Set the expiration time in minutes for the JWT Token that Portus uses to
+# authenticate with the registry.
+#
+# Note that this is just a work-around on the fact that the registry does not
+# try to get a new token again after the current one has expired. Once a
+# solution is issued upstream, we can deprecate this option.
 #
 # See: https://github.com/SUSE/Portus/issues/510
 jwt_expiration_time:
-  value: "5.minutes"
+  value: 5
 
 # The FQDN of the machine where Portus is being deployed.
 machine_fqdn:

--- a/config/cronotab.rb
+++ b/config/cronotab.rb
@@ -1,2 +1,5 @@
-env = ENV["CATALOG_CRON"] || "10.minutes"
-Crono.perform(CatalogJob).every eval(env)
+require "portus/migrate"
+
+env = ENV["CATALOG_CRON"] || 10
+value = Portus::Migrate.from_humanized_time(env, 10)
+Crono.perform(CatalogJob).every value

--- a/lib/portus/jwt_token.rb
+++ b/lib/portus/jwt_token.rb
@@ -1,3 +1,5 @@
+require "portus/migrate"
+
 module Portus
   # This class implements the JSON Web Token as expected by the registry. Read
   # the `spec` for more information:
@@ -64,9 +66,7 @@ module Portus
 
     # The expiration time to be added to the current token.
     def expiration_time
-      # rubocop:disable Lint/Eval
-      eval(APP_CONFIG["jwt_expiration_time"]["value"])
-      # rubocop:enable Lint/Eval
+      Portus::Migrate.from_humanized_time(APP_CONFIG["jwt_expiration_time"]["value"], 5)
     end
 
     # Returns an array with the authorized actions hash.

--- a/lib/portus/migrate.rb
+++ b/lib/portus/migrate.rb
@@ -1,0 +1,42 @@
+module Portus
+  # The Portus::Migrate module implements some methods that are used to handle a
+  # change from different versions of Portus where there is an old (and
+  # deprecated) way of doing things and a preferred new one.
+  module Migrate
+    # This method has to be used when migrating from an 'x.minutes' string
+    # configuration value (e.g. the `jwt_expiration_time` value).
+    #
+    # The duration parameter is the given original value, and the default
+    # parameter is an Integer with the value to be used whenever there is
+    # an error. Otherwise, if the given duration is not an integer and has
+    # a good (old) string format, then eval will be used just as we did
+    # it before.
+    #
+    # TODO: (mssola) remove in the next version.
+    def self.from_humanized_time(duration, default)
+      return duration.send(:minutes) if duration.is_a? Integer
+
+      # If it's not a String then just return the given default value.
+      return default.send(:minutes) unless duration.is_a? String
+
+      # If it's a string containing just a number, then convert it and return
+      # it. Otherwise, if it has a bad (old) format, then just return the default.
+      splitted = duration.split(".")
+      if splitted.size == 1
+        val = splitted.first.to_i
+        return val.send(:minutes) unless val == 0
+      end
+      return default.send(:minutes) if splitted.size != 2
+
+      Rails.logger.tagged("deprecated") do
+        Rails.logger.warn "The 'x.minutes' format is deprecated for configuration values such " \
+                          "as `jwt_expiration_time`. From now on these values are expected to " \
+                          "be integers representing minutes."
+      end
+
+      # rubocop:disable Lint/Eval
+      eval(duration)
+      # rubocop:enable Lint/Eval
+    end
+  end
+end

--- a/spec/lib/portus/migrate_spec.rb
+++ b/spec/lib/portus/migrate_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+describe Portus::Migrate do
+  describe "from_humanized_time" do
+    it "evaluates as minutes if it's an integer" do
+      val = Portus::Migrate.from_humanized_time(3, 2)
+      expect(val).to eq 3.minutes
+    end
+
+    it "returns as minutes if it's a string of an integer" do
+      val = Portus::Migrate.from_humanized_time("3", 2)
+      expect(val).to eq 3.minutes
+    end
+
+    it "returns the default on error" do
+      val = Portus::Migrate.from_humanized_time(/asd/, 2)
+      expect(val).to eq 2.minutes
+      val = Portus::Migrate.from_humanized_time("badformat", 2)
+      expect(val).to eq 2.minutes
+    end
+
+    it "evals the given expression if it comes with a similar format than the old one" do
+      val = Portus::Migrate.from_humanized_time("3.minutes", 2)
+      expect(val).to eq 3.minutes
+      val = Portus::Migrate.from_humanized_time("3.seconds", 2)
+      expect(val).to eq 3.seconds
+    end
+  end
+end


### PR DESCRIPTION
An integer should be provided instead. This is better than just taking a
string from the user an calling eval on it. I've added a module that implements
a compatibility layer so this change won't break current setups. That being
said, administrators will get a warning about its deprecation.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>