### PR TITLE
Honor external_hostname in token generation

### DIFF
--- a/app/controllers/api/v2/tokens_controller.rb
+++ b/app/controllers/api/v2/tokens_controller.rb
@@ -22,6 +22,10 @@ class Api::V2::TokensController < Api::BaseController
   def show
     authenticate_user! if request.headers["Authorization"]
     registry = Registry.find_by(hostname: params[:service])
+    if registry.nil?
+      logger.debug("No hostname matching #{params[:service]}, testing external_hostname")
+      registry = Registry.find_by(external_hostname: params[:service])
+    end
 
     auth_scopes = []
     auth_scopes = authorize_scopes(registry) unless registry.nil?

--- a/app/models/registry/auth_scope.rb
+++ b/app/models/registry/auth_scope.rb
@@ -3,6 +3,10 @@
 class Registry::AuthScope < Portus::AuthScope
   def resource
     reg = Registry.find_by(hostname: @registry.hostname)
+    if reg.nil?
+      Rails.logger.debug("No hostname matching #{@registry.hostname}, testing external_hostname")
+      reg = Registry.find_by(external_hostname: @registry.hostname)
+    end
     raise ResourceNotFound, "Could not find registry #{@registry.hostname}" if reg.nil?
     reg
   end


### PR DESCRIPTION
Otherwise token generation may fail in some cases.