### PR TITLE
Rely more on environment variables

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -11,13 +11,9 @@
 # if you're sharing your code publicly.
 
 default: &default
-  secret_key_base: 8bc8ccc710eafd73d43cd59ac8881aadc89f7a6ab55f1ac11c97fb436a3931cc78c38e735e664958d9e793725f3d52178f4e2c376c346edbaca3936aebf66e27
-  <% if ENV["PORTUS_KEY_PATH"] %>
-  encryption_private_key_path: <%= ENV["PORTUS_KEY_PATH"] %>
-  <% else %>
-  encryption_private_key_path: 'vagrant/conf/ca_bundle/server.key'
-  <% end %>
-  portus_password: 'portus1234'
+  secret_key_base:             8bc8ccc710eafd73d43cd59ac8881aadc89f7a6ab55f1ac11c97fb436a3931cc78c38e735e664958d9e793725f3d52178f4e2c376c346edbaca3936aebf66e27
+  encryption_private_key_path: <%= ENV["PORTUS_KEY_PATH"] || "vagrant/conf/ca_bundle/server.key" %>
+  portus_password:             "portus1234"
 
 development:
   <<: *default
@@ -26,17 +22,11 @@ staging:
   <<: *default
 
 test:
-  secret_key_base: 03423ada1c1d3dce1638664c17ad9debe3401fa51ae332ddfe9bc04de70466cf2213c619911c181534d2ba77836c0da50ce7e9748aad7c2e5c40e5b8ddb1d997
-  encryption_private_key_path: 'vagrant/conf/ca_bundle/server.key'
-  portus_password: 'portus1234'
+  <<: *default
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
 production:
-  <% if ENV["PORTUS_SECRET_KEY_BASE"] %>
-  secret_key_base: <%= ENV["PORTUS_SECRET_KEY_BASE"] %>
-  <% else %>
-  secret_key_base: CHANGE_ME
-  <% end %>
+  secret_key_base:             <%= ENV["PORTUS_SECRET_KEY_BASE"] %>
   encryption_private_key_path: <%= ENV["PORTUS_KEY_PATH"] %>
-  portus_password: <%= ENV["PORTUS_PASSWORD"] %>
+  portus_password:             <%= ENV["PORTUS_PASSWORD"] %>

--- a/lib/portus/checks.rb
+++ b/lib/portus/checks.rb
@@ -26,7 +26,7 @@ module Portus
 
       {}.tap do |fix|
         fix[:ssl]                                = check_ssl
-        fix[:secret_key_base]                    = secrets.secret_key_base == "CHANGE_ME"
+        fix[:secret_key_base]                    = secrets.secret_key_base.blank?
         fix[:secret_machine_fqdn]                = APP_CONFIG["machine_fqdn"]["value"].blank?
         fix[:secret_encryption_private_key_path] = secrets.encryption_private_key_path.nil?
         fix[:secret_portus_password]             = secrets.portus_password.nil?

--- a/packaging/suse/portus.spec.in
+++ b/packaging/suse/portus.spec.in
@@ -96,10 +96,6 @@ gem install --no-rdoc --no-ri --install-dir vendor/bundle/ruby/%{rb_ver}/ vendor
 
 rm -rf vendor/cache
 
-# Remove these files, they are going to be created by portusctl setup
-rm config/secrets.yml
-rm config/database.yml
-
 %install
 install -d %{buildroot}/%{portusdir}
 

--- a/packaging/suse/portusctl/lib/configurator.rb
+++ b/packaging/suse/portusctl/lib/configurator.rb
@@ -86,7 +86,8 @@ class Configurator
     Runner.exec("update-ca-certificates")
   end
 
-  # Creates the database.yml file required by Rails
+  # Creates the database.yml file required by Rails. Note that this method will
+  # wipe out any previous contents.
   def database_config
     TemplateWriter.process(
       "database.yml.erb",
@@ -144,10 +145,11 @@ class Configurator
     FileUtils.chmod(0o640, "/srv/Portus/config/config-local.yml")
   end
 
-  # Creates the secrets.yml file used by Rails
+  # Creates the secrets.yml file used by Rails. Note that this method will wipe
+  # out any previous contents.
   def secrets
     destination = "/srv/Portus/config/secrets.yml"
-    return if File.exist?(destination)
+
     TemplateWriter.process(
       "secrets.yml.erb",
       destination,

--- a/spec/controllers/errors_controller_spec.rb
+++ b/spec/controllers/errors_controller_spec.rb
@@ -28,7 +28,7 @@ describe ErrorsController do
       end
 
       it "sets @fix[:secret_key_base] as true" do
-        Rails.application.secrets.secret_key_base = "CHANGE_ME"
+        Rails.application.secrets.secret_key_base = ""
         get :show, id: 1, fixes: true
         expect(assigns(:fix)[:secret_key_base]).to be true
       end


### PR DESCRIPTION
The secrets.yml file will rely more on environment variables, so it's
easier to deploy on Docker images. Morever, the RPM no longer needs to
remove the database.yml and secrets.yml files

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>