### PR TITLE
show protected namespaces to all logged-in users

### DIFF
--- a/app/policies/namespace_policy.rb
+++ b/app/policies/namespace_policy.rb
@@ -73,9 +73,11 @@ class NamespacePolicy
       scope
         .joins(team: [:team_users])
         .where(
-          "(namespaces.visibility = :visibility OR team_users.user_id = :user_id) AND " \
+          "(namespaces.visibility = :public OR namespaces.visibility = :protected " \
+          "OR team_users.user_id = :user_id) AND " \
           "namespaces.global = :global AND namespaces.name != :username",
-          visibility: Namespace.visibilities[:visibility_public],
+          public: Namespace.visibilities[:visibility_public],
+          protected: Namespace.visibilities[:visibility_protected],
           user_id: user.id, global: false, username: user.username
         )
         .distinct

--- a/spec/policies/namespace_policy_spec.rb
+++ b/spec/policies/namespace_policy_spec.rb
@@ -214,5 +214,12 @@ describe NamespacePolicy do
       expected.first.update_attributes(visibility: :visibility_public)
       expect(Pundit.policy_scope(viewer, Namespace).to_a).to match_array(expected)
     end
+
+    it "shows protected namespaces" do
+      user = create(:user)
+      n = create(:namespace, visibility: :visibility_protected)
+      create(:team, namespaces: [n], owners: [owner])
+      expect(Pundit.policy_scope(user, Namespace)).to match_array([n])
+    end
   end
 end


### PR DESCRIPTION
All logged-in users are able to see protected namespaces regardless of
whether or not they are part of the namespace's team.

Fixes #1013

Signed-off-by: Thomas Hipp <thipp@suse.de>