### PR TITLE
Skip validations of devise's validatable module in LDAP setups

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,8 +36,12 @@
 class User < ActiveRecord::Base
   include PublicActivity::Common
 
-  devise :database_authenticatable, :registerable, :lockable,
-         :recoverable, :rememberable, :trackable, :validatable, authentication_keys: [:username]
+  enabled_devise_modules = [:database_authenticatable, :registerable, :lockable,
+                            :recoverable, :rememberable, :trackable, :validatable,
+                            authentication_keys: [:username]]
+
+  enabled_devise_modules.delete(:validatable) if Portus::LDAP.enabled?
+  devise(*enabled_devise_modules)
 
   APPLICATION_TOKENS_MAX = 5
 


### PR DESCRIPTION
Should solve #1040.
The mechanism is easy, the specs are tricky (Rubocop and Travis CI agree). Please, bear with me:

1. Once the user model class is loaded, `devise` configures it by mixing in its modules. In our case it mixes in the `validatable` module that contains the validation for the minimum length of a user's password (See [here](https://github.com/plataformatec/devise/blob/v3.5.1/lib/devise/models/validatable.rb#L35)). We have no way to to get rid of this validation during runtime. 
2. In case of an LDAP setup we want devise to leave out the `validatable` module because its validation of password length might be too strict  (#1040). 
3. In the specs the user model has already been loaded. It is not possible to enable the LDAP setting and _renew_ the class definition without a trick. This is done by reloading the user model class into a separate module (_the clean room_), where it can coexist with the original user model without side effects. 

In practice, we know beforehand if an LDAP setup is present or not and this is not subject to change during runtime - so this shouldn't be a problem.
