### PR TITLE
models: added the `find_by_hostname` method

### DIFF
--- a/app/controllers/api/v2/tokens_controller.rb
+++ b/app/controllers/api/v2/tokens_controller.rb
@@ -21,11 +21,7 @@ class Api::V2::TokensController < Api::BaseController
   # operation into the private registry.
   def show
     authenticate_user! if request.headers["Authorization"]
-    registry = Registry.find_by(hostname: params[:service])
-    if registry.nil?
-      logger.debug("No hostname matching #{params[:service]}, testing external_hostname")
-      registry = Registry.find_by(external_hostname: params[:service])
-    end
+    registry = Registry.find_by_hostname(params[:service])
 
     auth_scopes = []
     auth_scopes = authorize_scopes(registry) unless registry.nil?

--- a/app/models/registry.rb
+++ b/app/models/registry.rb
@@ -40,6 +40,17 @@ class Registry < ActiveRecord::Base
     Registry.first
   end
 
+  # Finds the registry with the given hostname. It first looks for the
+  # `hostname` column, and then it fallbacks to `external_hostname`.
+  def self.find_by_hostname(hostname)
+    registry = Registry.find_by(hostname: hostname)
+    if registry.nil?
+      Rails.logger.debug("No hostname matching `#{hostname}', testing external_hostname")
+      registry = Registry.find_by(external_hostname: hostname)
+    end
+    registry
+  end
+
   # Returns the global namespace owned by this registry.
   def global_namespace
     Namespace.find_by(registry: self, global: true)

--- a/app/models/registry/auth_scope.rb
+++ b/app/models/registry/auth_scope.rb
@@ -2,11 +2,7 @@
 # the "registry" type.
 class Registry::AuthScope < Portus::AuthScope
   def resource
-    reg = Registry.find_by(hostname: @registry.hostname)
-    if reg.nil?
-      Rails.logger.debug("No hostname matching #{@registry.hostname}, testing external_hostname")
-      reg = Registry.find_by(external_hostname: @registry.hostname)
-    end
+    reg = Registry.find_by_hostname(@registry.hostname)
     raise ResourceNotFound, "Could not find registry #{@registry.hostname}" if reg.nil?
     reg
   end


### PR DESCRIPTION
This method is similar to Registry.find_by(hostname ...) but it also
fall backs to the external hostname column.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>