### PR TITLE
Runtime checks will only be performed once

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
+  include Portus::Checks
   before_action :check_requirements
-  helper_method :fixes
+
   before_action :authenticate_user!
   before_action :force_update_profile!
   before_action :force_registry_config!
@@ -27,31 +28,7 @@ class ApplicationController < ActionController::Base
     new_user_session_path
   end
 
-  def fixes
-    secrets = Rails.application.secrets
-    check_ssl = Rails.env.production? && \
-      !request.ssl? && \
-      APP_CONFIG.enabled?("check_ssl_usage")
-
-    {}.tap do |fix|
-      fix[:ssl]                                = check_ssl
-      fix[:secret_key_base]                    = secrets.secret_key_base == "CHANGE_ME"
-      fix[:secret_machine_fqdn]                = APP_CONFIG["machine_fqdn"]["value"].blank?
-      fix[:secret_encryption_private_key_path] = secrets.encryption_private_key_path.nil?
-      fix[:secret_portus_password]             = secrets.portus_password.nil?
-      fix
-    end
-  end
-
   protected
-
-  # Check whether certain requirements are met, like ssl configuration
-  # for production or having setup secrets.
-  # If they are not met, render a page with status 500
-  def check_requirements
-    return unless fixes.value?(true)
-    redirect_to "/500?fixes=true"
-  end
 
   # Redirect users to their profile page if they haven't set up their email
   # account (this happens when signing up through LDAP suppor).

--- a/config/initializers/checks.rb
+++ b/config/initializers/checks.rb
@@ -1,0 +1,2 @@
+# Clear the cache
+Rails.cache.write("portus-checks", nil)

--- a/lib/portus/checks.rb
+++ b/lib/portus/checks.rb
@@ -1,0 +1,37 @@
+module Portus
+  # Performs some checks on runtime to validate that some settings from Portus
+  # are properly set.
+  module Checks
+    # Check whether certain requirements are met, like ssl configuration
+    # for production or having setup secrets.
+    # If they are not met, render a page with status 500
+    def check_requirements
+      return unless fixes.value?(true)
+      redirect_to "/500?fixes=true"
+    end
+
+    # Returns a hash with all the options that the administrator must fix in
+    # order to get Portus to work. If this hash is empty, then it means that
+    # everything worked as expected
+    #
+    # This method caches the results because the returned value will be the same
+    # after the first request has happened.
+    def fixes
+      # Return early if we already know the value
+      checks = Rails.cache.fetch("portus-checks")
+      return checks unless checks.nil?
+
+      secrets   = Rails.application.secrets
+      check_ssl = Rails.env.production? && !request.ssl? && APP_CONFIG.enabled?("check_ssl_usage")
+
+      {}.tap do |fix|
+        fix[:ssl]                                = check_ssl
+        fix[:secret_key_base]                    = secrets.secret_key_base == "CHANGE_ME"
+        fix[:secret_machine_fqdn]                = APP_CONFIG["machine_fqdn"]["value"].blank?
+        fix[:secret_encryption_private_key_path] = secrets.encryption_private_key_path.nil?
+        fix[:secret_portus_password]             = secrets.portus_password.nil?
+        Rails.cache.write("portus-checks", fix)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -58,6 +58,8 @@ RSpec.configure do |config|
       # This allows non-admins to modify teams
       "manage_team"       => { "enabled" => true }
     }
+
+    Rails.cache.write("portus-checks", nil)
   end
 
   config.order = :random


### PR DESCRIPTION
It's not a good idea to perform this checks for *every* request.
Instead, they will be checked only once after booting up.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>