### PR TITLE
compose: Try to fix dependencies on services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '2'
 services:
   portus:
     build: .
+    image: opensuse/portus:development
     command: bash /srv/Portus/examples/development/compose/init
     environment:
       - PORTUS_MACHINE_FQDN_VALUE=${MACHINE_FQDN}
@@ -20,8 +21,10 @@ services:
       - .:/srv/Portus
 
   crono:
-    image: portus_portus
+    image: opensuse/portus:development
     command: ./bin/crono
+    depends_on:
+      - portus
     environment:
       - PORTUS_MACHINE_FQDN_VALUE=${MACHINE_FQDN}
 


### PR DESCRIPTION
The name has been changed to a proper one (by taking the official
docker image as a reference), and a `depends_on` has been added, since
the crono service needs the image built in the portus service.

See #1313

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>