### PR TITLE
fix permissions on apache2 reinstall

### DIFF
--- a/packaging/suse/portusctl/lib/configurator.rb
+++ b/packaging/suse/portusctl/lib/configurator.rb
@@ -55,20 +55,23 @@ class Configurator
 
     key_file = "/etc/apache2/ssl.key/#{HOSTNAME}-ca.key"
     crt_file = "/etc/apache2/ssl.crt/#{HOSTNAME}-ca.crt"
+    portus_key = "/srv/Portus/config/server.key"
 
     missing_file(key_file) unless File.exist?(key_file)
     missing_file(crt_file) unless File.exist?(crt_file)
 
-    FileUtils.chown("wwwrun", "www", "/etc/apache2/ssl.key")
-    FileUtils.chmod(0o750, "/etc/apache2/ssl.key")
-
-    FileUtils.chown("wwwrun", "www", key_file)
-    FileUtils.chmod(0o440, key_file)
-
-    # Create key used by Portus to sign the JWT tokens
-    FileUtils.ln_sf(
+    # Move key to portus dir, set permissions and create symlink
+    # bsc#1022811
+    FileUtils.cp(
       key_file,
-      File.join("/srv/Portus/config", "server.key")
+      portus_key,
+    )
+    FileUtils.chown("wwwrun", "www", portus_key)
+    FileUtils.chmod(0o440, portus_key)
+    FileUtils.rm(key_file)
+    FileUtils.ln_s(
+      portus_key,
+      key_file
     )
 
     FileUtils.cp(


### PR DESCRIPTION
If we reinstall apache2, permissions and ownership of dir
/etc/apache2/ssl.key is reset to root and "read only by user root"
which make user wwwrun not being able to use this key

wwwrun is the user which Portus runs and needs to access to that
certificate

We used to change the ownership and create a symlink, but as stated,
reinstalling apache2 changes the ownership back.

Thus, the solution is to do it the other way around, move the key
outside apache dirs and instead create a symlink

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>