### PR TITLE
Better reflect updates

### DIFF
--- a/app/views/repositories/show.html.slim
+++ b/app/views/repositories/show.html.slim
@@ -114,7 +114,7 @@
                     - else
                       span[title="sha256:#{tag.first.image_id}"]
                         = tag.first.image_id[0, 12]
-                  td= tag.first.created_at
+                  td= tag.first.updated_at
             - else
               tr
                 td
@@ -128,7 +128,7 @@
                   - else
                     span[title="sha256:#{tag.first.image_id}"]
                       = tag.first.image_id[0, 12]
-                td= tag.first.created_at
+                td= tag.first.updated_at
 
                 - if can_destroy?(@repository)
                   td

--- a/spec/helpers/repositories_helper_spec.rb
+++ b/spec/helpers/repositories_helper_spec.rb
@@ -62,10 +62,14 @@ RSpec.describe RepositoriesHelper, type: :helper do
 
       idx = 0
 
+      na = "<strong>Someone pushed </strong><a href=\"/namespaces/#{global}\">registry:5000</a> / "\
+           "<a href=\"/repositories/#{repo.id}\">repo:0.1</a>"
+      expectations = expectations.unshift na
+
       # Changes because of the Catalog job.
-      expectations[3] = "<strong>#{nameo} pushed </strong><a href=\"/namespaces/#{global}\">"\
+      expectations[4] = "<strong>#{nameo} pushed </strong><a href=\"/namespaces/#{global}\">"\
         "registry:5000</a> / <span>repo2:0.3</span>"
-      expectations[4] = "<strong>#{nameo} pushed </strong><span>namespace</span> / <span>repo"\
+      expectations[5] = "<strong>#{nameo} pushed </strong><span>namespace</span> / <span>repo"\
           "3:0.4</span>"
 
       # Push activities

--- a/spec/jobs/catalog_job_spec.rb
+++ b/spec/jobs/catalog_job_spec.rb
@@ -157,9 +157,11 @@ describe CatalogJob do
       job = CatalogJobMock.new
       job.update_registry!([{ "name" => "repo", "tags" => ["0.1"] }])
 
-      # Two activities: push and then delete.
-      expect(PublicActivity::Activity.count).to eq 2
+      # Three activities: the original one, one more push for 0.1 and then the
+      # delete for latest.
+      expect(PublicActivity::Activity.count).to eq 3
       expect(PublicActivity::Activity.first.parameters[:tag_name]).to eq "latest"
+      expect(PublicActivity::Activity.all[1].recipient.name).to eq "0.1"
       expect(PublicActivity::Activity.last.key).to eq "repository.delete"
     end
   end


### PR DESCRIPTION
Now Portus will be able to track better updates on repositories and tags.
Moreover, updates will create activities too, and this will also be the case
for crono updates (whenever it makes sense).

Fixes #553

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>