### PR TITLE
Fix dashboard sidebar links

### DIFF
--- a/app/assets/javascripts/dashboard.js
+++ b/app/assets/javascripts/dashboard.js
@@ -1,15 +1,5 @@
 jQuery(function ($) {
-  $('#starred a').on('click', function (e) {
-    e.preventDefault();
-    $(this).tab('show');
-  });
-
-  $('#all a').on('click', function (e) {
-    e.preventDefault();
-    $(this).tab('show');
-  });
-
-  $('#personal a').on('click', function (e) {
+  $('#sidebar-tabs a').on('click', function (e) {
     e.preventDefault();
     $(this).tab('show');
   });

--- a/app/views/dashboard/index.html.slim
+++ b/app/views/dashboard/index.html.slim
@@ -12,7 +12,7 @@
       .panel-heading
         h5 Repositories
 
-        ul.nav.nav-tabs{role="tablist"}
+        ul#sidebar-tabs.nav.nav-tabs{role="tablist"}
           li.active{role="presentation"}
             a{href="#all" aria-controls="all" role="tab" data-toggle="tab"} All
           li{role="presentation"}


### PR DESCRIPTION
Added an ID to the dashboard sidebar tabs header and modified dashboard.js to select all of tab links based on their relationship to this ID, as in the example at http://getbootstrap.com/javascript/#tabs-examples.

This closes #1265 

Note: Since we are not cache-busting our webpack assets in development, this fix may only be evident if one's browser has been configured to not load assets from its cache, or if the webpack bundle is force reloaded via a hard reload of $PORTUS_ROOT_URL/assets/webpack/application.js

Signed-off-by: Hart Simha <hart.simha@suse.com>