### PR TITLE
Add a parameter for an external hostname field

### DIFF
--- a/app/controllers/admin/registries_controller.rb
+++ b/app/controllers/admin/registries_controller.rb
@@ -30,7 +30,8 @@ class Admin::RegistriesController < Admin::BaseController
       unless msg.empty?
         logger.info "\nRegistry not reachable:\n#{@registry.inspect}\n#{msg}\n"
         msg = "#{msg} You can skip this check by clicking on the \"Skip remote checks\" checkbox."
-        hsh = { name: @registry.name, hostname: @registry.hostname, use_ssl: @registry.use_ssl }
+        hsh = { name: @registry.name, hostname: @registry.hostname,
+          use_ssl: @registry.use_ssl, external_hostname: @registry.external_hostname }
         redirect_to new_admin_registry_path(hsh), alert: msg
         return
       end
@@ -73,13 +74,13 @@ class Admin::RegistriesController < Admin::BaseController
 
   # The required/permitted parameters on the create method.
   def create_params
-    params.require(:registry).permit(:name, :hostname, :use_ssl)
+    params.require(:registry).permit(:name, :hostname, :use_ssl, :external_hostname)
   end
 
   # The required/permitted parameters on update. The hostname parameter will be
   # allowed depending whether there are repositories already created or not.
   def update_params
-    permitted = [:name, :use_ssl, (:hostname unless Repository.any?)].compact
+    permitted = [:name, :use_ssl, (:hostname unless Repository.any?), :external_hostname].compact
     params.require(:registry).permit(permitted)
   end
 end

--- a/app/models/registry.rb
+++ b/app/models/registry.rb
@@ -2,12 +2,13 @@
 #
 # Table name: registries
 #
-#  id         :integer          not null, primary key
-#  name       :string(255)      not null
-#  hostname   :string(255)      not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  use_ssl    :boolean
+#  id                :integer          not null, primary key
+#  name              :string(255)      not null
+#  hostname          :string(255)      not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  use_ssl           :boolean
+#  external_hostname :string(255)
 #
 # Indexes
 #
@@ -25,6 +26,7 @@ class Registry < ActiveRecord::Base
 
   validates :name, presence: true, uniqueness: true
   validates :hostname, presence: true, uniqueness: true
+  validates :external_hostname, presence: false
   validates :use_ssl, inclusion: [true, false]
 
   # On create, make sure that all the needed namespaces are in place.
@@ -51,10 +53,14 @@ class Registry < ActiveRecord::Base
 
   # Find the registry for the given push event.
   def self.find_from_event(event)
-    registry = Registry.find_by(hostname: event["request"]["host"])
+    request_hostname = event["request"]["host"]
+    registry = Registry.find_by(hostname: request_hostname)
     if registry.nil?
-      logger.info("Ignoring event coming from unknown registry
-                  #{event["request"]["host"]}")
+      logger.debug("No hostname matching #{request_hostname}, testing external_hostname")
+      registry = Registry.find_by(external_hostname: request_hostname)
+    end
+    if registry.nil?
+      logger.info("Ignoring event coming from unknown registry #{request_hostname}")
     end
     registry
   end

--- a/app/views/admin/registries/edit.html.slim
+++ b/app/views/admin/registries/edit.html.slim
@@ -19,6 +19,32 @@
         = f.label :use_ssl, "Use SSL", {class: 'control-label col-md-2', title: 'Set this to enable SSL in the communication between Portus and the Registry', checked: @registry.use_ssl?}
         .col-md-7
           = f.check_box(:use_ssl)
+      div.collapse#advanced
+        .form-group
+          = f.label :external_hostname, "External Registry Name", {class:'control-label col-md-2', title: 'Set this if the name that clients use to communicate with the registry is different than the name that Portus uses to connect'}
+          .col-md-7
+            - if params[:external_hostname]
+              = f.text_field(:external_hostname, class: 'form-control', value: params[:external_hostname], placeholder: '(Optional)', required: false)
+            - else
+              = f.text_field(:external_hostname, class: 'form-control', placeholder: '(Optional)', required: false)
+            span.help-block
+              | Portus uses the hostname field to communicate with the registry,
+                but this may be on an internal network and inaccessible to the
+                client.
+                Clients may connect to the registry by a name different to the
+                hostname above, for example if it is behind a reverse proxy.
+                This field must be set to prevent Portus from ignoring registry
+                events originating from this external hostname.
       .form-group
         .col-md-offset-2.col-md-7
-          = f.submit('Update', class: 'btn btn-primary')
+          div.btn-toolbar role='toolbar'
+            div.btn-group role='group'
+              = f.submit('Update', class: 'btn btn-primary')
+            div.btn-group role='group'
+              span data-toggle='collapse' data-target='#advanced'
+                button.btn.btn-primary#advancedButton type='button' data-toggle='button' aria-expanded='false' aria-controls='advanced' Show Advanced
+                javascript:
+                  $('#advancedButton').click(function() {
+                    $(this).text($(this).text() == 'Show Advanced' ? 'Hide Advanced' : 'Show Advanced');
+                  });
+

--- a/app/views/admin/registries/new.html.slim
+++ b/app/views/admin/registries/new.html.slim
@@ -44,6 +44,22 @@
             = f.check_box(:use_ssl, checked: true)
           - else
             = f.check_box(:use_ssl)
+      div.collapse#advanced
+        .form-group
+          = f.label :external_hostname, "External Registry Name", {class:'control-label col-md-2', title: 'Set this if the name that clients use to communicate with the registry is different than the name that Portus uses to connect'}
+          .col-md-7
+            - if params[:external_hostname]
+              = f.text_field(:external_hostname, class: 'form-control', value: params[:external_hostname], placeholder: '(Optional)', required: false)
+            - else
+              = f.text_field(:external_hostname, class: 'form-control', placeholder: '(Optional)', required: false)
+            span.help-block
+              | Portus uses the hostname field to communicate with the registry,
+                but this may be on an internal network and inaccessible to the
+                client.
+                Clients may connect to the registry by a name different to the
+                hostname above, for example if it is behind a reverse proxy.
+                This field must be set to prevent Portus from ignoring registry
+                events originating from this external hostname.
       - unless flash[:alert].nil? || flash[:alert].empty?
         .form-group.has-error
           = label_tag :force, "Skip remote checks", {class: 'control-label col-md-2', title: "Force the creation of the registry, even if it's not reachable."}
@@ -51,5 +67,14 @@
             = check_box_tag(:force)
       .form-group
         .col-md-offset-2.col-md-7
-          = f.submit('Create', class: 'btn btn-primary')
+          div.btn-toolbar role='toolbar'
+            div.btn-group role='group'
+              = f.submit('Create', class: 'btn btn-primary')
+            div.btn-group role='group'
+              span data-toggle='collapse' data-target='#advanced'
+                button.btn.btn-primary#advancedButton type='button' data-toggle='button' aria-expanded='false' aria-controls='advanced' Show Advanced
+                javascript:
+                  $('#advancedButton').click(function() {
+                    $(this).text($(this).text() == 'Show Advanced' ? 'Hide Advanced' : 'Show Advanced');
+                  });
 

--- a/db/migrate/20160519110301_add_external_hostname_to_registries.rb
+++ b/db/migrate/20160519110301_add_external_hostname_to_registries.rb
@@ -1,0 +1,5 @@
+class AddExternalHostnameToRegistries < ActiveRecord::Migration
+  def change
+    add_column :registries, :external_hostname, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -78,11 +78,12 @@ ActiveRecord::Schema.define(version: 20160614122012) do
   add_index "namespaces", ["team_id"], name: "index_namespaces_on_team_id", using: :btree
 
   create_table "registries", force: :cascade do |t|
-    t.string   "name",       limit: 255, null: false
-    t.string   "hostname",   limit: 255, null: false
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
+    t.string   "name",              limit: 255, null: false
+    t.string   "hostname",          limit: 255, null: false
+    t.datetime "created_at",                    null: false
+    t.datetime "updated_at",                    null: false
     t.boolean  "use_ssl"
+    t.string   "external_hostname", limit: 255
   end
 
   add_index "registries", ["hostname"], name: "index_registries_on_hostname", unique: true, using: :btree

--- a/spec/factories/registries.rb
+++ b/spec/factories/registries.rb
@@ -2,12 +2,13 @@
 #
 # Table name: registries
 #
-#  id         :integer          not null, primary key
-#  name       :string(255)      not null
-#  hostname   :string(255)      not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  use_ssl    :boolean
+#  id                :integer          not null, primary key
+#  name              :string(255)      not null
+#  hostname          :string(255)      not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  use_ssl           :boolean
+#  external_hostname :string(255)
 #
 # Indexes
 #

--- a/spec/models/registry_spec.rb
+++ b/spec/models/registry_spec.rb
@@ -2,12 +2,13 @@
 #
 # Table name: registries
 #
-#  id         :integer          not null, primary key
-#  name       :string(255)      not null
-#  hostname   :string(255)      not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  use_ssl    :boolean
+#  id                :integer          not null, primary key
+#  name              :string(255)      not null
+#  hostname          :string(255)      not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  use_ssl           :boolean
+#  external_hostname :string(255)
 #
 # Indexes
 #

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -72,7 +72,11 @@ describe Repository do
   describe "handle push event" do
     let(:tag_name) { "latest" }
     let(:repository_name) { "busybox" }
-    let(:registry) { create(:registry, hostname: "registry.test.lan") }
+    let(:registry) do
+      create(:registry,
+             hostname:          "registry.test.lan",
+             external_hostname: "external.test.lan")
+    end
     let(:user) { create(:user) }
 
     before :each do
@@ -130,6 +134,62 @@ describe Repository do
       end
     end
 
+    context "event comes from an internally named registry" do
+      before :each do
+        @event = build(:raw_push_manifest_event).to_test_hash
+        @event["target"]["repository"] = repository_name
+        @event["target"]["url"] = get_url(repository_name, tag_name)
+        @event["target"]["mediaType"] = "application/vnd.docker.distribution.manifest.v1+json"
+        @event["request"]["host"] = "registry.test.lan"
+        @event["actor"]["name"] = user.username
+      end
+
+      it "sends event to logger" do
+        expect(Rails.logger).to receive(:info)
+        expect do
+          Repository.handle_push_event(@event)
+        end.to change(Repository, :count).by(0)
+      end
+
+      it "finds an internal registry" do
+        registry # create registry
+
+        reg = Registry.find_by(hostname: @event["request"]["host"])
+        expect(reg).not_to be_nil
+
+        reg = Registry.find_from_event(@event)
+        expect(reg).not_to be_nil
+      end
+    end
+
+    context "event comes from an externally named registry" do
+      before :each do
+        @event = build(:raw_push_manifest_event).to_test_hash
+        @event["target"]["repository"] = repository_name
+        @event["target"]["url"] = get_url(repository_name, tag_name)
+        @event["target"]["mediaType"] = "application/vnd.docker.distribution.manifest.v1+json"
+        @event["request"]["host"] = "external.test.lan"
+        @event["actor"]["name"] = user.username
+      end
+
+      it "sends event to logger" do
+        expect(Rails.logger).to receive(:info)
+        expect do
+          Repository.handle_push_event(@event)
+        end.to change(Repository, :count).by(0)
+      end
+
+      it "finds an external registry" do
+        registry # create registry
+
+        reg = Registry.find_by(hostname: @event["request"]["host"])
+        expect(reg).to be_nil
+
+        reg = Registry.find_from_event(@event)
+        expect(reg).not_to be_nil
+      end
+    end
+
     context "event comes from an unknown registry" do
       before :each do
         @event = build(:raw_push_manifest_event).to_test_hash
@@ -145,6 +205,13 @@ describe Repository do
         expect do
           Repository.handle_push_event(@event)
         end.to change(Repository, :count).by(0)
+      end
+
+      it "doesn't find any registry" do
+        registry # create registry
+
+        reg = Registry.find_from_event(@event)
+        expect(reg).to be_nil
       end
     end
 


### PR DESCRIPTION
I haven't actually written anything here, I just rebased @jmahowald's pr #888 onto `master`, but it seems to work fine. I'm willing to pick it up if you think there's anything that needs to be done before this can be merged though.

Here's my use case:

Registry configured at `http://registry.my.host:5000`
Portus configured at `http://registry.my.host:3000/portus`
Apache SSL proxying `https://registry.my.host/portus -> http://registry.my.host:3000/portus` and `https://registry.my.host/v2 -> http://registry.my.host:5000/v2`
So in Portus, I have configured the registry as:
![screenshot from 2016-08-01 10-31-32](https://cloud.githubusercontent.com/assets/450276/17289882/81f05f02-57d3-11e6-9ec6-e8c808a956bc.png)

