### PR TITLE
Remove turbolinks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,10 +23,6 @@ gem "redcarpet"
 gem "font-awesome-rails"
 gem "bootstrap-typeahead-rails"
 gem "rails_stdout_logging", "~> 0.0.5", group: [:development, :staging, :production]
-# turbolinks need to be installed on production because if you use nginx or another
-# proxy/load-balancer, it expects this js files to be installed
-gem "jquery-turbolinks"
-gem "turbolinks"
 
 # Pinning these specific versions because that's what we have on OBS.
 gem "ethon", "~> 0.9.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,9 +166,6 @@ GEM
     jquery-rails (3.1.3)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
-    jquery-turbolinks (2.1.0)
-      railties (>= 3.1.0)
-      turbolinks
     json (1.8.3)
     json-schema (2.5.1)
       addressable (~> 2.3.7)
@@ -362,8 +359,6 @@ GEM
     timecop (0.7.4)
     treetop (1.6.5)
       polyglot (~> 0.3)
-    turbolinks (2.5.3)
-      coffee-rails
     typhoeus (1.0.2)
       ethon (>= 0.9.0)
     tzinfo (1.2.2)
@@ -427,7 +422,6 @@ DEPENDENCIES
   guard-rubocop
   hirb
   jquery-rails
-  jquery-turbolinks
   json-schema
   jwt
   kaminari
@@ -456,7 +450,6 @@ DEPENDENCIES
   sprockets (~> 2.12.3)
   thor
   timecop
-  turbolinks
   typhoeus (~> 1.0.2)
   uglifier
   vcr
@@ -466,4 +459,4 @@ DEPENDENCIES
   wirble
 
 BUNDLED WITH
-   1.12.2
+   1.13.6

--- a/app/assets/javascripts/application.coffee
+++ b/app/assets/javascripts/application.coffee
@@ -1,7 +1,5 @@
 #= require jquery
-#= require jquery.turbolinks
 #= require jquery_ujs
-#= require turbolinks
 #= require bootstrap-sprockets
 #= require lifeitup_layout
 #= require bootstrap-typeahead-rails

--- a/app/assets/javascripts/auth/registrations.coffee
+++ b/app/assets/javascripts/auth/registrations.coffee
@@ -1,4 +1,4 @@
-$(document).on "page:change", ->
+$(document).ready ->
   $('#add_application_token_btn').on 'click', (event) ->
     $('#add_application_token_form').toggle 400, "swing", ->
       if $('#add_application_token_form').is(':visible')

--- a/app/assets/javascripts/dashboard.coffee
+++ b/app/assets/javascripts/dashboard.coffee
@@ -1,4 +1,4 @@
-$(document).on "page:change", ->
+$(document).ready ->
   $('#starred a').on 'click', (event) ->
     e.preventDefault()
     $(this).tab('show')

--- a/app/assets/javascripts/namespaces.coffee
+++ b/app/assets/javascripts/namespaces.coffee
@@ -1,7 +1,7 @@
 #= require includes/set_typehead
 #= require includes/open_close_icon
 
-$(document).on "page:change", ->
+$(document).ready ->
   $('#edit_namespace').on 'click', (event) ->
     set_typeahead('/teams/typeahead/%QUERY')
 

--- a/app/assets/javascripts/repositories.coffee
+++ b/app/assets/javascripts/repositories.coffee
@@ -1,4 +1,4 @@
-$(document).on "page:change", ->
+$(document).ready ->
 
   # Shows and hides the comment form
   $('#write_comment_repository_btn').unbind('click').on 'click', (event) ->

--- a/app/assets/javascripts/teams.coffee
+++ b/app/assets/javascripts/teams.coffee
@@ -1,6 +1,6 @@
 #= require namespaces
 
-$(document).on "page:change", ->
+$(document).ready ->
   $('#add_team_user_btn').on 'click', (event) ->
     $('#team_user_user').val('')
     $('#team_user_role').val('viewer')

--- a/packaging/suse/patches/0_change_versions.gem.patch
+++ b/packaging/suse/patches/0_change_versions.gem.patch
@@ -1,5 +1,5 @@
 diff --git a/Gemfile b/Gemfile
-index 4f8d7f1f46db..f28dc8545b6b 100644
+index afabdbb1a246..d62eef509a22 100644
 --- a/Gemfile
 +++ b/Gemfile
 @@ -1,6 +1,6 @@
@@ -10,7 +10,7 @@ index 4f8d7f1f46db..f28dc8545b6b 100644
  gem "jquery-rails"
  gem "sass-rails", ">= 3.2"
  gem "bootstrap-sass", "~> 3.3.4"
-@@ -60,7 +60,7 @@ def packaging?
+@@ -56,7 +56,7 @@ def packaging?
  end
  
  # If the deployment is done through Puma, include it in the bundle.
@@ -19,7 +19,7 @@ index 4f8d7f1f46db..f28dc8545b6b 100644
  
  # In order to create the Gemfile.lock required for packaging
  # meaning that it should contain only the production packages
-@@ -76,6 +76,7 @@ unless packaging?
+@@ -72,6 +72,7 @@ unless packaging?
      gem "pry-rails"
      gem "git-review", require: false
      gem "rack-mini-profiler", require: false
@@ -27,7 +27,7 @@ index 4f8d7f1f46db..f28dc8545b6b 100644
      gem "guard", require: false
      gem "guard-rubocop", require: false
      gem "guard-rspec", require: false
-@@ -92,7 +93,6 @@ unless packaging?
+@@ -88,7 +89,6 @@ unless packaging?
      gem "factory_girl_rails"
      gem "ffaker"
      gem "rubocop", "~> 0.41.2", require: false
@@ -35,14 +35,14 @@ index 4f8d7f1f46db..f28dc8545b6b 100644
      gem "database_cleaner"
      gem "md2man", "~>5.1.1", require: false
      gem "binman", "~>5.1.0"
-@@ -111,4 +111,5 @@ unless packaging?
+@@ -107,4 +107,5 @@ unless packaging?
      gem "codeclimate-test-reporter", group: :test, require: nil
      gem "docker-api", "~> 1.28.0"
    end
 +
  end
 diff --git a/Gemfile.lock b/Gemfile.lock
-index f9d117a0a6ce..3a85f0811cde 100644
+index 18a78f1291ad..f9ca47cd1950 100644
 --- a/Gemfile.lock
 +++ b/Gemfile.lock
 @@ -1,40 +1,40 @@
@@ -123,16 +123,16 @@ index f9d117a0a6ce..3a85f0811cde 100644
        activesupport (>= 4.1.0)
      gravatar_image_tag (1.2.0)
      guard (2.13.0)
-@@ -169,7 +169,7 @@ GEM
-     jquery-turbolinks (2.1.0)
-       railties (>= 3.1.0)
-       turbolinks
+@@ -166,7 +166,7 @@ GEM
+     jquery-rails (3.1.3)
+       railties (>= 3.0, < 5.0)
+       thor (>= 0.14, < 2.0)
 -    json (1.8.3)
 +    json (1.8.1)
      json-schema (2.5.1)
        addressable (~> 2.3.7)
      jwt (1.5.0)
-@@ -181,28 +181,27 @@ GEM
+@@ -178,28 +178,27 @@ GEM
      listen (3.0.6)
        rb-fsevent (>= 0.9.3)
        rb-inotify (>= 0.9.7)
@@ -171,7 +171,7 @@ index f9d117a0a6ce..3a85f0811cde 100644
      notiffany (0.0.8)
        nenv (~> 0.1)
        shellany (~> 0.0)
-@@ -219,7 +218,7 @@ GEM
+@@ -216,7 +215,7 @@ GEM
        cliver (~> 0.3.1)
        multi_json (~> 1.0)
        websocket-driver (>= 0.2.0)
@@ -180,7 +180,7 @@ index f9d117a0a6ce..3a85f0811cde 100644
      powerpack (0.1.1)
      pry (0.10.1)
        coderay (~> 1.1.0)
-@@ -232,7 +231,7 @@ GEM
+@@ -229,7 +228,7 @@ GEM
        activerecord (>= 3.0)
        i18n (>= 0.5.0)
        railties (>= 3.0.0)
@@ -189,7 +189,7 @@ index f9d117a0a6ce..3a85f0811cde 100644
      pundit (1.0.1)
        activesupport (>= 3.0.0)
      quiet_assets (1.1.0)
-@@ -240,22 +239,22 @@ GEM
+@@ -237,22 +236,22 @@ GEM
      rack (1.6.4)
      rack-mini-profiler (0.9.3)
        rack (>= 1.1.3)
@@ -223,7 +223,7 @@ index f9d117a0a6ce..3a85f0811cde 100644
        activesupport (>= 4.2.0.beta, < 5.0)
        nokogiri (~> 1.6.0)
        rails-deprecated_sanitizer (>= 1.0.1)
-@@ -264,20 +263,20 @@ GEM
+@@ -261,20 +260,20 @@ GEM
        activesupport (>= 3.2)
        choice (~> 0.2.0)
        ruby-graphviz (~> 1.2)
@@ -250,7 +250,7 @@ index f9d117a0a6ce..3a85f0811cde 100644
      responders (2.1.0)
        railties (>= 4.2.0, < 5)
      rouge (1.11.1)
-@@ -345,23 +344,24 @@ GEM
+@@ -342,23 +341,24 @@ GEM
        temple (~> 0.6.6)
        tilt (>= 1.3.3, < 2.1)
      slop (3.6.0)
@@ -277,10 +277,10 @@ index f9d117a0a6ce..3a85f0811cde 100644
 +    treetop (1.4.15)
 +      polyglot
 +      polyglot (>= 0.3.1)
-     turbolinks (2.5.3)
-       coffee-rails
      typhoeus (1.0.2)
-@@ -438,11 +438,11 @@ DEPENDENCIES
+       ethon (>= 0.9.0)
+     tzinfo (1.2.2)
+@@ -432,11 +432,11 @@ DEPENDENCIES
    poltergeist
    pry-rails
    public_activity


### PR DESCRIPTION
It's causing troubles in situations where assets are served by NGinx or
haproxy, and we are not using it anyways. Moreover, this is a first step
if we want to take a look at other frameworks such as React or Vuejs.

Moreover, I've also updated the packaging patch.