### PR TITLE
Autofocus on registrations/new

### DIFF
--- a/app/views/devise/registrations/new.html.slim
+++ b/app/views/devise/registrations/new.html.slim
@@ -5,8 +5,8 @@ section.sign-up class=(@have_users ? '' : 'first-user')
       = render 'shared/notifications'
       = image_tag 'layout/portus-logo-login-page.png', class: 'login-picture'
       = form_for(resource, as: resource_name, url: { action: 'create' }, :html => {:autocomplete => "off"}) do |f|
-        = f.text_field :username, class: 'form-control input-lg', placeholder: 'Username', required: true
-        = f.email_field :email, autofocus: true, class: 'form-control input-lg first', placeholder: 'Email', required: true
+        = f.text_field :username, class: 'form-control input-lg', placeholder: 'Username', required: true, autofocus: true
+        = f.email_field :email, class: 'form-control input-lg first', placeholder: 'Email', required: true
         = f.password_field :password, class: 'form-control input-lg', placeholder: 'Password (8 characters min.)', required: true
         = f.password_field :password_confirmation, class: 'form-control input-lg last', placeholder: 'Password again', required: true
 


### PR DESCRIPTION
After changing the email to become the second field in order, `autofocus` attribute was left there instead of added to the first field.

Signed-off-by: Vítor Avelino <contact@vitoravelino.me>