### PR TITLE
[packaging] fix portile name/version in patch

### DIFF
--- a/packaging/suse/patches/0_change_versions.gem.patch
+++ b/packaging/suse/patches/0_change_versions.gem.patch
@@ -161,7 +161,7 @@ index 481374c0b290..cf5d577309dc 100644
 -    nokogiri (1.6.7.2)
 -      mini_portile2 (~> 2.0.0.rc2)
 +    nokogiri (1.6.1)
-+      mini_portile2 (~> 0.5.0)
++      mini_portile (~> 0.5.0)
      notiffany (0.0.8)
        nenv (~> 0.1)
        shellany (~> 0.0)


### PR DESCRIPTION
in commit

 79fb15164f32a3da86b39e7a7b2340588830c8c9

portile was renamed to portile2 in the patch, which broke the
Gemfile.lock after applying such patch

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>