### PR TITLE
Added help section to menu

### DIFF
--- a/app/views/shared/_aside.html.slim
+++ b/app/views/shared/_aside.html.slim
@@ -25,3 +25,7 @@ aside
           | Admin
         - if current_page?(url_for controller: 'admin/dashboard', action: 'index')
           .list-selected
+    li.active
+      a[href="http://port.us.org/documentation" target="_blank"]
+        i[class="fa fa-life-ring"]
+        | Help


### PR DESCRIPTION
Closes #289 

Just added a link to Portus documentation on side menu:

![1469496157936screensave](https://cloud.githubusercontent.com/assets/2891076/17123292/e7f11dfc-52b8-11e6-8430-cb564c598311.png)


Signed-off-by: Matheus Fernandes <matheus.souza.fernandes@gmail.com>