### PR TITLE
enhance the way of running local specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,6 +72,7 @@ unless ENV["PACKAGING"] && ENV["PACKAGING"] == "yes"
   end
 
   group :development, :test do
+    gem "rspec-rails"
     gem "byebug"
     gem "web-console", "~> 2.1.3"
     gem "puma"
@@ -91,7 +92,6 @@ unless ENV["PACKAGING"] && ENV["PACKAGING"] == "yes"
 
   group :test do
     gem "shoulda"
-    gem "rspec-rails"
     gem "vcr"
     gem "webmock", require: false
     gem "simplecov", require: false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -40,4 +40,5 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+  config.log_level = :error
 end


### PR DESCRIPTION
now you can just run `bundle exec rake spec:models` after making some change to a model e.g. and the tests run much faster, as the successful activerecord logs aren't written anymore in the test env

you still have to provide the mysql test database and `phantomjs` though...
