### PR TITLE
Portus now reads the TZ env variable to display dates correctly

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -14,7 +14,7 @@ module Portus
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-    # config.time_zone = 'Central Time (US & Canada)'
+    config.time_zone = ENV["TZ"] || "UTC"
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]


### PR DESCRIPTION
Portus Currently displays all date/time in UTC, with this change, if the TZ environment variable is present the dates are displayed in this timezone, else they are displayed as UTC.

Signed-off-by: Yann Lopez <l@lonewulf.net>