### PR TITLE
ldap: avoid clashes on emails

### DIFF
--- a/lib/portus/ldap.rb
+++ b/lib/portus/ldap.rb
@@ -168,9 +168,12 @@ module Portus
 
       # The user does not exist in Portus yet, let's create it.
       unless user
+        em = guess_email
+        em = nil if User.exists?(email: em)
+
         user = User.create(
           username: username,
-          email:    guess_email,
+          email:    em,
           password: password,
           admin:    !User.not_portus.any?
         )


### PR DESCRIPTION
When creating users on LDAP, make sure that the email won't clash. If
that was to happen, then set the email to nil so the user has to enter
the email manually.

Fixes #1302

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>