### PR TITLE
Split user permissions between create and manage

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ inherit_from:
 
 # TODO: (mssola) only the LDAP class and portusctl require this.
 Metrics/ClassLength:
-  Max: 180
+  Max: 181
 
 # TODO: (mssola) Some methods are offending this cop. In the SUSE's style guide
 # the approach is to use Rubocop's default value. In the near future I will

--- a/app/helpers/namespaces_helper.rb
+++ b/app/helpers/namespaces_helper.rb
@@ -5,7 +5,7 @@ module NamespacesHelper
   end
 
   def can_create_namespace?
-    current_user.admin? || APP_CONFIG.enabled?("user_permission.manage_namespace")
+    current_user.admin? || APP_CONFIG.enabled?("user_permission.create_namespace")
   end
 
   def can_change_visibility?(namespace)

--- a/app/helpers/teams_helper.rb
+++ b/app/helpers/teams_helper.rb
@@ -5,7 +5,7 @@ module TeamsHelper
   end
 
   def can_create_team?
-    current_user.admin? || APP_CONFIG.enabled?("user_permission.manage_team")
+    current_user.admin? || APP_CONFIG.enabled?("user_permission.create_team")
   end
 
   def role_within_team(team)

--- a/app/policies/namespace_policy.rb
+++ b/app/policies/namespace_policy.rb
@@ -42,10 +42,15 @@ class NamespacePolicy
 
   def create?
     raise Pundit::NotAuthorizedError, "must be logged in" unless user
-    (APP_CONFIG.enabled?("user_permission.manage_namespace") || user.admin?) && push?
+    (APP_CONFIG.enabled?("user_permission.create_namespace") || user.admin?) && push?
   end
 
-  alias update? create?
+  def update?
+    raise Pundit::NotAuthorizedError, "must be logged in" unless user
+    (user.admin? || (APP_CONFIG.enabled?("user_permission.manage_namespace") &&
+                     namespace.team.owners.exists?(user.id))) && push?
+  end
+
   alias all? push?
 
   def change_visibility?

--- a/app/policies/team_policy.rb
+++ b/app/policies/team_policy.rb
@@ -16,11 +16,11 @@ class TeamPolicy
   end
 
   def create?
-    APP_CONFIG.enabled?("user_permission.manage_team") || user.admin?
+    APP_CONFIG.enabled?("user_permission.create_team") || user.admin?
   end
 
   def update?
-    create? && !@team.hidden? && owner?
+    (APP_CONFIG.enabled?("user_permission.manage_team") || user.admin?) && !@team.hidden? && owner?
   end
 
   alias show? member?

--- a/config/config.yml
+++ b/config/config.yml
@@ -147,9 +147,19 @@ user_permission:
   change_visibility:
     enabled: true
 
+  # Allow users to create teams. If this is disabled only an admin will be able
+  # to do this. This defaults to true.
+  create_team:
+    enabled: true
+
   # Allow users to create/modify teams if they are an owner of it. If this is
   # disabled only an admin will be able to do this. This defaults to true.
   manage_team:
+    enabled: true
+
+  # Allow users to create namespaces. If this is disabled, only an admin will
+  # be able to do this. This defaults to true.
+  create_namespace:
     enabled: true
 
   # Allow users to create/modify namespaces if they are an owner of it. If this

--- a/packaging/suse/portusctl/lib/cli.rb
+++ b/packaging/suse/portusctl/lib/cli.rb
@@ -143,8 +143,18 @@ Looks for the following required certificate files in the specified folder:
     type:    :boolean,
     default: true
 
+  option "create-namespace-enable",
+    desc:    "Allow users to modify new namespaces",
+    type:    :boolean,
+    default: true
+
   option "manage-team-enable",
     desc:    "Allow users to modify their teams",
+    type:    :boolean,
+    default: true
+
+  option "create-team-enable",
+    desc:    "Allow users to create new teams",
     type:    :boolean,
     default: true
 

--- a/packaging/suse/portusctl/lib/configurator.rb
+++ b/packaging/suse/portusctl/lib/configurator.rb
@@ -64,7 +64,7 @@ class Configurator
     # bsc#1022811
     FileUtils.cp(
       key_file,
-      portus_key,
+      portus_key
     )
     FileUtils.chown("wwwrun", "www", portus_key)
     FileUtils.chmod(0o440, portus_key)

--- a/packaging/suse/portusctl/man/man1/portusctl-setup.1
+++ b/packaging/suse/portusctl/man/man1/portusctl-setup.1
@@ -185,12 +185,20 @@ When enabled, users will be able to change the visibility of their
 namespaces. It's enabled by default.
 .TP
 \fB\-\-manage\-namespace\-enable\fP
-Allow users to create/modify namespaces if they are an owner of it. If this
+Allow users to modify namespaces if they are an owner of it. If this
 is disabled, only an admin will be able to do this. This defaults to true.
 .TP
+\fB\-\-create\-namespace\-enable\fP
+Allow users to create namespaces. If this is disabled, only an admin will
+be able to do this. This defaults to true.
+.TP
 \fB\-\-manage\-team\-enable\fP
-Allow users to create/modify teams if they are an owner of it. If this is
+Allow users to modify teams if they are an owner of it. If this is
 disabled only an admin will be able to do this. This defaults to true.
+.TP
+\fB\-\-create\-team\-enable\fP
+Allow users to create teams. If this is disabled only an admin will be
+able to do this. This defaults to true.
 .SH EXAMPLES
 .PP
 The simplest example is:

--- a/packaging/suse/portusctl/man/markdown/portusctl-setup.md
+++ b/packaging/suse/portusctl/man/markdown/portusctl-setup.md
@@ -187,12 +187,20 @@ first time.
   namespaces. It's enabled by default.
 
 **--manage-namespace-enable**
-  Allow users to create/modify namespaces if they are an owner of it. If this
+  Allow users to modify namespaces if they are an owner of it. If this
   is disabled, only an admin will be able to do this. This defaults to true.
 
+**--create-namespace-enable**
+  Allow users to create namespaces. If this is disabled, only an admin will
+  be able to do this. This defaults to true.
+
 **--manage-team-enable**
-  Allow users to create/modify teams if they are an owner of it. If this is
+  Allow users to modify teams if they are an owner of it. If this is
   disabled only an admin will be able to do this. This defaults to true.
+
+**--create-team-enable**
+  Allow users to create teams. If this is disabled only an admin will be
+  able to do this. This defaults to true.
 
 # EXAMPLES
 

--- a/packaging/suse/portusctl/spec/options_spec.rb
+++ b/packaging/suse/portusctl/spec/options_spec.rb
@@ -11,7 +11,9 @@ def format_key(key)
      .gsub(/^check-ssl-usage-enable$/, "secure")
      .gsub(/^user-permission-change-visibility-enable$/, "change-visibility-enable")
      .gsub(/^user-permission-manage-namespace-enable$/, "manage-namespace-enable")
+     .gsub(/^user-permission-create-namespace-enable$/, "create-namespace-enable")
      .gsub(/^user-permission-manage-team-enable$/, "manage-team-enable")
+     .gsub(/^user-permission-create-team-enable$/, "create-team-enable")
 end
 
 # Get the keys as given by the config.yml file.

--- a/spec/controllers/namespaces_controller_spec.rb
+++ b/spec/controllers/namespaces_controller_spec.rb
@@ -260,7 +260,7 @@ describe NamespacesController do
 
       context "non-admins are not allowed to create namespaces" do
         it "does not create a new Namespace" do
-          APP_CONFIG["user_permission"]["manage_namespace"]["enabled"] = false
+          APP_CONFIG["user_permission"]["create_namespace"]["enabled"] = false
           expect do
             post :create, @post_params
           end.to change(Namespace, :count).by(0)

--- a/spec/controllers/teams_controller_spec.rb
+++ b/spec/controllers/teams_controller_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe TeamsController, type: :controller do
 
       context "non-admins are not allowed to create teams" do
         it "prohibits user from creating a new Team" do
-          APP_CONFIG["user_permission"]["manage_team"]["enabled"] = false
+          APP_CONFIG["user_permission"]["create_team"]["enabled"] = false
 
           expect do
             post :create, team: valid_attributes, format: :js

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,8 +55,12 @@ RSpec.configure do |config|
       "change_visibility" => { "enabled" => true },
       # This allows non-admins to modify namespaces
       "manage_namespace"  => { "enabled" => true },
+      # This allows non-admins to create namespaces
+      "create_namespace"  => { "enabled" => true },
       # This allows non-admins to modify teams
-      "manage_team"       => { "enabled" => true }
+      "manage_team"       => { "enabled" => true },
+      # This allows non-admins to create teams
+      "create_team"       => { "enabled" => true }
     }
 
     Rails.cache.write("portus-checks", nil)


### PR DESCRIPTION
This allows restricting creation of teams or namespaces to admins, while
allowing owners to manage their own teams/namespaces.