### PR TITLE
introduce more optional user restrictions

### DIFF
--- a/app/controllers/namespaces_controller.rb
+++ b/app/controllers/namespaces_controller.rb
@@ -87,16 +87,6 @@ class NamespacesController < ApplicationController
     # Update the visibility if needed
     return if params[:visibility] == @namespace.visibility
 
-    # Check whether or not the user may change the visibility of his/her
-    # personal namespace. Admins of course may do whatever they want.
-    if !current_user.admin? && !APP_CONFIG.enabled?("user_change_visibility") && \
-        @namespace == current_user.namespace
-      respond_to do |format|
-        format.js { respond_with nil, status: :unauthorized }
-      end
-      return
-    end
-
     return unless @namespace.update_attributes(visibility: params[:visibility])
     @namespace.create_activity :change_visibility,
       owner:      current_user,

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -24,7 +24,8 @@ class TeamsController < ApplicationController
   # POST /teams
   # POST /teams.json
   def create
-    @team = Team.new(team_params)
+    @team = fetch_team
+    authorize @team
     @team.owners << current_user
 
     if @team.save
@@ -65,11 +66,16 @@ class TeamsController < ApplicationController
 
   private
 
-  def set_team
-    @team = Team.find(params[:id])
+  # Fetch the team to be created from the given parameters.
+  def fetch_team
+    team = params.require(:team).permit(:name, :description)
+
+    @team = Team.new(name: team["name"])
+    @team.description = team["description"] if team["description"]
+    @team
   end
 
-  def team_params
-    params.require(:team).permit(:name, :description)
+  def set_team
+    @team = Team.find(params[:id])
   end
 end

--- a/app/helpers/namespaces_helper.rb
+++ b/app/helpers/namespaces_helper.rb
@@ -1,10 +1,16 @@
 module NamespacesHelper
   def can_manage_namespace?(namespace)
-    current_user.admin? || owner?(namespace)
+    current_user.admin? || (owner?(namespace) &&
+                            APP_CONFIG.enabled?("user_permission.manage_namespace"))
+  end
+
+  def can_create_namespace?
+    current_user.admin? || APP_CONFIG.enabled?("user_permission.manage_namespace")
   end
 
   def can_change_visibility?(namespace)
-    current_user.admin? || (owner?(namespace) && APP_CONFIG.enabled?("user_change_visibility"))
+    current_user.admin? || (owner?(namespace) &&
+                            APP_CONFIG.enabled?("user_permission.change_visibility"))
   end
 
   def owner?(namespace)

--- a/app/helpers/teams_helper.rb
+++ b/app/helpers/teams_helper.rb
@@ -1,6 +1,11 @@
 module TeamsHelper
   def can_manage_team?(team)
-    current_user.admin? || team.owners.exists?(current_user.id)
+    current_user.admin? || (team.owners.exists?(current_user.id) &&
+                            APP_CONFIG.enabled?("user_permission.manage_team"))
+  end
+
+  def can_create_team?
+    current_user.admin? || APP_CONFIG.enabled?("user_permission.manage_team")
   end
 
   def role_within_team(team)

--- a/app/policies/team_policy.rb
+++ b/app/policies/team_policy.rb
@@ -15,8 +15,12 @@ class TeamPolicy
     user.admin? || @team.owners.exists?(user.id)
   end
 
+  def create?
+    APP_CONFIG.enabled?("user_permission.manage_team") || user.admin?
+  end
+
   def update?
-    !@team.hidden? && owner?
+    create? && !@team.hidden? && owner?
   end
 
   alias show? member?

--- a/app/views/namespaces/index.html.slim
+++ b/app/views/namespaces/index.html.slim
@@ -58,7 +58,7 @@
         h5
           ' Namespaces you have access to
       .col-sm-6.text-right
-        - if Registry.any?
+        - if Registry.any? && can_create_namespace?
           a#add_namespace_btn.btn.btn-xs.btn-link.js-toggle-button[role="button"]
             i.fa.fa-plus-circle
             | Create new namespace

--- a/app/views/teams/index.html.slim
+++ b/app/views/teams/index.html.slim
@@ -19,9 +19,10 @@
         h5
           ' Teams you are member of
       .col-sm-6.text-right
-        a#add_team_btn.btn.btn-xs.btn-link.js-toggle-button[role="button"]
-          i.fa.fa-plus-circle
-          | Create new team
+        - if can_create_team?
+          a#add_team_btn.btn.btn-xs.btn-link.js-toggle-button[role="button"]
+            i.fa.fa-plus-circle
+            | Create new team
 
   .panel-body
     .table-responsive

--- a/app/views/teams/show.html.slim
+++ b/app/views/teams/show.html.slim
@@ -1,31 +1,32 @@
 .panel-group
-  .collapse id="update_team_#{@team.id}"
-    = form_for @team, remote: true, html: {role: 'form'} do |f|
-      .panel.panel-default
-        .panel-heading
-          .input-group
-            = f.text_field(:name,
-                           class: 'form-control',
-                           placeholder: html_escape(@team.name),
-                           required: true,
-                           input_html: { tabindex: 1 })
-            .input-group-btn
-              button.btn.btn-link.btn-xs.btn-edit-role[
-                value="#{@team.id}"
-                type="button"
-                class="button_edit_team"]
-                i.fa.fa-close
-                | Edit team
-        .panel-body
-          = f.text_area(:description,
-                        class: 'form-control',
-                        placeholder: html_escape(@team.description),
-                        input_html: { tabindex: 2 })
-          br
-          = button_tag(type: 'submit', class: 'btn btn-primary pull-right') do
-            i.fa.fa-check
-            | Save
-        .panel-footer
+  - if can_manage_team?(@team)
+    .collapse id="update_team_#{@team.id}"
+      = form_for @team, remote: true, html: {role: 'form'} do |f|
+        .panel.panel-default
+          .panel-heading
+            .input-group
+              = f.text_field(:name,
+                             class: 'form-control',
+                             placeholder: html_escape(@team.name),
+                             required: true,
+                             input_html: { tabindex: 1 })
+              .input-group-btn
+                button.btn.btn-link.btn-xs.btn-edit-role[
+                  value="#{@team.id}"
+                  type="button"
+                  class="button_edit_team"]
+                  i.fa.fa-close
+                  | Edit team
+          .panel-body
+            = f.text_area(:description,
+                          class: 'form-control',
+                          placeholder: html_escape(@team.description),
+                          input_html: { tabindex: 2 })
+            br
+            = button_tag(type: 'submit', class: 'btn btn-primary pull-right') do
+              i.fa.fa-check
+              | Save
+          .panel-footer
   .panel.panel-default.team_information
     .panel-heading
       .row

--- a/config/config.yml
+++ b/config/config.yml
@@ -136,7 +136,18 @@ machine_fqdn:
 display_name:
   enabled: false
 
-# Allow users to change the visibility or their personal namespace. If this is
-# disabled, only an admin will be able to change this. It defaults to true.
-user_change_visibility:
-  enabled: true
+user_permission:
+  # Allow users to change the visibility or their personal namespace. If this is
+  # disabled, only an admin will be able to change this. It defaults to true.
+  change_visibility:
+    enabled: true
+
+  # Allow users to create/modify teams if they are an owner of it. If this is
+  # disabled only an admin will be able to do this. This defaults to true.
+  manage_team:
+    enabled: true
+
+  # Allow users to create/modify namespaces if they are an owner of it. If this
+  # is disabled, only an admin will be able to do this. This defaults to true.
+  manage_namespace:
+    enabled: true

--- a/packaging/suse/portusctl/lib/cli.rb
+++ b/packaging/suse/portusctl/lib/cli.rb
@@ -133,8 +133,18 @@ Looks for the following required certificate files in the specified folder:
     type:    :boolean,
     default: false
 
-  option "user-change-visibility-enable",
-    desc:    "Allow users to change the visibility of their personal namespace",
+  option "change-visibility-enable",
+    desc:    "Allow users to change the visibility of their namespaces",
+    type:    :boolean,
+    default: true
+
+  option "manage-namespace-enable",
+    desc:    "Allow users to modify their namespaces",
+    type:    :boolean,
+    default: true
+
+  option "manage-team-enable",
+    desc:    "Allow users to modify their teams",
     type:    :boolean,
     default: true
 

--- a/packaging/suse/portusctl/spec/options_spec.rb
+++ b/packaging/suse/portusctl/spec/options_spec.rb
@@ -9,6 +9,9 @@ def format_key(key)
      .gsub(/^registry-jwt-expiration-time-value$/, "jwt-expiration-time")
      .gsub(/^registry-catalog-page-value$/, "catalog-page")
      .gsub(/^check-ssl-usage-enable$/, "secure")
+     .gsub(/^user-permission-change-visibility-enable$/, "change-visibility-enable")
+     .gsub(/^user-permission-manage-namespace-enable$/, "manage-namespace-enable")
+     .gsub(/^user-permission-manage-team-enable$/, "manage-team-enable")
 end
 
 # Get the keys as given by the config.yml file.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -49,6 +49,15 @@ RSpec.configure do |config|
       "jwt_expiration_time" => { "value" => 5   },
       "catalog_page"        => { "value" => 100 }
     }
+
+    APP_CONFIG["user_permission"] = {
+      # This allows non-admins to change the visibility of their personal namespace
+      "change_visibility" => { "enabled" => true },
+      # This allows non-admins to modify namespaces
+      "manage_namespace"  => { "enabled" => true },
+      # This allows non-admins to modify teams
+      "manage_team"       => { "enabled" => true }
+    }
   end
 
   config.order = :random


### PR DESCRIPTION
Options regarding user permissions can be found under the
`user_permission` node in the config file.

The three options are:

* **change_visibility**
permits the user to change the visibility of namespaces he/she owns
* **modify_team**
permits the user to change team attributes, e.g. name or description,
given that he/she is an owners
* **modify_namespace**
permits the user to change namespace attributes, e.g. name, team, or
description, given that he/she is an owners

Note that the previous user restriction regarding namespace visibility
only applied to a user's personal namespace. This has been extended to
all namespaces the user owns.

Resolves #676

Signed-off-by: Thomas Hipp <thipp@suse.de>