### PR TITLE
use ruby:2.3.1 container for the docker compose setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM library/rails:4.2.2
+FROM library/ruby:2.3.1
 MAINTAINER Flavio Castelli <fcastelli@suse.com>
 
 ENV COMPOSE=1
@@ -16,7 +16,7 @@ RUN wget http://download.opensuse.org/repositories/home:/flavio_castelli:/phanto
   apt-key add Release.key && \
   rm Release.key
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends phantomjs && \
+    apt-get install -y --no-install-recommends phantomjs nodejs && \
     rm -rf /var/lib/apt/lists/*
 
 ADD . .


### PR DESCRIPTION
as the rails image will soon be deprecated by 2016-12-31
(see https://hub.docker.com/r/library/rails/)

another benefit is that the ruby image is more than 100mb smaller
in size than the rails image

it contains all necessary dependencies but nodejs, which is added
via the Dockerfile

also the version (rails:4.2.2) of the image was lower than the
version that is actually used (4.2.6) from the Gemfile

I have chosen ruby:2.3.1 as it has been the latest in .travis.yml