### PR TITLE
Fix builds for ruby 2.3.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ rvm:
 
   # Other Ruby Versions
   - 2.1.10
-  - 2.2.4
-  - 2.3.0
+  - 2.2.5
+  - 2.3.1
 
   # Future versions
   - ruby-head
@@ -22,6 +22,7 @@ before_install:
     bash -c " # Install MariaDB
     sudo bash .travis_mariadb.sh
     "
+  - gem update --system
 
 before_script:
   - mysql -e 'create database portus_test;'

--- a/Gemfile
+++ b/Gemfile
@@ -85,6 +85,7 @@ unless ENV["PACKAGING"] && ENV["PACKAGING"] == "yes"
     gem "brakeman", require: false
     gem "database_cleaner"
     gem "md2man", "~>5.1.1", require: false
+    gem "binman", "~>5.1.0"
   end
 
   group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -403,6 +403,7 @@ DEPENDENCIES
   awesome_print
   base32
   bcrypt
+  binman (~> 5.1.0)
   bootstrap-sass (~> 3.3.4)
   bootstrap-typeahead-rails
   brakeman


### PR DESCRIPTION
Apparently a `gem update --system` is needed in order to install
`binman ~> 5.1.0`. Moreover, I've also specified the exact binman
version that we want just in case.

Finally, I've also taken the chance to update the ruby versions being
tested to their latest patch-level releases. The ruby versions being used
for SLE12 and openSUSE are left untouched.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>