### PR TITLE
[package] change ownership of tmp/cache after setting up the database

### DIFF
--- a/packaging/suse/portusctl/lib/configurator.rb
+++ b/packaging/suse/portusctl/lib/configurator.rb
@@ -122,6 +122,7 @@ class Configurator
       puts "Are you sure the database is empty?"
       puts "Ignoring error"
     end
+    FileUtils.chown_R("wwwrun", "www", "/srv/Portus/tmp/cache")
   end
 
   # Creates the config-local.yml file used by Portus


### PR DESCRIPTION
Because running portusctl as root, creates some files under tmp/cache
which after will be used by the rails application. Specifically, the
portus-check files. Unless we change the ownership, we'll get a
permission problem

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>