### PR TITLE
Fix check for missing digest in id_and_digest_from_event

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -160,7 +160,7 @@ class Repository < ActiveRecord::Base
     digest = event.try(:[], "target").try(:[], "digest")
     id = ""
 
-    unless digest.blank?
+    if digest.blank?
       begin
         id, = Registry.get.client.manifest(repo, digest)
       rescue StandardError => e


### PR DESCRIPTION
The check for blank digest was wrong. It has to execute the manifest
fetching in case it is blank and not when it is not blank.