### PR TITLE
Removed unused bootstrap plugins

### DIFF
--- a/app/assets/javascripts/application.coffee
+++ b/app/assets/javascripts/application.coffee
@@ -1,6 +1,9 @@
 #= require jquery
 #= require jquery_ujs
-#= require bootstrap-sprockets
+#= require bootstrap/transition
+#= require bootstrap/tab
+#= require bootstrap/tooltip
+#= require bootstrap/popover
 #= require lifeitup_layout
 #= require bootstrap-typeahead-rails
 #= require_tree .


### PR DESCRIPTION
As you already know. `#= require bootstrap-sprockets` will include [all bootstrap plugins](https://github.com/twbs/bootstrap-sass/blob/master/assets/javascripts/bootstrap-sprockets.js). As far as I could investigate, Portus is using only 3 (tooltip, popover, tab) of them.

Signed-off-by: Vítor Avelino <contact@vitoravelino.me>

**Update:** this one different from the others has testing failing in all environments, so I probably broke something. :sweat_smile: I'll investigate and get back to this.