### PR TITLE
packaging: upload the node_modules when needed

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -6,8 +6,8 @@ namespace :portus do
     task :available do
       unless system("yarn --version", out: File::NULL)
         warn(
-          "Error: Yarn executable was not detected in the system.".color(:red),
-          "Download Yarn at https://yarnpkg.com/en/docs/install".color(:green)
+          "Error: Yarn executable was not detected in the system.",
+          "Download Yarn at https://yarnpkg.com/en/docs/install"
         )
         abort
       end
@@ -20,8 +20,8 @@ namespace :portus do
 
       unless system(cmd, out: File::NULL)
         warn(
-          "Error: You have unmet dependencies. (`yarn check` command failed)".color(:red),
-          "Run `yarn install` to install missing modules.".color(:green)
+          "Error: You have unmet dependencies. (`yarn check` command failed)",
+          "Run `yarn install` to install missing modules."
         )
         abort
       end

--- a/packaging/suse/package_and_push_to_obs.sh
+++ b/packaging/suse/package_and_push_to_obs.sh
@@ -9,12 +9,21 @@
 # The other ones are set per project basis by the user in travis. See:
 # http://docs.travis-ci.com/user/environment-variables/#Using-Settings
 
-if [ $TRAVIS_PULL_REQUEST == "false" ] && [ $OBS_BRANCH ] && [ $TRAVIS_COMMIT ] && [ $OSC_CREDENTIALS ] && [ $OBS_REPO ] && [ $TRAVIS_BRANCH == $OBS_BRANCH ];then 
+if [ $TRAVIS_PULL_REQUEST == "false" ] && [ $OBS_BRANCH ] && [ $TRAVIS_COMMIT ] && [ $OSC_CREDENTIALS ] && [ $OBS_REPO ] && [ $TRAVIS_BRANCH == $OBS_BRANCH ];then
   packaging/suse/make_spec.sh portus
   curl -X PUT -T packaging/suse/portus.spec -u $OSC_CREDENTIALS https://api.opensuse.org/source/$OBS_REPO/portus/portus.spec?comment=update_portus.spec\_to_commit_$TRAVIS_COMMIT\_from_branch_$OBS_BRANCH
   for p in packaging/suse/patches/*.patch;do
       curl -X PUT -T $p -u $OSC_CREDENTIALS https://api.opensuse.org/source/$OBS_REPO/portus/$(basename $p)?comment=update_patches\_to_commit_$TRAVIS_COMMIT\_from_branch_$OBS_BRANCH
   done
+
+  # Get the yarn.lock file from OBS and compare it. If they differ, then push a
+  # new node_modules.tar.gz file.
+  curl -u $OSC_CREDENTIALS https://api.opensuse.org/source/$OBS_REPO/portus/yarn.lock > obs-yarn.lock
+  if ! diff -q yarn.lock obs-yarn.lock &>/dev/null; then
+      tar czvf node_modules.tar.gz node_modules
+      curl -X PUT -T node_modules.tar.gz -u $OSC_CREDENTIALS https://api.opensuse.org/source/$OBS_REPO/portus/node_modules.tar.gz?comment=update_node_modules.tar.gz\_to_commit_$TRAVIS_COMMIT\_from_branch_$OBS_BRANCH
+      curl -X PUT -T yarn.lock -u $OSC_CREDENTIALS https://api.opensuse.org/source/$OBS_REPO/portus/yarn.lock?comment=update_yarn.lock\_to_commit_$TRAVIS_COMMIT\_from_branch_$OBS_BRANCH
+  fi
 else
   echo "Didn't package nor commit to obs"
   echo "Reasons"
@@ -38,4 +47,3 @@ else
   fi
   exit -1
 fi
-


### PR DESCRIPTION
The node_modules.tar.gz file, even if compressed, is quite heavy and we
don't want to put this burden into our CI process. For this, we will
have to upload the latest yarn.lock file in OBS as well.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>