### PR TITLE
fix ffi gem installation

### DIFF
--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -34,6 +34,9 @@ additional_native_build_requirements() {
   if [ $1 == "ethon" ];then
     echo "BuildRequires: libcurl-devel\nRequires: libcurl4\n"
   fi
+  if [ $1 == "ffi" ];then
+    echo "BuildRequires: libffi-devel\n"
+  fi
 }
 
 mkdir -p build/Portus-$branch


### PR DESCRIPTION
in order to install this gem, it needs libffi-devel install, since
this is a native gem. Otherwise, it won't build for other archs other
than x86_64.