### PR TITLE
portusctl: show proper output for unknown flags

### DIFF
--- a/packaging/suse/portusctl/lib/cli.rb
+++ b/packaging/suse/portusctl/lib/cli.rb
@@ -1,5 +1,7 @@
 # Class implementing the cli interface of portusctl
 class Cli < Thor
+  check_unknown_options!
+
   desc "setup", "Configure Portus"
   option "secure", desc: "Toggle SSL usage for Portus", type: :boolean, default: true
 

--- a/packaging/suse/portusctl/spec/options_spec.rb
+++ b/packaging/suse/portusctl/spec/options_spec.rb
@@ -49,4 +49,9 @@ describe Cli do
     msg = raw + diff.join(", ") + "."
     expect(diff).to be_empty, msg
   end
+
+  it "returns the proper name of the given flag" do
+    argv = ["--flag"]
+    expect { Cli.start(argv) }.to output("Unknown switches '--flag'\n").to_stderr
+  end
 end


### PR DESCRIPTION
Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>