### PR TITLE
team: description field cleared

### DIFF
--- a/app/assets/javascripts/teams.coffee
+++ b/app/assets/javascripts/teams.coffee
@@ -71,6 +71,7 @@ $(document).ready ->
 
   $('#add_team_btn').on 'click', (event) ->
     $('#team_name').val('')
+    $('#team_description').val('')
     $('#add_team_form').toggle 400, "swing", ->
       if $('#add_team_form').is(':visible')
         $('#add_team_btn i').addClass("fa-minus-circle")


### PR DESCRIPTION
Team description field now being cleared when adding a new team without reloading the page.

If the previous value was left uncleared on purpose, please do not consider this PR. I'm new to the project, just trying to contribute as much as I can. :)

Signed-off-by: Vítor Avelino <contact@vitoravelino.me>