### PR TITLE
fix ownership for tmp/cache directory

### DIFF
--- a/packaging/suse/portus.spec.in
+++ b/packaging/suse/portus.spec.in
@@ -132,6 +132,9 @@ install -p -m 644 packaging/suse/portusctl/man/man1/*.1 %{buildroot}%{_mandir}/m
 %service_add_pre portus_crono.service
 
 %post
+if [ -d /srv/Portus/tmp ];then
+  chown -R wwwrun:www /srv/Portus/tmp
+fi
 %service_add_post portus_crono.service
 %{restart_on_update apache2}
 

--- a/packaging/suse/portusctl/lib/configurator.rb
+++ b/packaging/suse/portusctl/lib/configurator.rb
@@ -125,7 +125,7 @@ class Configurator
       puts "Are you sure the database is empty?"
       puts "Ignoring error"
     end
-    FileUtils.chown_R("wwwrun", "www", "/srv/Portus/tmp/cache")
+    FileUtils.chown_R("wwwrun", "www", "/srv/Portus/tmp")
   end
 
   # Creates the config-local.yml file used by Portus


### PR DESCRIPTION
This should be owned by wwwrun:www but if this is an update, it is
owned by root. Thus, we need to force it to be owned by wwwrun:www

This follows up with the fix in 496976