### PR TITLE
assets: removed redundant bootstrap reference

### DIFF
--- a/app/assets/javascripts/application.coffee
+++ b/app/assets/javascripts/application.coffee
@@ -2,7 +2,6 @@
 #= require jquery.turbolinks
 #= require jquery_ujs
 #= require turbolinks
-#= require bootstrap-sprockets
 #= require lifeitup_layout
 #= require bootstrap-typeahead-rails
 #= require_tree .

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,7 +9,6 @@
 @import "pacifico";
 
 // Core libraries.
-@import "bootstrap-sprockets";
 @import 'core/**/*';
 @import 'bootstrap';
 @import 'lifeitup/lifeitup';


### PR DESCRIPTION
bootstrap-sprockects is the same as bootstrap, but with the files
splitted so it's easier to embed in sprocket's workflow.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>