### PR TITLE
bcrypt is not a Rails dependency so it's absolutely required in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,8 +27,7 @@ gem "rails_stdout_logging", "~> 0.0.5", group: [:development, :staging, :product
 gem "ethon", "~> 0.9.0"
 gem "typhoeus", "~> 1.0.2"
 
-# Used to store application tokens. This is already a Rails depedency. However
-# better safe than sorry...
+# Used to store application tokens.
 gem "bcrypt"
 
 # This is already a Rails dependency, but we use it to run portusctl


### PR DESCRIPTION
bcrypt stop being a hard dependency of rails since this [commit](https://github.com/rails/rails/commit/67790644372ad3a771810f1d6d99687d795789ea), so it's totally required here for application tokens.