### PR TITLE
Mute crono unhandled pull events. Closes #1263

### DIFF
--- a/lib/portus/registry_notification.rb
+++ b/lib/portus/registry_notification.rb
@@ -11,7 +11,14 @@ module Portus
     # object, which is the event object as given by the registry.
     def self.process!(data, *handlers)
       data["events"].each do |event|
-        Rails.logger.debug "Incoming event:\n#{JSON.pretty_generate(event)}"
+        if event["action"] == "pull" && event["request"]["useragent"] == "Ruby" &&
+            event["actor"]["name"] == "portus"
+          Rails.logger.tagged("crono", "catalog_pull") do
+            Rails.logger.debug event["target"]["url"]
+          end
+        else
+          Rails.logger.debug "Incoming event:\n#{JSON.pretty_generate(event)}"
+        end
 
         next unless should_handle?(event)
         action = event["action"]

--- a/spec/lib/portus/registry_notification_spec.rb
+++ b/spec/lib/portus/registry_notification_spec.rb
@@ -4,12 +4,24 @@ describe Portus::RegistryNotification do
   let(:body) do
     {
       "events" => [
-        { "action" => "push" },
-        { "action" => "push", "target" => { "mediaType" => "some" } },
         {
-          "action" => "pull", "target" => {
+          "action" => "push",
+          "request"   => {},
+          "actor"     => {}
+        },
+        {
+          "action" => "push",
+          "target" => { "mediaType" => "some" },
+          "request"   => {},
+          "actor"     => {}
+        },
+        {
+          "action" => "pull",
+          "target" => {
             "mediaType" => "application/vnd.docker.distribution.manifest.v1+json"
-          }
+          },
+          "request"   => {},
+          "actor"     => {}
         }
       ]
     }
@@ -23,6 +35,16 @@ describe Portus::RegistryNotification do
         "digest"     => "sha256:1977980aad73e19f918c676de1860b0ee56167b07c20641ecda3f9d74b69627d",
         "repository" => "mssola/busybox",
         "url"        => "http://registry.test.lan/v2/mssola/busybox/manifests/sha256:1977980aad7"
+      },
+      "request"   => {
+        "id"        => "e30471d8-39c3-41c0-abc2-775ed43e81c9",
+        "addr"      => "127.0.0.1:54032",
+        "host"      => "registry.mssola.cat:5000",
+        "method"    => "PUT",
+        "useragent" => "docker/1.9.1 go/go1.5.2 git-commit/a34a1d5 kernel/4.4.0-1-default os/linux arch/amd64"
+      },
+      "actor"     => {
+        "name" => "mssola"
       }
     }
   end

--- a/spec/lib/portus/registry_notification_spec.rb
+++ b/spec/lib/portus/registry_notification_spec.rb
@@ -5,23 +5,23 @@ describe Portus::RegistryNotification do
     {
       "events" => [
         {
-          "action" => "push",
-          "request"   => {},
-          "actor"     => {}
+          "action"  => "push",
+          "request" => {},
+          "actor"   => {}
         },
         {
-          "action" => "push",
-          "target" => { "mediaType" => "some" },
-          "request"   => {},
-          "actor"     => {}
+          "action"  => "push",
+          "target"  => { "mediaType" => "some" },
+          "request" => {},
+          "actor"   => {}
         },
         {
-          "action" => "pull",
-          "target" => {
+          "action"  => "pull",
+          "target"  => {
             "mediaType" => "application/vnd.docker.distribution.manifest.v1+json"
           },
-          "request"   => {},
-          "actor"     => {}
+          "request" => {},
+          "actor"   => {}
         }
       ]
     }
@@ -29,21 +29,21 @@ describe Portus::RegistryNotification do
 
   let(:relevant) do
     {
-      "action" => "push",
-      "target" => {
+      "action"  => "push",
+      "target"  => {
         "mediaType"  => "application/vnd.docker.distribution.manifest.v1+json",
         "digest"     => "sha256:1977980aad73e19f918c676de1860b0ee56167b07c20641ecda3f9d74b69627d",
         "repository" => "mssola/busybox",
         "url"        => "http://registry.test.lan/v2/mssola/busybox/manifests/sha256:1977980aad7"
       },
-      "request"   => {
+      "request" => {
         "id"        => "e30471d8-39c3-41c0-abc2-775ed43e81c9",
         "addr"      => "127.0.0.1:54032",
         "host"      => "registry.mssola.cat:5000",
         "method"    => "PUT",
-        "useragent" => "docker/1.9.1 go/go1.5.2 git-commit/a34a1d5 kernel/4.4.0-1-default os/linux arch/amd64"
+        "useragent" => "docker/1.9.1 go/go1.5.2 git-commit/a34a1d5 kernel/4.4.0-1-default"
       },
-      "actor"     => {
+      "actor"   => {
         "name" => "mssola"
       }
     }


### PR DESCRIPTION
Crono triggers a pull event for each repo and tag every time it runs.
Displaying the full event here generates more output in the log file
than anything else.

Signed-off-by: Hart Simha <hart.simha@suse.com>