### PR TITLE
Allow us to turn off smtp authentication

### DIFF
--- a/config/initializers/smtp.rb
+++ b/config/initializers/smtp.rb
@@ -3,17 +3,25 @@
 
 if defined?(APP_CONFIG) && APP_CONFIG["email"]["smtp"]["enabled"]
   Portus::Application.config.action_mailer.delivery_method = :smtp
-
   smtp = APP_CONFIG["email"]["smtp"]
-  ActionMailer::Base.smtp_settings = {
+  smtp_settings = {
     address:              smtp["address"],
     port:                 smtp["port"],
-    user_name:            smtp["user_name"],
-    password:             smtp["password"],
     domain:               smtp["domain"],
-    authentication:       :login,
-    enable_starttls_auto: true
+    enable_starttls_auto: false
   }
+  if smtp["user_name"].blank?
+    Rails.logger.info "No smtp username supplied, not using smtp authentication"
+  else
+    auth_settings = {
+      user_name:            smtp["user_name"],
+      password:             smtp["password"],
+      authentication:       :login,
+      enable_starttls_auto: true
+    }
+    smtp_settings = smtp_settings.merge(auth_settings)
+  end
+  ActionMailer::Base.smtp_settings = smtp_settings
 else
   # If SMTP is not enabled, then go for sendmail.
   Portus::Application.config.action_mailer.delivery_method = :sendmail


### PR DESCRIPTION
In a minimal docker compose type setting it's useful to have smtp turned on and to let the relay handle all the authentication.  Otherwise, you'll have errors about 

`
portus_1       | Net::SMTPSyntaxError (503 AUTH command used when not advertised
portus_1       | ):

`

if using a basic smtp image like namshi/smtp
