### PR TITLE
Added support for Ruby 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,19 +3,24 @@ rvm:
   # The version used at SLE12
   - 2.1.2
 
-  # The version used at openSUSE 13.2
-  - 2.1.3
-
-  # Other Ruby Versions
+  # Stable versions
   - 2.1.10
-  - 2.2.5
-  - 2.3.1
+  - 2.2.6
+  - 2.3.3
+  - 2.4.0
 
   # Future versions
   - ruby-head
 matrix:
   allow_failures:
     - rvm: ruby-head
+
+# Cache some directories and dependencies
+cache:
+  bundler: true
+  directories:
+    - node_modules
+    - $HOME/.nvm
 
 before_install:
   - gem update --system

--- a/Gemfile
+++ b/Gemfile
@@ -96,7 +96,7 @@ unless packaging?
   group :test do
     gem "shoulda"
     gem "vcr"
-    gem "webmock", require: false
+    gem "webmock", "~> 2.3.2", require: false
     gem "simplecov", require: false
     gem "capybara"
     gem "poltergeist", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,7 +43,7 @@ GEM
     annotate (2.6.5)
       activerecord (>= 2.3.0)
       rake (>= 0.8.7)
-    arel (6.0.3)
+    arel (6.0.4)
     ast (2.3.0)
     autoprefixer-rails (5.2.0.1)
       execjs
@@ -148,6 +148,7 @@ GEM
       rubocop (~> 0.20)
     haml (4.0.7)
       tilt
+    hashdiff (0.3.2)
     hashie (3.4.2)
     highline (1.7.8)
     hike (1.2.3)
@@ -355,7 +356,7 @@ GEM
       json (>= 1.8.0)
     unicode-display_width (1.1.0)
     uri_template (0.5.3)
-    vcr (2.9.3)
+    vcr (3.0.3)
     warden (1.2.3)
       rack (>= 1.0)
     web-console (2.1.3)
@@ -363,10 +364,11 @@ GEM
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)
       sprockets-rails (>= 2.0, < 4.0)
-    webmock (1.21.0)
+    webmock (2.3.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
     webpack-rails (0.9.10)
+      hashdiff
       railties (>= 3.2.0)
     websocket-driver (0.5.4)
       websocket-extensions (>= 0.1.0)
@@ -376,7 +378,7 @@ GEM
     wirble (0.1.3)
     xpath (2.0.0)
       nokogiri (~> 1.3)
-    yajl-ruby (1.2.1)
+    yajl-ruby (1.3.0)
 
 PLATFORMS
   ruby
@@ -440,7 +442,7 @@ DEPENDENCIES
   uglifier
   vcr
   web-console (~> 2.1.3)
-  webmock
+  webmock (~> 2.3.2)
   webpack-rails
   wirb
   wirble

--- a/lib/portus/registry_client.rb
+++ b/lib/portus/registry_client.rb
@@ -6,6 +6,10 @@ module Portus
   class RegistryClient
     include HttpHelpers
 
+    # Exception being raised when we get an error from the Registry API that we
+    # don't know how to handle.
+    class RegistryError < StandardError; end
+
     # Initialize the client by setting up a hostname and the user. Note that if
     # no user was given, the "portus" special user is assumed.
     def initialize(host, use_ssl = false, username = nil, password = nil)
@@ -82,7 +86,8 @@ module Portus
       elsif res.code.to_i == 404 || res.code.to_i == 405
         handle_error res, name: name, digest: digest
       else
-        raise "Something went wrong while deleting blob: " \
+        raise ::Portus::RegistryClient::RegistryError,
+          "Something went wrong while deleting blob: " \
           "[#{res.code}] - #{res.body}"
       end
     end
@@ -116,7 +121,8 @@ module Portus
       elsif res.code.to_i == 404
         handle_error res
       else
-        raise "Something went wrong while fetching the catalog " \
+        raise ::Portus::RegistryClient::RegistryError,
+          "Something went wrong while fetching the catalog " \
           "Response: [#{res.code}] - #{res.body}"
       end
     end

--- a/packaging/suse/patches/0_change_versions.gem.patch
+++ b/packaging/suse/patches/0_change_versions.gem.patch
@@ -1,5 +1,5 @@
 diff --git a/Gemfile b/Gemfile
-index 5548863a624e..3bc8dcf90690 100644
+index 3bd983744bfc..2ba818fcf484 100644
 --- a/Gemfile
 +++ b/Gemfile
 @@ -1,6 +1,6 @@
@@ -36,7 +36,7 @@ index 5548863a624e..3bc8dcf90690 100644
      gem "md2man", "~>5.1.1", require: false
      gem "binman", "~>5.1.0"
 diff --git a/Gemfile.lock b/Gemfile.lock
-index 7211c46565a7..3d4b4da1735f 100644
+index 3f7dcc13cf3f..a3696ac81433 100644
 --- a/Gemfile.lock
 +++ b/Gemfile.lock
 @@ -1,40 +1,40 @@
@@ -103,7 +103,7 @@ index 7211c46565a7..3d4b4da1735f 100644
      annotate (2.6.5)
        activerecord (>= 2.3.0)
        rake (>= 0.8.7)
--    arel (6.0.3)
+-    arel (6.0.4)
 +    arel (6.0.0)
      ast (2.3.0)
      autoprefixer-rails (5.2.0.1)
@@ -117,7 +117,7 @@ index 7211c46565a7..3d4b4da1735f 100644
        activesupport (>= 4.1.0)
      gravatar_image_tag (1.2.0)
      guard (2.13.0)
-@@ -165,28 +165,27 @@ GEM
+@@ -166,28 +166,27 @@ GEM
      listen (3.0.6)
        rb-fsevent (>= 0.9.3)
        rb-inotify (>= 0.9.7)
@@ -156,7 +156,7 @@ index 7211c46565a7..3d4b4da1735f 100644
      notiffany (0.0.8)
        nenv (~> 0.1)
        shellany (~> 0.0)
-@@ -203,7 +202,7 @@ GEM
+@@ -204,7 +203,7 @@ GEM
        cliver (~> 0.3.1)
        multi_json (~> 1.0)
        websocket-driver (>= 0.2.0)
@@ -165,7 +165,7 @@ index 7211c46565a7..3d4b4da1735f 100644
      powerpack (0.1.1)
      pry (0.10.1)
        coderay (~> 1.1.0)
-@@ -216,7 +215,7 @@ GEM
+@@ -217,7 +216,7 @@ GEM
        activerecord (>= 3.0)
        i18n (>= 0.5.0)
        railties (>= 3.0.0)
@@ -174,7 +174,7 @@ index 7211c46565a7..3d4b4da1735f 100644
      pundit (1.0.1)
        activesupport (>= 3.0.0)
      quiet_assets (1.1.0)
-@@ -224,22 +223,22 @@ GEM
+@@ -225,22 +224,22 @@ GEM
      rack (1.6.4)
      rack-mini-profiler (0.9.3)
        rack (>= 1.1.3)
@@ -208,7 +208,7 @@ index 7211c46565a7..3d4b4da1735f 100644
        activesupport (>= 4.2.0.beta, < 5.0)
        nokogiri (~> 1.6.0)
        rails-deprecated_sanitizer (>= 1.0.1)
-@@ -248,20 +247,20 @@ GEM
+@@ -249,20 +248,20 @@ GEM
        activesupport (>= 3.2)
        choice (~> 0.2.0)
        ruby-graphviz (~> 1.2)
@@ -235,7 +235,7 @@ index 7211c46565a7..3d4b4da1735f 100644
      responders (2.1.0)
        railties (>= 4.2.0, < 5)
      rouge (1.11.1)
-@@ -329,23 +328,24 @@ GEM
+@@ -330,23 +329,24 @@ GEM
        temple (~> 0.6.6)
        tilt (>= 1.3.3, < 2.1)
      slop (3.6.0)
@@ -265,7 +265,7 @@ index 7211c46565a7..3d4b4da1735f 100644
      typhoeus (1.0.2)
        ethon (>= 0.9.0)
      tzinfo (1.2.2)
-@@ -418,11 +418,11 @@ DEPENDENCIES
+@@ -420,11 +420,11 @@ DEPENDENCIES
    poltergeist
    pry-rails
    public_activity

--- a/spec/lib/portus/registry_client_spec.rb
+++ b/spec/lib/portus/registry_client_spec.rb
@@ -120,8 +120,8 @@ describe Portus::RegistryClient do
       begin
         VCR.turned_off do
           WebMock.disable_net_connect!
-          auth = "service=foo,Bearer realm=http://bar.test.lan/token"
-          url  = "http://flavio:this%20is%20a%20test@bar.test.lan/token?account=flavio&service=foo"
+          auth = "service=foo,Bearer realm=http://portus.test.lan/token"
+          url  = "http://portus.test.lan/token?account=flavio&service=foo"
 
           stub_request(:get, "http://#{registry_server}/v2/")
             .to_return(headers: { "www-authenticate" => auth }, status: 401)
@@ -347,7 +347,7 @@ describe Portus::RegistryClient do
 
           expect do
             registry.catalog
-          end.to raise_error(RuntimeError)
+          end.to raise_error(::Portus::RegistryClient::RegistryError)
         end
       ensure
         WebMock.allow_net_connect!
@@ -441,7 +441,7 @@ describe Portus::RegistryClient do
         expect do
           registry.delete("busybox",
                           "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4")
-        end.to raise_error StandardError
+        end.to raise_error ::Portus::RegistryClient::RegistryError
       end
     end
   end

--- a/spec/vcr_cassettes/registry/delete_blob.yml
+++ b/spec/vcr_cassettes/registry/delete_blob.yml
@@ -38,7 +38,7 @@ http_interactions:
   recorded_at: Thu, 13 Aug 2015 11:34:14 GMT
 - request:
     method: get
-    uri: http://portus:portus1234@portus.test.lan/v2/token?account=portus&scope=repository:busybox:pull&service=registry.test.lan
+    uri: http://portus.test.lan/v2/token?account=portus&scope=repository:busybox:pull&service=registry.test.lan
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/registry/delete_disabled.yml
+++ b/spec/vcr_cassettes/registry/delete_disabled.yml
@@ -38,7 +38,7 @@ http_interactions:
   recorded_at: Thu, 13 Aug 2015 11:34:14 GMT
 - request:
     method: get
-    uri: http://portus:portus1234@portus.test.lan/v2/token?account=portus&scope=repository:busybox:pull&service=registry.test.lan
+    uri: http://portus.test.lan/v2/token?account=portus&scope=repository:busybox:pull&service=registry.test.lan
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/registry/delete_missing_blob.yml
+++ b/spec/vcr_cassettes/registry/delete_missing_blob.yml
@@ -38,7 +38,7 @@ http_interactions:
   recorded_at: Thu, 13 Aug 2015 11:34:14 GMT
 - request:
     method: get
-    uri: http://portus:portus1234@portus.test.lan/v2/token?account=portus&scope=repository:busybox:pull&service=registry.test.lan
+    uri: http://portus.test.lan/v2/token?account=portus&scope=repository:busybox:pull&service=registry.test.lan
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/registry/get_image_manifest.yml
+++ b/spec/vcr_cassettes/registry/get_image_manifest.yml
@@ -38,7 +38,7 @@ http_interactions:
   recorded_at: Mon, 20 Apr 2015 10:06:19 GMT
 - request:
     method: get
-    uri: http://flavio:this%20is%20a%20test@portus.test.lan/v2/token?account=flavio&scope=repository:foo/busybox:pull&service=registry.test.lan
+    uri: http://portus.test.lan/v2/token?account=flavio&scope=repository:foo/busybox:pull&service=registry.test.lan
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/registry/get_missing_image_manifest.yml
+++ b/spec/vcr_cassettes/registry/get_missing_image_manifest.yml
@@ -38,7 +38,7 @@ http_interactions:
   recorded_at: Mon, 20 Apr 2015 10:11:01 GMT
 - request:
     method: get
-    uri: http://flavio:this%20is%20a%20test@portus.test.lan/v2/token?account=flavio&scope=repository:foo/busybox:pull&service=registry.test.lan
+    uri: http://portus.test.lan/v2/token?account=flavio&scope=repository:foo/busybox:pull&service=registry.test.lan
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/registry/invalid_delete_blob.yml
+++ b/spec/vcr_cassettes/registry/invalid_delete_blob.yml
@@ -38,7 +38,7 @@ http_interactions:
   recorded_at: Thu, 13 Aug 2015 11:34:14 GMT
 - request:
     method: get
-    uri: http://portus:portus1234@portus.test.lan/v2/token?account=portus&scope=repository:busybox:pull&service=registry.test.lan
+    uri: http://portus.test.lan/v2/token?account=portus&scope=repository:busybox:pull&service=registry.test.lan
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/registry/successful_authentication.yml
+++ b/spec/vcr_cassettes/registry/successful_authentication.yml
@@ -34,11 +34,11 @@ http_interactions:
       encoding: UTF-8
       string: |
         {"errors":[{"code":"UNAUTHORIZED","message":"access to the requested resource is not authorized","detail":null}]}
-    http_version: 
+    http_version:
   recorded_at: Mon, 20 Apr 2015 09:44:11 GMT
 - request:
     method: get
-    uri: http://flavio:this%20is%20a%20test@portus.test.lan/v2/token?account=flavio&service=registry.test.lan
+    uri: http://portus.test.lan/v2/token?account=flavio&service=registry.test.lan
     body:
       encoding: US-ASCII
       string: ''
@@ -90,7 +90,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlBUV1Q6Rk5KRTo3VFc3OlVMSTc6RFpRQTpKSkpJOlJESlE6Mk03NjpIRDZHOlpSU0M6VlBJRjpPNUJVIn0.eyJpc3MiOiJwb3J0dXMudGVzdC5sYW4iLCJzdWIiOiJmbGF2aW8iLCJhdWQiOiJyZWdpc3RyeS50ZXN0LmxhbiIsImV4cCI6MTQyOTUyMzM1MiwibmJmIjoxNDI5NTIzMDUyLCJpYXQiOjE0Mjk1MjMwNTIsImp0aSI6Inc4YnRUaUVTaDN4TWNYdU5YWlBtZWE5cXRhZWdzRVNOUG9BaFZMNHl3RyJ9.krXq32ehbyly6BXr5sQUwKbvzvY7eyt8Vj3odwffWp7bO-Ysl7Whv0LJcENSw-BStgkiwKPlkMX4oUhQAa0r8EHkDjgJJ2lZWDEsyz5XIoBX2MsNGR4sZLs-gvNTw0X5Pugt2KGlCUbxxxOavSgBiKZmGKh3jvZQdQekKjo8wZUsTCLpMP0efj6LNvNcc3Vb_9Fw7mV3G4TLdopajVX3h2SMNZerOb3KLzjtOmnsV3dqTI69cXRFzCj4Jt7uSq2TsETbx2__UkY0EObuY6_jS0QqDqHpVRxhpZeJRw1pSngZJ6P2mh4iFg-Uhpl2qrF4c3aEbgIW50F9gIkBySY9o77TweagDjIaTy7E9nGRwJToVT8dY-Nm6X7--AFDEQk_VH3IJro8_yx88yR44RPRmh4aEiF6WCQAo87v6YJmMICotBQnUxtRyiwGcAhrbfEI5FuYOZ52_dqJyCOfKOnvqguau_Nv4_85xIzAV4gZaKs0s3qMYuVfcxQDWmqIp1jy7HOH9vQST-GLaa--boX_5am6qjOopLFVXj108FS-moOu9SIOPqRDqF0ZpVDlBsHXviqdPOaItwhh0z4IkfHv1Ngq8EdyWT2-AqZ7W410knA_nOX2jzPreJFbWYVQYhdxQceT9tD4mbePg1qlGY1SGH8NqqI8CHjmuezIo1SLijY"}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 20 Apr 2015 09:44:12 GMT
 - request:
     method: get
@@ -125,6 +125,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "{}"
-    http_version: 
+    http_version:
   recorded_at: Mon, 20 Apr 2015 09:44:12 GMT
 recorded_with: VCR 2.9.3

--- a/spec/vcr_cassettes/registry/wrong_authentication.yml
+++ b/spec/vcr_cassettes/registry/wrong_authentication.yml
@@ -34,11 +34,11 @@ http_interactions:
       encoding: UTF-8
       string: |
         {"errors":[{"code":"UNAUTHORIZED","message":"access to the requested resource is not authorized","detail":null}]}
-    http_version: 
+    http_version:
   recorded_at: Mon, 20 Apr 2015 09:49:56 GMT
 - request:
     method: get
-    uri: http://flavio:wrong%20password@portus.test.lan/v2/token?account=flavio&service=registry.test.lan
+    uri: http://portus.test.lan/v2/token?account=flavio&service=registry.test.lan
     body:
       encoding: US-ASCII
       string: ''
@@ -87,6 +87,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"error":"Invalid username or password."}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 20 Apr 2015 09:49:57 GMT
 recorded_with: VCR 2.9.3


### PR DESCRIPTION
- The arel and json gems needed to be upgraded, otherwise some pages
  were utterly broken.
- VCRs were broken, and previous versions didn't catch that.
- Some gems related to testing had to be upgraded (e.g. vcr)
- I've added a `cache` section in the travis file to speed things up,
  and I've updated the rubies being used to the latest stable releases.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>