### PR TITLE
provide phantomjs via rubygem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,17 +6,8 @@ EXPOSE 3000
 
 WORKDIR /portus
 COPY Gemfile* ./
-RUN bundle install --retry=3
-
-# Install phantomjs, this is required for testing and development purposes
-# There are no official deb packages for it, hence we built it inside of the
-# open build service.
-RUN echo "deb http://download.opensuse.org/repositories/home:/flavio_castelli:/phantomjs/Debian_8.0/ ./" >> /etc/apt/sources.list
-RUN wget http://download.opensuse.org/repositories/home:/flavio_castelli:/phantomjs/Debian_8.0/Release.key && \
-  apt-key add Release.key && \
-  rm Release.key
+RUN bundle install --retry=3 && bundle binstubs phantomjs
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends phantomjs nodejs && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get install -y --no-install-recommends nodejs
 
 ADD . .

--- a/Gemfile
+++ b/Gemfile
@@ -86,6 +86,7 @@ unless ENV["PACKAGING"] && ENV["PACKAGING"] == "yes"
     gem "database_cleaner"
     gem "md2man", "~>5.1.1", require: false
     gem "binman", "~>5.1.0"
+    gem "phantomjs", "~> 2.1.1.0"
   end
 
   group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,6 +213,7 @@ GEM
     paint (1.0.0)
     parser (2.3.1.2)
       ast (~> 2.2)
+    phantomjs (2.1.1.0)
     poltergeist (1.6.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -433,6 +434,7 @@ DEPENDENCIES
   md2man (~> 5.1.1)
   mysql2
   net-ldap
+  phantomjs (~> 2.1.1.0)
   poltergeist
   pry-rails
   public_activity


### PR DESCRIPTION
this removes the obs dependency for the deb package and also
enables running local rspec without having to care about providing
phantomjs

Signed-off-by: Maximilian Meister mmeister@suse.de
