### PR TITLE
RPM: remove man pages rake task from the RPM

### DIFF
--- a/packaging/suse/portus.spec.in
+++ b/packaging/suse/portus.spec.in
@@ -144,6 +144,8 @@ fi
 %exclude %{portusdir}/vagrant
 %exclude %{portusdir}/Vagrantfile
 %exclude %{portusdir}/compose
+%exclude %{portusdir}/lib/man_pages.rb
+%exclude %{portusdir}/lib/tasks/man.rake
 %doc %{portusdir}/README.md
 %doc %{portusdir}/CONTRIBUTING.md
 %doc %{portusdir}/LICENSE


### PR DESCRIPTION
We don't need the rake task for creating the man pages in the RPM.
Otherwise, running the assets precompilation fails because it requires
md2man gem which is in the development group.

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>