### PR TITLE
fix assets precompilation in the RPM (remove man pages and fix

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,2 +1,2 @@
 Rails.application.config.assets.version = "1.0"
-Rails.application.config.assets.precompile += %w(*.woff2 *.css *.js)
+Rails.application.config.assets.precompile += %w(*.woff2 *.js)

--- a/packaging/suse/portus.spec.in
+++ b/packaging/suse/portus.spec.in
@@ -144,6 +144,8 @@ fi
 %exclude %{portusdir}/vagrant
 %exclude %{portusdir}/Vagrantfile
 %exclude %{portusdir}/compose
+%exclude %{portusdir}/lib/man_pages.rb
+%exclude %{portusdir}/lib/tasks/man.rake
 %doc %{portusdir}/README.md
 %doc %{portusdir}/CONTRIBUTING.md
 %doc %{portusdir}/LICENSE


### PR DESCRIPTION
initialization)

We don't need the rake task for creating the man pages in the RPM.
Otherwise, running the assets precompilation fails.

Also, fix the initialization of the assets or the variables can't be
found when precompiling the assets.

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>