### PR TITLE
prevent validation error in the specs

### DIFF
--- a/spec/controllers/admin/activities_controller_spec.rb
+++ b/spec/controllers/admin/activities_controller_spec.rb
@@ -117,8 +117,8 @@ CSV
 
     it "generates an CSV file with all the entries" do
       # Create activities way beyond a single page.
-      50.times do
-        team = Team.new(name: "team#{rand(1000..10000)}")
+      Array.new(50) { rand(1000..10000) }.uniq.each do |nr|
+        team = Team.new(name: "team#{nr}")
         team.owners << user
         team.save
         team.create_activity :create, owner: user


### PR DESCRIPTION
due to the randomness there is a chance that a number occurs multiple
times, which causes a validation error and the test to fail

Signed-off-by: Maximilian Meister mmeister@suse.de
