### PR TITLE
standardize on notification messages

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -15,7 +15,7 @@ class Admin::UsersController < Admin::BaseController
     @user = User.create(user_create_params)
 
     if @user.persisted?
-      flash[:notice] = "User created successfully!"
+      flash[:notice] = "User '#{@user.username}' was created successfully"
       flash[:float] = true
       redirect_to admin_users_path
     else
@@ -36,7 +36,8 @@ class Admin::UsersController < Admin::BaseController
     attr = params.require(:user).permit([:email, :display_name])
 
     if @user.update_attributes(attr)
-      redirect_to admin_users_path, notice: "User updated successfully", float: true
+      redirect_to admin_users_path, notice: "User '#{@user.username}' was updated successfully",
+                                    float:  true
     else
       redirect_to edit_admin_user_path(@user), alert: @user.errors.full_messages, float: true
     end
@@ -56,7 +57,8 @@ class Admin::UsersController < Admin::BaseController
                           parameters: { username: @user.username }
     @user.destroy!
 
-    redirect_to admin_users_path, notice: "User removed successfully", float: true
+    redirect_to admin_users_path, notice: "User '#{@user.username}' was removed successfully",
+                                  float:  true
   end
 
   # PATCH/PUT /admin/user/1/toggle_admin

--- a/app/views/application_tokens/create.js.erb
+++ b/app/views/application_tokens/create.js.erb
@@ -3,7 +3,7 @@
   $('#float-alert').fadeIn(setTimeOutAlertDelay());
 <% else %>
   $("<%= escape_javascript(render @application_token) %>").appendTo("#application_tokens");
-  $('#float-alert p').html("New token created: <code><%= @plain_token %></code>");
+  $('#float-alert p').html("Token <code><%= @plain_token %></code> was created successfully");
   $('#float-alert').fadeIn();
   $('#add_application_token_btn i').removeClass("fa-minus-circle");
   $('#add_application_token_btn i').addClass("fa-plus-circle");

--- a/app/views/application_tokens/destroy.js.erb
+++ b/app/views/application_tokens/destroy.js.erb
@@ -2,7 +2,7 @@
   $('#float-alert p').html("<%= escape_javascript(@application_token.errors.full_messages.join('<br/>')) %>");
 <% else %>
   $("#application_token_<%= @application_token.id %>").remove();
-  $('#float-alert p').html("<em>\"<%= @application_token.application %>\"</em> token has been removed");
+  $('#float-alert p').html("Token <em>\"<%= @application_token.application %>\"</em> was removed successfully");
   <% if current_user.application_tokens.count < User::APPLICATION_TOKENS_MAX %>
     $('#add_application_token_btn').removeAttr("disabled");
   <% end %>

--- a/app/views/comments/create.js.erb
+++ b/app/views/comments/create.js.erb
@@ -9,7 +9,7 @@
   <% end %>
   $(".number_of_comments").text("<%= escape_javascript(@repository.comments.count.to_s) %>");
   $("<%= escape_javascript(render @comment) %>").appendTo(".container-full");
-  $('#float-alert p').html("New comment posted");
+  $('#float-alert p').html("Comment was posted successfully");
   $('#write_comment_form').fadeOut();
 <% end %>
 $('#float-alert').fadeIn(setTimeOutAlertDelay());

--- a/app/views/comments/destroy.js.erb
+++ b/app/views/comments/destroy.js.erb
@@ -9,6 +9,6 @@
   <% end %>
   $("#comment_<%= escape_javascript(@comment.id.to_s) %>").remove();
   $(".number_of_comments").text("<%= escape_javascript(@repository.comments.count.to_s) %>");
-  $('#float-alert p').html("Comment successfully deleted");
+  $('#float-alert p').html("Comment was deleted successfully");
 <% end %>
 $('#float-alert').fadeIn(setTimeOutAlertDelay());

--- a/app/views/namespaces/create.js.erb
+++ b/app/views/namespaces/create.js.erb
@@ -3,7 +3,7 @@
 <% elsif @namespace.errors.any? %>
   $('#float-alert p').html("<%= escape_javascript(@namespace.errors.full_messages.join('<br/>')) %>");
 <% else %>
-  $('#float-alert p').html("New namespace created");
+  $('#float-alert p').html("Namespace '<%= escape_javascript(@namespace.name) %>' was created successfully");
 
   $('#add_namespace_form').fadeOut();
   $('#add_namespace_btn i').addClass("fa-chevron-down")

--- a/app/views/team_users/create.js.erb
+++ b/app/views/team_users/create.js.erb
@@ -3,9 +3,9 @@
 <% else %>
   $("<%= escape_javascript(render @team_user) %>").appendTo("#team_users");
   <% if @promoted_role %>
-    $('#float-alert p').html("New user added to the team (promoted to owner because it is a Portus admin).");
+    $('#float-alert p').html("User '<%= escape_javascript(@team_user.user.username) %>' was added to the team (promoted to owner because it is a Portus admin).");
   <% else %>
-    $('#float-alert p').html("New user added to the team");
+    $('#float-alert p').html("User '<%= escape_javascript(@team_user.user.username) %>' was added to the team");
   <% end %>
   $('#add_team_user_form').fadeOut();
   $('#add_team_user_btn i').addClass("fa-chevron-down")

--- a/app/views/team_users/destroy.js.erb
+++ b/app/views/team_users/destroy.js.erb
@@ -2,6 +2,6 @@
   $('#float-alert p').html("<%= escape_javascript(@team_user.errors.full_messages.join('<br/>')) %>");
 <% else %>
   $("#team_user_<%= @team_user.id %>").remove();
-  $('#float-alert p').html("User removed from the team");
+  $('#float-alert p').html("User '<%= escape_javascript(@team_user.user.username) %>' was removed from the team");
 <% end %>
 $('#float-alert').fadeIn(setTimeOutAlertDelay());

--- a/app/views/teams/create.js.erb
+++ b/app/views/teams/create.js.erb
@@ -2,7 +2,7 @@
   $('#float-alert p').html("<%= escape_javascript(@team.errors.full_messages.join('<br/>')) %>");
 <% else %>
   $("<%= escape_javascript(render @team) %>").appendTo("#teams");
-  $('#float-alert p').html("The team '<%= @team.name %>' was created successfully");
+  $('#float-alert p').html("Team '<%= escape_javascript(@team.name) %>' was created successfully");
   $('#add_team_form').fadeOut();
   $('#add_team_btn i').addClass("fa-plus-circle")
   $('#add_team_btn i').removeClass("fa-minus-circle")

--- a/app/views/webhook_headers/create.js.erb
+++ b/app/views/webhook_headers/create.js.erb
@@ -2,7 +2,7 @@
   $('#alert p').html("<%= escape_javascript(@webhook_header.errors.full_messages.join('<br/>')) %>");
   $('#alert').fadeIn();
 <% else %>
-  $('#alert p').html("Header '<%= @webhook_header.name %>' has been created successfully");
+  $('#alert p').html("Header '<%= @webhook_header.name %>' was created successfully");
   $('#alert').fadeIn();
 
   $('#add_webhook_header_form').fadeOut();

--- a/app/views/webhook_headers/destroy.js.erb
+++ b/app/views/webhook_headers/destroy.js.erb
@@ -3,6 +3,6 @@
   $('#alert').fadeIn();
 <% else %>
   $("#webhook_header_<%= @webhook_header.id %>").remove();
-  $('#alert p').html("Header '<%= @webhook_header.name %>' has been removed successfully");
+  $('#alert p').html("Header '<%= @webhook_header.name %>' was removed successfully");
   $('#alert').fadeIn();
 <% end %>

--- a/spec/features/admin/users_spec.rb
+++ b/spec/features/admin/users_spec.rb
@@ -22,7 +22,7 @@ feature "Admin - Users panel" do
 
       wait_for_effect_on("#float-alert")
       expect { User.find(user.id) }.to raise_error(ActiveRecord::RecordNotFound)
-      expect(page).to have_content("User removed successfully")
+      expect(page).to have_content("User '#{user.username}' was removed successfully")
       expect(page).to_not have_content(original)
     end
 
@@ -37,7 +37,7 @@ feature "Admin - Users panel" do
 
       wait_for_effect_on("#float-alert")
       expect { User.find(user.id) }.to raise_error(ActiveRecord::RecordNotFound)
-      expect(page).to have_content("User removed successfully")
+      expect(page).to have_content("User '#{user.username}' was removed successfully")
       expect(page).to_not have_content(original)
     end
   end
@@ -107,7 +107,7 @@ feature "Admin - Users panel" do
 
       wait_for_effect_on("#float-alert")
       expect(page).to have_content("another@example.com")
-      expect(page).to have_content("User updated successfully")
+      expect(page).to have_content("User '#{user.username}' was updated successfully")
     end
 
     scenario "disallows the admin to update a user with a wrong name", js: true do

--- a/spec/features/application_tokens_spec.rb
+++ b/spec/features/application_tokens_spec.rb
@@ -26,7 +26,7 @@ feature "Application tokens" do
       expect(current_path).to eql edit_user_registration_path
 
       wait_for_effect_on("#float-alert")
-      expect(page).to have_content("New token created")
+      expect(page).to have_content("was created successfully")
       expect(page).to have_content("awesome-application")
     end
 
@@ -70,7 +70,7 @@ feature "Application tokens" do
       expect(current_path).to eql edit_user_registration_path
 
       wait_for_effect_on("#float-alert")
-      expect(page).to have_content("New token created")
+      expect(page).to have_content("was created successfully")
       expect(page).to have_content("awesome-application")
       expect(disabled?("#add_application_token_btn")).to be true
     end
@@ -100,7 +100,7 @@ feature "Application tokens" do
       wait_for_ajax
       wait_for_effect_on("#float-alert")
 
-      expect(page).to have_content("token has been removed")
+      expect(page).to have_content("was removed successfully")
     end
   end
 

--- a/spec/features/namespaces_spec.rb
+++ b/spec/features/namespaces_spec.rb
@@ -81,7 +81,7 @@ feature "Namespaces support" do
       expect(page).to have_content("valid-namespace")
 
       wait_for_effect_on("#float-alert")
-      expect(page).to have_content("New namespace created")
+      expect(page).to have_content(/Namespace '.+' was created successfully/)
 
       # Check that it created a link to it and that it's accessible.
       click_link "valid-namespace"

--- a/spec/features/teams_spec.rb
+++ b/spec/features/teams_spec.rb
@@ -57,7 +57,7 @@ feature "Teams support" do
       expect(page).to have_content("valid-team")
 
       wait_for_effect_on("#float-alert")
-      expect(page).to have_content("The team 'valid-team' was created successfully")
+      expect(page).to have_content("Team 'valid-team' was created successfully")
     end
 
     scenario 'The "Create new team" link has a toggle effect', js: true do
@@ -140,7 +140,7 @@ feature "Teams support" do
       wait_for_ajax
       wait_for_effect_on("#float-alert")
 
-      expect(page).to have_content("New user added to the team")
+      expect(page).to have_content(/User '.+' was added to the team/)
       expect(page).to have_content("Contributor")
     end
 
@@ -154,7 +154,9 @@ feature "Teams support" do
       wait_for_ajax
       wait_for_effect_on("#float-alert")
 
-      expect(page).to have_content("New user added to the team (promoted to")
+      expect(page).to have_content(
+        /User '.+' was added to the team \(promoted to owner because it is a Portus admin\)\./
+      )
       expect(page).to have_content("Owner")
     end
 
@@ -184,7 +186,7 @@ feature "Teams support" do
       wait_for_ajax
       wait_for_effect_on("#float-alert")
 
-      expect(page).to have_content("User removed from the team")
+      expect(page).to have_content(/User '.+' was removed from the team/)
     end
 
     scenario "The only member of a team cannot be removed", js: true do


### PR DESCRIPTION
there have been different wordings for some actions like creating or
removing users, comments, tokens, namespaces etc.

fixes #885
supersedes #923 

Signed-off-by: Maximilian Meister <mmeister@suse.de>

NOTE: I am probably still missing the fixes for the unit tests, as I had some trouble with running them, 606 of them failed when run inside the container, which I found a bit strange for a small patch like this, a lot of `Factory not registered` errors etc.

I have also run them on my host, which required me to setup a mysql db like in `.travis.yml`, and I got 132 errors. I guess there is sth wrong with the setup (a lot of permission errors, and missing `phantomjs`)

I have read https://github.com/SUSE/Portus/wiki/How-we-test-Portus but it was not yet clear if I should run the tests on my host or in directly in the `portus_web` container, or what's the best way to run them for a patch like this one?

I guess my setup is missing something, though finding the right spots to adapt the tests is not yet really obvious to me right now... :-(

EDIT: in the meantime I have used travis as a starting point to fix the tests

Thanks