### PR TITLE
Added the registry.catalog_page option

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ inherit_from:
 
 # TODO: (mssola) only the LDAP class and portusctl require this.
 Metrics/ClassLength:
-  Max: 162
+  Max: 180
 
 # TODO: (mssola) Some methods are offending this cop. In the SUSE's style guide
 # the approach is to use Rubocop's default value. In the near future I will

--- a/config/config.yml
+++ b/config/config.yml
@@ -105,16 +105,26 @@ signup:
 check_ssl_usage:
   enabled: true
 
-# Set the expiration time in minutes for the JWT Token that Portus uses to
-# authenticate with the registry.
-#
-# Note that this is just a work-around on the fact that the registry does not
-# try to get a new token again after the current one has expired. Once a
-# solution is issued upstream, we can deprecate this option.
-#
-# See: https://github.com/SUSE/Portus/issues/510
-jwt_expiration_time:
-  value: 5
+# Contains advanced options that tweak how Portus interacts with the
+# Registry. Don't touch any of these values unless you *really* know what you
+# are doing.
+registry:
+  # Set the expiration time in minutes for the JWT Token that Portus uses to
+  # authenticate with the registry.
+  #
+  # Note that this is just a work-around on the fact that the registry does not
+  # try to get a new token again after the current one has expired. Once a
+  # solution is issued upstream, we can deprecate this option.
+  #
+  # See: https://github.com/SUSE/Portus/issues/510
+  jwt_expiration_time:
+    value: 5
+
+  # Set the pagination value for API calls that fetch data from the
+  # registry. You can read more about pagination in the registry here:
+  #   https://github.com/docker/distribution/blob/master/docs/spec/api.md#pagination
+  catalog_page:
+    value: 100
 
 # The FQDN of the machine where Portus is being deployed.
 machine_fqdn:

--- a/lib/portus/jwt_token.rb
+++ b/lib/portus/jwt_token.rb
@@ -66,7 +66,8 @@ module Portus
 
     # The expiration time to be added to the current token.
     def expiration_time
-      Portus::Migrate.from_humanized_time(APP_CONFIG["jwt_expiration_time"]["value"], 5)
+      value = Portus::Migrate.registry_config("jwt_expiration_time")
+      Portus::Migrate.from_humanized_time(value, 5)
     end
 
     # Returns an array with the authorized actions hash.

--- a/lib/portus/migrate.rb
+++ b/lib/portus/migrate.rb
@@ -38,5 +38,20 @@ module Portus
       eval(duration)
       # rubocop:enable Lint/Eval
     end
+
+    # Provides a compatibility layer for Portus 2.1 for users that haven't
+    # migrated yet from `jwt_expiration_time` to `registry.jwt_expiration_time`.
+    #
+    # TODO: (mssola) remove in the next version.
+    def self.registry_config(key)
+      return APP_CONFIG["registry"][key]["value"] if APP_CONFIG["registry"]
+
+      Rails.logger.tagged("deprecated") do
+        Rails.logger.warn "The usage of '#{key}' is deprecated and it's now under the 'registry' "\
+                          "configuration section."
+      end
+
+      APP_CONFIG[key]["value"]
+    end
   end
 end

--- a/lib/portus/registry_client.rb
+++ b/lib/portus/registry_client.rb
@@ -94,7 +94,7 @@ module Portus
     # wrong, it raises an exception.
     def paged_response(link, field)
       res = []
-      link += "?n=100"
+      link += "?n=#{APP_CONFIG["registry"]["catalog_page"]["value"]}"
 
       until link.empty?
         page, link = get_page(link)

--- a/packaging/suse/portusctl/lib/cli.rb
+++ b/packaging/suse/portusctl/lib/cli.rb
@@ -109,7 +109,12 @@ Looks for the following required certificate files in the specified folder:
   # JWT EXPIRATION TIME
   option "jwt-expiration-time",
     desc:    "Expiration time for the JWT token used by Portus",
-    default: "5.minutes"
+    default: 5
+
+  # Catalog pagination
+  option "catalog-page",
+    desc:    "Pagination value for API calls to the registry",
+    default: 100
 
   # FIRST USER
   option "first-user-admin-enable",

--- a/packaging/suse/portusctl/spec/options_spec.rb
+++ b/packaging/suse/portusctl/spec/options_spec.rb
@@ -6,7 +6,8 @@ def format_key(key)
   key.tr("_", "-")
      .gsub("enabled", "enable")
      .gsub("user-name", "username")
-     .gsub(/^jwt-expiration-time-value$/, "jwt-expiration-time")
+     .gsub(/^registry-jwt-expiration-time-value$/, "jwt-expiration-time")
+     .gsub(/^registry-catalog-page-value$/, "catalog-page")
      .gsub(/^check-ssl-usage-enable$/, "secure")
 end
 

--- a/packaging/suse/portusctl/templates/config-local.yml.erb
+++ b/packaging/suse/portusctl/templates/config-local.yml.erb
@@ -114,14 +114,26 @@ signup:
 check_ssl_usage:
   enabled: <%= @options["secure"] %>
 
-# Set the expiration time for the JWT Token that Portus uses to authenticate
-# with the registry. Note that this is just a work-around on the fact that the
-# registry does not try to get a new token again after the current one has
-# expired. Once a solution is issued upstream, we can deprecate this option.
-#
-# See: https://github.com/SUSE/Portus/issues/510
-jwt_expiration_time:
-  value: <%= @options["jwt-expiration-time"] %>
+# Contains advanced options that tweak how Portus interacts with the
+# Registry. Don't touch any of these values unless you *really* know what you
+# are doing.
+registry:
+  # Set the expiration time in minutes for the JWT Token that Portus uses to
+  # authenticate with the registry.
+  #
+  # Note that this is just a work-around on the fact that the registry does not
+  # try to get a new token again after the current one has expired. Once a
+  # solution is issued upstream, we can deprecate this option.
+  #
+  # See: https://github.com/SUSE/Portus/issues/510
+  jwt_expiration_time:
+    value: <%= @options["jwt-expiration-time"] %>
+
+  # Set the pagination value for API calls that fetch data from the
+  # registry. You can read more about pagination in the registry here:
+  #   https://github.com/docker/distribution/blob/master/docs/spec/api.md#pagination
+  catalog_page:
+    value: <%= @options["catalog-page"] %>
 
 # The FQDN of the machine where Portus is being deployed.
 machine_fqdn:

--- a/spec/lib/portus/jwt_token_spec.rb
+++ b/spec/lib/portus/jwt_token_spec.rb
@@ -74,7 +74,7 @@ describe Portus::JwtToken do
 
       describe ":exp" do
         it "is set to #expires_at" do
-          APP_CONFIG["jwt_expiration_time"] = { "value" => "6.minutes" }
+          APP_CONFIG["registry"]["jwt_expiration_time"] = { "value" => "6.minutes" }
 
           now = Time.zone.now
           expected = now + 6.minutes

--- a/spec/lib/portus/migrate_spec.rb
+++ b/spec/lib/portus/migrate_spec.rb
@@ -26,4 +26,24 @@ describe Portus::Migrate do
       expect(val).to eq 3.seconds
     end
   end
+
+  describe "registry_config" do
+    before :each do
+      @registry = APP_CONFIG["registry"]
+    end
+
+    after :each do
+      APP_CONFIG["registry"] = @registry
+      APP_CONFIG["jwt_expiration_time"] = nil
+    end
+
+    it "returns a value depending of the format" do
+      expect(Portus::Migrate.registry_config("jwt_expiration_time")).to_not be_nil
+
+      APP_CONFIG["registry"] = nil
+      APP_CONFIG["jwt_expiration_time"] = { "value" => 5 }
+
+      expect(Portus::Migrate.registry_config("jwt_expiration_time")).to eq 5
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,3 @@
-
 require "codeclimate-test-reporter"
 CodeClimate::TestReporter.start
 
@@ -46,7 +45,10 @@ RSpec.configure do |config|
 
     # This value is expected to be always available. The default value will be
     # set
-    APP_CONFIG["jwt_expiration_time"] = { "value" => "5.minutes" }
+    APP_CONFIG["registry"] = {
+      "jwt_expiration_time" => { "value" => 5   },
+      "catalog_page"        => { "value" => 100 }
+    }
   end
 
   config.order = :random


### PR DESCRIPTION
With this option we will be able to workaround docker/distribution#1854.
Moreover, with this we will allow administrators to further tweak how Portus
interacts with the registry.

Moreover, because of this new addition, I felt like groupping registry-related
configurable options would be a good idea, so now all these options are under
the new `registry` section. We are still providing a compatibility layer in the
Portus::Migrate module.

Fixes #1001

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>