### PR TITLE
Optionally add puma in the bundle in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,13 +52,23 @@ unless ENV["IGNORE_ASSETS"] == "yes"
   gem "turbolinks"
 end
 
+# Returns true if the bundle is targeted towards building a package.
+def packaging?
+  ENV["PACKAGING"] == "yes"
+end
+
+# If the deployment is done through Puma, include it in the bundle.
+if ENV["PORTUS_PUMA_DEPLOYMENT"] == "yes" || !packaging?
+  gem "puma", "~> 3.7.0"
+end
+
 # In order to create the Gemfile.lock required for packaging
 # meaning that it should contain only the production packages
 # run:
 #
 # PACKAGING=yes bundle list
 
-unless ENV["PACKAGING"] && ENV["PACKAGING"] == "yes"
+unless packaging?
   group :development do
     gem "annotate"
     gem "rails-erd"
@@ -75,7 +85,6 @@ unless ENV["PACKAGING"] && ENV["PACKAGING"] == "yes"
     gem "rspec-rails"
     gem "byebug"
     gem "web-console", "~> 2.1.3"
-    gem "puma"
     gem "awesome_print"
     gem "hirb"
     gem "wirb"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -232,7 +232,7 @@ GEM
       activerecord (>= 3.0)
       i18n (>= 0.5.0)
       railties (>= 3.0.0)
-    puma (3.6.2)
+    puma (3.7.0)
     pundit (1.0.1)
       activesupport (>= 3.0.0)
     quiet_assets (1.1.0)
@@ -438,7 +438,7 @@ DEPENDENCIES
   poltergeist
   pry-rails
   public_activity
-  puma
+  puma (~> 3.7.0)
   pundit
   quiet_assets
   rack-mini-profiler
@@ -466,4 +466,4 @@ DEPENDENCIES
   wirble
 
 BUNDLED WITH
-   1.11.2
+   1.12.2


### PR DESCRIPTION
For now puma was included in the development/test bundle, but in some
deployments it might be more convenient to also use puma for production.
With this commit, you only need to set the `PORTUS_PUMA_DEPLOYMENT` to
"yes" in order to accomplish that.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>