### PR TITLE
Icon incoherent in teams page on add namespace action button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Improvements and small features
 
 - Update the development environment for docker-compose v2.
+- Fixed icon incoherent in teams page on add namespace action button
 
 ## 2.2.0
 

--- a/app/views/namespaces/create.js.erb
+++ b/app/views/namespaces/create.js.erb
@@ -6,8 +6,8 @@
   $('#float-alert p').html("Namespace '<%= escape_javascript(@namespace.name) %>' was created successfully");
 
   $('#add_namespace_form').fadeOut();
-  $('#add_namespace_btn i').addClass("fa-chevron-down")
-  $('#add_namespace_btn i').removeClass("fa-chevron-up")
+  $('#add_namespace_btn i').addClass("fa-plus-circle")
+  $('#add_namespace_btn i').removeClass("fa-minus-circle")
 
   // Check on which page we are creating the namespace.
   if ($('#namespaces').length > 0) {

--- a/app/views/teams/show.html.slim
+++ b/app/views/teams/show.html.slim
@@ -156,7 +156,7 @@
       .col-sm-6.text-right
         - if can_manage_team?(@team) && Registry.any?
           a#add_namespace_btn.btn.btn-xs.btn-link.js-toggle-button role="button"
-            i.fa.fa-plus
+            i.fa.fa-plus-circle
             | Add namespace
 
   .panel-body

--- a/spec/features/namespaces_spec.rb
+++ b/spec/features/namespaces_spec.rb
@@ -108,6 +108,27 @@ feature "Namespaces support" do
       expect(page).to_not have_css("#add_namespace_btn i.fa-minus-circle")
     end
 
+    scenario 'The "Create new namespace" keeps icon after add new namespace', js: true do
+      visit namespaces_path
+      expect(page).to have_css("#add_namespace_btn i.fa-plus-circle")
+      expect(page).to_not have_css("#add_namespace_btn i.fa-minus-circle")
+
+      find("#add_namespace_btn").click
+      fill_in "Namespace", with: "valid-namespace"
+      fill_in "Team", with: namespace.team.name
+      wait_for_effect_on("#add_namespace_form")
+
+      expect(page).to_not have_css("#add_namespace_btn i.fa-plus-circle")
+      expect(page).to have_css("#add_namespace_btn i.fa-minus-circle")
+
+      click_button "Create"
+      wait_for_ajax
+      wait_for_effect_on("#add_namespace_form")
+
+      expect(page).to have_css("#add_namespace_btn i.fa-plus-circle")
+      expect(page).to_not have_css("#add_namespace_btn i.fa-minus-circle")
+    end
+
     scenario "The namespace visibility can be changed", js: true do
       visit namespaces_path
       id = namespace.id


### PR DESCRIPTION
Changed icon to fa-plus-circle.
After registering a namespace the icon on action maintains behavior.
Added automatic test to validate the behavior.

Signed-off-by: Ricardo Mateus <rjmateus@gmail.com>