### PR TITLE
Watch front-end assets from 'web' container. Closes #1245

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ EXPOSE 3000
 WORKDIR /portus
 COPY Gemfile* ./
 RUN bundle install --retry=3 && bundle binstubs phantomjs
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends nodejs
-
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo "deb http://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list && \
+    curl -sL https://deb.nodesource.com/setup_6.x | bash - && \
+    apt-get install -y --no-install-recommends nodejs yarn
 ADD . .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 services:
   web:
     build: .
-    command: pumactl -F /portus/config/puma.rb start
+    command: bash -c "yarn && yarn run webpack --watch --config /portus/config/webpack & pumactl -F /portus/config/puma.rb start"
     environment:
       - PORTUS_MACHINE_FQDN_VALUE=${EXTERNAL_IP}
       - PORTUS_DB_HOST=db


### PR DESCRIPTION
This PR makes the docker-compose deployment build the front-end assets in the web container. Users running Portus for the first time may still hit  #1245 if they attempt to visit the web console before the yarn dependency installation and webpack asset build have completed (this usually takes a few seconds). Once these have completed, the web console will start working, and webpack will pick up any further changes the user makes.

These changes affect the docker-compose deployment only.