### PR TITLE
Improved testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,34 @@
 language: ruby
+sudo: required
+dist: trusty
 rvm:
   # The version used at SLE12
   - 2.1.2
 
   # Stable versions
-  - 2.1.10
-  - 2.2.6
-  - 2.3.3
-  - 2.4.0
+  - 2.2.7
+  - 2.3.4
+  - 2.4.1
 
   # Future versions
   - ruby-head
+
 matrix:
   allow_failures:
     - rvm: ruby-head
 
+cache:
+  bundler: true
+  directories:
+    - $PWD/travis_phantomjs
+
 before_install:
-  - gem update --system
+  - phantomjs --version
+  - export PATH=$PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH
+  - if [ $(phantomjs --version) != '2.1.1' ]; then rm -rf $PWD/travis_phantomjs; mkdir -p $PWD/travis_phantomjs; fi
+  - if [ $(phantomjs --version) != '2.1.1' ]; then wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2; fi
+  - if [ $(phantomjs --version) != '2.1.1' ]; then tar -xvf $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis_phantomjs; fi
+  - phantomjs --version
 
   # Use the latest stable Node.js
   - nvm install stable

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ EXPOSE 3000
 
 WORKDIR /srv/Portus
 COPY Gemfile* ./
-RUN bundle install --retry=3 && bundle binstubs phantomjs
+RUN bundle install --retry=3
 RUN apt-get update && \
     apt-get install -y --no-install-recommends nodejs
 

--- a/Gemfile
+++ b/Gemfile
@@ -88,7 +88,6 @@ unless packaging?
     gem "database_cleaner"
     gem "md2man", "~>5.1.1", require: false
     gem "binman", "~>5.1.0"
-    gem "phantomjs", "~> 2.1.1.0"
   end
 
   group :test do
@@ -96,8 +95,8 @@ unless packaging?
     gem "vcr"
     gem "webmock", "~> 2.3.2", require: false
     gem "simplecov", require: false
-    gem "capybara"
-    gem "poltergeist", require: false
+    gem "capybara", "~> 2.14.3"
+    gem "poltergeist", "~> 1.15.0", require: false
     gem "json-schema"
     gem "timecop"
     gem "codeclimate-test-reporter", group: :test, require: nil

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,7 +71,8 @@ GEM
     builder (3.2.2)
     byebug (5.0.0)
       columnize (= 0.9.0)
-    capybara (2.4.4)
+    capybara (2.14.4)
+      addressable
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
@@ -176,18 +177,18 @@ GEM
       redcarpet (~> 3.0)
       rouge (~> 1.0)
     method_source (0.8.2)
-    mime-types (3.0)
+    mime-types (3.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2016.0221)
-    mini_portile2 (2.0.0)
+    mime-types-data (3.2016.0521)
+    mini_portile2 (2.1.0)
     minitest (5.8.4)
-    multi_json (1.11.2)
+    multi_json (1.12.1)
     multipart-post (2.0.0)
-    mysql2 (0.3.18)
+    mysql2 (0.4.8)
     nenv (0.3.0)
     net-ldap (0.11)
-    nokogiri (1.6.7.2)
-      mini_portile2 (~> 2.0.0.rc2)
+    nokogiri (1.6.8.1)
+      mini_portile2 (~> 2.1.0)
     notiffany (0.0.8)
       nenv (~> 0.1)
       shellany (~> 0.0)
@@ -198,11 +199,9 @@ GEM
     paint (1.0.0)
     parser (2.3.1.2)
       ast (~> 2.2)
-    phantomjs (2.1.1.0)
-    poltergeist (1.6.0)
+    poltergeist (1.15.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
-      multi_json (~> 1.0)
       websocket-driver (>= 0.2.0)
     polyglot (0.3.5)
     powerpack (0.1.1)
@@ -222,7 +221,7 @@ GEM
       activesupport (>= 3.0.0)
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
-    rack (1.6.4)
+    rack (1.6.8)
     rack-mini-profiler (0.9.3)
       rack (>= 1.1.3)
     rack-test (0.6.3)
@@ -367,16 +366,17 @@ GEM
     webmock (2.3.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
+      hashdiff
     webpack-rails (0.9.10)
       hashdiff
       railties (>= 3.2.0)
-    websocket-driver (0.5.4)
+    websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
     wirb (2.0.0)
       paint (>= 0.9, < 2.0)
     wirble (0.1.3)
-    xpath (2.0.0)
+    xpath (2.1.0)
       nokogiri (~> 1.3)
     yajl-ruby (1.3.0)
 
@@ -394,7 +394,7 @@ DEPENDENCIES
   bootstrap-sass (~> 3.3.4)
   brakeman
   byebug
-  capybara
+  capybara (~> 2.14.3)
   codeclimate-test-reporter
   crono
   database_cleaner
@@ -416,8 +416,7 @@ DEPENDENCIES
   md2man (~> 5.1.1)
   mysql2
   net-ldap
-  phantomjs (~> 2.1.1.0)
-  poltergeist
+  poltergeist (~> 1.15.0)
   pry-rails
   public_activity
   puma (~> 3.7.0)

--- a/app/assets/javascripts/alert.js
+++ b/app/assets/javascripts/alert.js
@@ -22,7 +22,7 @@
     w.setTimeOutAlertDelay = function () {
       setTimeout(function () {
         $('.alert-hide').click();
-      }, 4000);
+      }, 5000);
     };
 
     w.setTimeOutAlertDelay();

--- a/app/assets/javascripts/modules/users/pages/sign-in.js
+++ b/app/assets/javascripts/modules/users/pages/sign-in.js
@@ -6,7 +6,7 @@ import { fadeIn } from '~/utils/effects';
 // the user's sign in page components and handle interactions.
 class UsersSignInPage extends BaseComponent {
   mount() {
-    fadeIn(this.$el);
+    fadeIn(this.$el.find('> .container-fluid'));
   }
 }
 

--- a/app/assets/javascripts/modules/users/pages/sign-up.js
+++ b/app/assets/javascripts/modules/users/pages/sign-up.js
@@ -6,7 +6,7 @@ import { fadeIn } from '~/utils/effects';
 // the user's sign up page components and handle interactions.
 class UsersSignUpPage extends BaseComponent {
   mount() {
-    fadeIn(this.$el);
+    fadeIn(this.$el.find('> .container-fluid'));
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "eslint": "eslint --max-warnings 0 --ext .js .",
+    "eslint": "eslint --max-warnings 0 --ext .js ./app/assets/javascripts",
     "webpack": "webpack --watch --config config/webpack.js"
   },
   "devDependencies": {

--- a/spec/controllers/admin/activities_controller_spec.rb
+++ b/spec/controllers/admin/activities_controller_spec.rb
@@ -125,7 +125,9 @@ CSV
       end
 
       get :index, format: :csv
-      expect(response.body.split("\n").size).to eq 61
+      # The rand() used above will eventually conflict and
+      # we need to rely on Team.count instead of 50
+      expect(response.body.split("\n").size).to eq(Team.count + 3)
     end
   end
 end

--- a/spec/features/admin/registries_spec.rb
+++ b/spec/features/admin/registries_spec.rb
@@ -10,7 +10,7 @@ feature "Admin - Registries panel" do
   describe "#force_registry_config!" do
     it "redirects to new_admin_registry_path if no registry has been configured" do
       visit authenticated_root_path
-      expect(current_path).to eq new_admin_registry_path
+      expect(page).to have_current_path(new_admin_registry_path)
     end
   end
 
@@ -33,7 +33,7 @@ feature "Admin - Registries panel" do
       check "force"
       click_button "Create"
 
-      expect(current_path).to eq admin_registries_path
+      expect(page).to have_current_path(admin_registries_path)
       expect(page).to have_content("Registry was successfully created.")
       expect(Registry.any?).to be_truthy
     end
@@ -60,7 +60,7 @@ feature "Admin - Registries panel" do
       click_button "Update"
 
       expect(page).to have_content("Registry updated successfully!")
-      expect(current_path).to eq admin_registries_path
+      expect(page).to have_current_path(admin_registries_path)
       registry.reload
       expect(registry.hostname).to eq "lala"
     end

--- a/spec/features/admin/users_spec.rb
+++ b/spec/features/admin/users_spec.rb
@@ -17,10 +17,8 @@ feature "Admin - Users panel" do
       expect(page).to have_content(original)
 
       find("#user_#{user.id} .remove-btn").click
-      wait_for_effect_on("#user_#{user.id}")
       find("#user_#{user.id} .btn-confirm-remove").click
 
-      wait_for_effect_on("#float-alert")
       expect { User.find(user.id) }.to raise_error(ActiveRecord::RecordNotFound)
       expect(page).to have_content("User '#{user.username}' was removed successfully")
       expect(page).to_not have_content(original)
@@ -33,9 +31,8 @@ feature "Admin - Users panel" do
       expect(page).to have_content(original)
 
       find(".btn-danger").click
-      expect(current_path).to eq admin_users_path
+      expect(page).to have_current_path(admin_users_path)
 
-      wait_for_effect_on("#float-alert")
       expect { User.find(user.id) }.to raise_error(ActiveRecord::RecordNotFound)
       expect(page).to have_content("User '#{user.username}' was removed successfully")
       expect(page).to_not have_content(original)
@@ -47,10 +44,7 @@ feature "Admin - Users panel" do
       expect(page).to have_css("#user_#{user.id}")
       find("#user_#{user.id} .enabled-btn").click
 
-      wait_for_effect_on("#user_#{user.id}")
-
       expect(page).to have_css("#user_#{user.id} .fa-toggle-off")
-      wait_for_effect_on("#float-alert")
       expect(page).to have_content("User '#{user.username}' has been disabled.")
     end
 
@@ -61,10 +55,7 @@ feature "Admin - Users panel" do
       expect(page).to have_css("#user_#{user.id}")
       find("#user_#{user.id} .enabled-btn").click
 
-      wait_for_effect_on("#user_#{user.id}")
-
       expect(page).to have_css("#user_#{user.id} .fa-toggle-on")
-      wait_for_effect_on("#float-alert")
       expect(page).to have_content("User '#{user.username}' has been enabled.")
     end
   end
@@ -74,8 +65,6 @@ feature "Admin - Users panel" do
       expect(page).to have_css("#user_#{user.id}")
       expect(page).to have_css("#user_#{user.id} .admin-btn .fa-toggle-off")
       find("#user_#{user.id} .admin-btn").click
-
-      wait_for_effect_on("#float-alert")
 
       expect(page).to_not have_css("#user_#{user.id} .admin-btn .fa-toggle-off")
       expect(page).to have_css("#user_#{user.id} .admin-btn .fa-toggle-on")
@@ -90,8 +79,6 @@ feature "Admin - Users panel" do
       expect(page).to have_css("#user_#{user.id} .admin-btn .fa-toggle-on")
       find("#user_#{user.id} .admin-btn").click
 
-      wait_for_effect_on("#float-alert")
-
       expect(page).to_not have_css("#user_#{user.id} .admin-btn .fa-toggle-on")
       expect(page).to have_css("#user_#{user.id} .admin-btn .fa-toggle-off")
       expect(page).to have_content("User '#{user.username}' is no longer an admin")
@@ -105,7 +92,6 @@ feature "Admin - Users panel" do
       fill_in "Email", with: "another@example.com"
       click_button "Update"
 
-      wait_for_effect_on("#float-alert")
       expect(page).to have_content("another@example.com")
       expect(page).to have_content("User '#{user.username}' was updated successfully")
     end
@@ -116,7 +102,6 @@ feature "Admin - Users panel" do
       fill_in "Email", with: admin.email
       click_button "Update"
 
-      wait_for_effect_on("#float-alert")
       expect(page).to have_content("has already been taken")
     end
   end

--- a/spec/features/application_spec.rb
+++ b/spec/features/application_spec.rb
@@ -8,7 +8,7 @@ feature "Global application" do
     it "does nothing for accounts with a proper email" do
       login_as user, scope: :user
       visit root_path
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path(root_path)
     end
 
     it "redirects properly for accounts without email" do
@@ -17,11 +17,11 @@ feature "Global application" do
       login_as incomplete, scope: :user
 
       visit root_path
-      expect(current_path).to eq edit_user_registration_path
+      expect(page).to have_current_path(edit_user_registration_path)
 
       expect(page).to have_content("Your profile is not complete.")
       find("#logout").click
-      expect(current_path).to eq new_user_session_path
+      expect(page).to have_current_path(new_user_session_path)
     end
   end
 end

--- a/spec/features/application_tokens_spec.rb
+++ b/spec/features/application_tokens_spec.rb
@@ -20,12 +20,10 @@ feature "Application tokens" do
 
       click_button "Create"
       wait_for_ajax
-      wait_for_effect_on("#add_application_token_form")
 
       expect(user.application_tokens.count).to be(1)
-      expect(current_path).to eql edit_user_registration_path
+      expect(page).to have_current_path(edit_user_registration_path)
 
-      wait_for_effect_on("#float-alert")
       expect(page).to have_content("was created successfully")
       expect(page).to have_content("awesome-application")
     end
@@ -42,12 +40,10 @@ feature "Application tokens" do
 
       click_button "Create"
       wait_for_ajax
-      wait_for_effect_on("#add_application_token_form")
 
       expect(user.application_tokens.count).to be(1)
-      expect(current_path).to eql edit_user_registration_path
+      expect(page).to have_current_path(edit_user_registration_path)
 
-      wait_for_effect_on("#float-alert")
       expect(page).to have_content("Application has already been taken")
     end
 
@@ -65,11 +61,9 @@ feature "Application tokens" do
 
       click_button "Create"
       wait_for_ajax
-      wait_for_effect_on("#add_application_token_form")
 
-      expect(current_path).to eql edit_user_registration_path
+      expect(page).to have_current_path(edit_user_registration_path)
 
-      wait_for_effect_on("#float-alert")
       expect(page).to have_content("was created successfully")
       expect(page).to have_content("awesome-application")
       expect(disabled?("#add_application_token_btn")).to be true
@@ -98,7 +92,6 @@ feature "Application tokens" do
       find(".popover-content .btn-primary").click
 
       wait_for_ajax
-      wait_for_effect_on("#float-alert")
 
       expect(page).to have_content("was removed successfully")
     end
@@ -110,10 +103,8 @@ feature "Application tokens" do
 
       expect(page).to have_css("#add_application_token_btn i.fa-plus-circle")
       find("#add_application_token_btn").click
-      wait_for_effect_on("#add_application_token_form")
       expect(page).to have_css("#add_application_token_btn i.fa-minus-circle")
       find("#add_application_token_btn").click
-      wait_for_effect_on("#add_application_token_form")
       expect(page).to have_css("#add_application_token_btn i.fa-plus-circle")
     end
   end

--- a/spec/features/auth/login_feature_spec.rb
+++ b/spec/features/auth/login_feature_spec.rb
@@ -76,14 +76,14 @@ feature "Login feature" do
     fill_in "user_password", with: "bar"
     find("#login-btn").click
 
-    expect(current_path).to eq new_user_session_path
+    expect(page).to have_current_path(new_user_session_path)
     expect(page).to have_content("Invalid username or password")
   end
 
   scenario "When guest tries to access dashboard - he is redirected to the login page" do
     visit root_path
     expect(page).to have_content("Login")
-    expect(current_path).to eq root_path
+    expect(page).to have_current_path(root_path)
   end
 
   scenario "Successful login when trying to access a page redirects back the guest" do
@@ -92,7 +92,7 @@ feature "Login feature" do
     fill_in "user_username", with: user.username
     fill_in "user_password", with: user.password
     find("button.classbutton").click
-    expect(current_path).to eq namespaces_path
+    expect(page).to have_current_path(namespaces_path)
     expect(page).to have_content("Namespaces you have access to")
   end
 
@@ -104,20 +104,20 @@ feature "Login feature" do
 
     expect(page).to have_content(user.inactive_message)
     expect(page).to have_content("Login")
-    expect(current_path).to eq new_user_session_path
+    expect(page).to have_current_path(new_user_session_path)
   end
 
   scenario "Sign up is disabled" do
     APP_CONFIG["signup"] = { "enabled" => true }
 
     visit root_path
-    expect(current_path).to eq root_path
+    expect(page).to have_current_path(root_path)
     expect(page).to have_content("Create a new account")
 
     APP_CONFIG["signup"] = { "enabled" => false }
 
     visit root_path
-    expect(current_path).to eq root_path
+    expect(page).to have_current_path(root_path)
     expect(page).to have_content("I forgot my password")
     expect(page).to_not have_content("Create a new account")
   end

--- a/spec/features/auth/profile_feature_spec.rb
+++ b/spec/features/auth/profile_feature_spec.rb
@@ -18,7 +18,7 @@ feature "Update password feature" do
 
     # Click the button, the contents should be updated.
     click_button("Update")
-    expect(current_path).to eq edit_user_registration_path
+    expect(page).to have_current_path(edit_user_registration_path)
     expect(disabled?("#edit_user .btn")).to be true
     expect(find("#user_email").value).to eq "another@example.com"
   end
@@ -50,7 +50,7 @@ feature "Update password feature" do
 
     # Click the button and see that everything is as expected.
     click_button "Change"
-    expect(current_path).to eq edit_user_registration_path
+    expect(page).to have_current_path(edit_user_registration_path)
     expect(User.first.valid_password?("12341234")).to be true
   end
 
@@ -61,8 +61,7 @@ feature "Update password feature" do
     visit edit_user_registration_path
 
     click_button "Disable"
-    wait_until { current_path == root_path }
-    expect(current_path).to eq root_path
+    expect(page).to have_current_path(root_path)
     expect(page).to have_content("Login")
   end
 

--- a/spec/features/auth/signup_feature_spec.rb
+++ b/spec/features/auth/signup_feature_spec.rb
@@ -16,14 +16,14 @@ feature "Signup feature" do
     click_link("Create a new account")
     expect(page).to have_field("user_email")
     expect(page).to_not have_css("section.first-user")
-    expect(page).to_not have_css("#user_admin")
+    expect(page).to_not have_css("#user_admin", visible: false)
   end
 
   scenario "The first user to be created is the admin if first_user_admin is enabled" do
     User.delete_all
     visit new_user_registration_url
     expect(page).to have_content("Create admin")
-    expect(page).to have_css("#user_admin")
+    expect(page).to have_css("#user_admin", visible: false)
   end
 
   scenario "The first user to be created is NOT admin if first_user_admin is disabled" do
@@ -31,7 +31,7 @@ feature "Signup feature" do
     APP_CONFIG["first_user_admin"] = { "enabled" => false }
     visit new_user_registration_url
     expect(page).to_not have_content("Create admin")
-    expect(page).to_not have_css("#user_admin")
+    expect(page).to_not have_css("#user_admin", visible: false)
   end
 
   scenario "The portus user does not interfere with regular admin creation" do
@@ -41,7 +41,7 @@ feature "Signup feature" do
     visit new_user_registration_url
 
     expect(page).to have_content("Create admin")
-    expect(page).to have_css("#user_admin")
+    expect(page).to have_css("#user_admin", visible: false)
   end
 
   scenario "As a guest I am able to signup" do
@@ -145,9 +145,9 @@ feature "Signup feature" do
 
   scenario "If there are users on the system, and can move through sign_in and sign_up" do
     click_link("Login")
-    expect(current_path).to eql(new_user_session_path)
+    expect(page).to have_current_path(new_user_session_path)
     click_link("Create a new account")
-    expect(current_path).to eql(new_user_registration_path)
+    expect(page).to have_current_path(new_user_registration_path)
   end
 
   describe "signup disabled" do
@@ -157,7 +157,7 @@ feature "Signup feature" do
 
     scenario "does not allow the user to access the signup page if disabled" do
       visit new_user_registration_path
-      expect(current_path).to eq new_user_session_path
+      expect(page).to have_current_path(new_user_session_path)
     end
   end
 end

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -44,7 +44,6 @@ feature "Dashboard page" do
     scenario "Show personal repositories", js: true do
       visit authenticated_root_path
       click_link("Personal")
-      wait_for_effect_on(".tab-content")
 
       expect(page).to have_content("#{personal_namespace.name}/#{personal_repository.name}")
       expect(page).not_to have_content("#{namespace.name}/#{starred_repo.name}")
@@ -56,7 +55,6 @@ feature "Dashboard page" do
     scenario "Show personal repositories", js: true do
       visit authenticated_root_path
       click_link("Starred")
-      wait_for_effect_on(".tab-content")
 
       expect(page).to have_content("#{namespace.name}/#{starred_repo.name}")
       expect(page).not_to have_content("#{personal_namespace.name}/#{personal_repository.name}")

--- a/spec/features/forgotten_password_spec.rb
+++ b/spec/features/forgotten_password_spec.rb
@@ -23,12 +23,12 @@ feature "Forgotten password support" do
 
     fill_in "Email", with: "random@example.com"
     click_button "Reset password"
-    expect(current_path).to eq new_user_password_path
+    expect(page).to have_current_path(new_user_password_path)
     expect(page).to have_content("Email not found")
 
     fill_in "Email", with: user.email
     click_button "Reset password"
-    expect(current_path).to eq new_user_session_path
+    expect(page).to have_current_path(new_user_session_path)
     expect(page).to have_content("You will receive an email with instructions on " \
       "how to reset your password in a few minutes.")
 

--- a/spec/features/namespaces_spec.rb
+++ b/spec/features/namespaces_spec.rb
@@ -18,13 +18,13 @@ feature "Namespaces support" do
 
       visit namespaces_path
       find("#add_namespace_btn").click
-      wait_for_effect_on("#add_namespace_form")
 
       click_button "Create"
+
       wait_for_ajax
-      wait_for_effect_on("#add_namespace_form")
+
       expect(Namespace.count).to eql namespaces_count
-      expect(current_path).to eql namespaces_path
+      expect(page).to have_current_path(namespaces_path)
     end
 
     scenario "An user cannot create a namespace that already exists", js: true do
@@ -32,17 +32,19 @@ feature "Namespaces support" do
 
       visit namespaces_path
       find("#add_namespace_btn").click
-      fill_in "Namespace", with: Namespace.first.name
-      fill_in "Team", with: Team.where(hidden: false).first.name
       wait_for_effect_on("#add_namespace_form")
 
+      fill_in "Namespace", with: Namespace.first.name
+      fill_in "Team", with: Team.where(hidden: false).first.name
       click_button "Create"
+
       wait_for_ajax
       wait_for_effect_on("#float-alert")
-      expect(Namespace.count).to eql namespaces_count
-      expect(current_path).to eql namespaces_path
+
+      expect(page).to have_current_path(namespaces_path)
+      expect(page).to have_css("#float-alert")
       expect(page).to have_content("Name has already been taken")
-      expect(page).to have_css("#float-alert .alert.alert-dismissible.alert-info.float-alert")
+      expect(Namespace.count).to eql namespaces_count
     end
 
     scenario "An user cannot create a namespace for a hidden team", js: true do
@@ -50,17 +52,19 @@ feature "Namespaces support" do
 
       visit namespaces_path
       find("#add_namespace_btn").click
-      fill_in "Namespace", with: Namespace.first.name
-      fill_in "Team", with: Team.where(hidden: true).first.name
       wait_for_effect_on("#add_namespace_form")
 
+      fill_in "Namespace", with: Namespace.first.name
+      fill_in "Team", with: Team.where(hidden: true).first.name
       click_button "Create"
+
       wait_for_ajax
       wait_for_effect_on("#float-alert")
-      expect(Namespace.count).to eql namespaces_count
-      expect(current_path).to eql namespaces_path
+
+      expect(page).to have_current_path(namespaces_path)
+      expect(page).to have_css("#float-alert")
       expect(page).to have_content("Selected team does not exist")
-      expect(page).to have_css("#float-alert .alert.alert-dismissible.alert-info")
+      expect(Namespace.count).to eql namespaces_count
     end
 
     scenario "A namespace can be created from the index page", js: true do
@@ -68,26 +72,25 @@ feature "Namespaces support" do
 
       visit namespaces_path
       find("#add_namespace_btn").click
+      wait_for_effect_on("#add_namespace_form")
+
       fill_in "Namespace", with: "valid-namespace"
       fill_in "Team", with: namespace.team.name
-      wait_for_effect_on("#add_namespace_form")
-
       click_button "Create"
+
       wait_for_ajax
-      wait_for_effect_on("#add_namespace_form")
-
-      expect(Namespace.count).to eql namespaces_count + 1
-      expect(current_path).to eql namespaces_path
-      expect(page).to have_content("valid-namespace")
-
       wait_for_effect_on("#float-alert")
-      expect(page).to have_content(/Namespace '.+' was created successfully/)
+
+      expect(page).to have_css("#float-alert")
+      expect(page).to have_content("Namespace 'valid-namespace' was created successfully")
 
       # Check that it created a link to it and that it's accessible.
-      click_link "valid-namespace"
+      expect(Namespace.count).to eql namespaces_count + 1
+      expect(page).to have_link("valid-namespace")
+      find(:link, "valid-namespace").trigger(:click)
+
       namespace = Namespace.find_by(name: "valid-namespace")
-      wait_until { current_path == namespace_path(namespace) }
-      expect(current_path).to eq namespace_path(namespace)
+      expect(page).to have_current_path(namespace_path(namespace))
     end
 
     scenario 'The "Create new namespace" link has a toggle effect', js: true do
@@ -96,13 +99,11 @@ feature "Namespaces support" do
       expect(page).to_not have_css("#add_namespace_btn i.fa-minus-circle")
 
       find("#add_namespace_btn").click
-      wait_for_effect_on("#add_namespace_form")
 
       expect(page).to_not have_css("#add_namespace_btn i.fa-plus-circle")
       expect(page).to have_css("#add_namespace_btn i.fa-minus-circle")
 
       find("#add_namespace_btn").click
-      wait_for_effect_on("#add_namespace_form")
 
       expect(page).to have_css("#add_namespace_btn i.fa-plus-circle")
       expect(page).to_not have_css("#add_namespace_btn i.fa-minus-circle")
@@ -116,14 +117,12 @@ feature "Namespaces support" do
       find("#add_namespace_btn").click
       fill_in "Namespace", with: "valid-namespace"
       fill_in "Team", with: namespace.team.name
-      wait_for_effect_on("#add_namespace_form")
 
       expect(page).to_not have_css("#add_namespace_btn i.fa-plus-circle")
       expect(page).to have_css("#add_namespace_btn i.fa-minus-circle")
 
       click_button "Create"
       wait_for_ajax
-      wait_for_effect_on("#add_namespace_form")
 
       expect(page).to have_css("#add_namespace_btn i.fa-plus-circle")
       expect(page).to_not have_css("#add_namespace_btn i.fa-minus-circle")
@@ -162,7 +161,6 @@ feature "Namespaces support" do
       find("#change_description_namespace_#{namespace.id} .btn").click
 
       wait_for_ajax
-      wait_for_effect_on("#float-alert")
       expect(page).to have_content("Team 'unknown' unknown")
     end
   end

--- a/spec/features/repositories_spec.rb
+++ b/spec/features/repositories_spec.rb
@@ -42,10 +42,10 @@ feature "Repositories support" do
 
     scenario "A user can star a repository", js: true do
       visit repository_path(repository)
-      expect(find("#toggle_star")).to be_visible
+      expect(page).to have_css("#toggle_star")
       find("#toggle_star").click
       wait_for_ajax
-      expect(current_path).to eq repository_path(repository)
+      expect(page).to have_current_path(repository_path(repository))
 
       # See the response.
       repo = Repository.find(repository.id)
@@ -55,10 +55,10 @@ feature "Repositories support" do
 
     scenario "A user can unstar a repository", js: true do
       visit repository_path(starred_repo)
-      expect(find("#toggle_star")).to be_visible
+      expect(page).to have_css("#toggle_star")
       find("#toggle_star").click
       wait_for_ajax
-      expect(current_path).to eq repository_path(starred_repo)
+      expect(page).to have_current_path(repository_path(starred_repo))
 
       # See the response.
       repo = Repository.find(repository.id)

--- a/spec/features/teams_spec.rb
+++ b/spec/features/teams_spec.rb
@@ -15,13 +15,12 @@ feature "Teams support" do
 
       visit teams_path
       find("#add_team_btn").click
-      wait_for_effect_on("#add_team_form")
 
       click_button "Add"
       wait_for_ajax
-      wait_for_effect_on("#add_team_form")
+
       expect(Team.count).to eql teams_count
-      expect(current_path).to eql teams_path
+      expect(page).to have_current_path(teams_path)
     end
 
     scenario "A team cannot be created if the name has already been picked", js: true do
@@ -30,15 +29,14 @@ feature "Teams support" do
       visit teams_path
       find("#add_team_btn").click
       fill_in "Name", with: Team.first.name
-      wait_for_effect_on("#add_team_form")
 
       click_button "Add"
       wait_for_ajax
       wait_for_effect_on("#float-alert")
+
       expect(Team.count).to eql teams_count
-      expect(current_path).to eql teams_path
+      expect(page).to have_current_path(teams_path)
       expect(page).to have_content("Name has already been taken")
-      expect(page).to have_css("#float-alert .alert.alert-dismissible.alert-info")
     end
 
     scenario "A team can be created from the index page", js: true do
@@ -47,16 +45,14 @@ feature "Teams support" do
       visit teams_path
       find("#add_team_btn").click
       fill_in "Name", with: "valid-team"
-      wait_for_effect_on("#add_team_form")
 
       click_button "Add"
       wait_for_ajax
-      wait_for_effect_on("#add_team_form")
-      expect(Team.count).to eql teams_count + 1
-      expect(current_path).to eql teams_path
-      expect(page).to have_content("valid-team")
-
       wait_for_effect_on("#float-alert")
+
+      expect(Team.count).to eql teams_count + 1
+      expect(page).to have_current_path(teams_path)
+      expect(page).to have_link("valid-team")
       expect(page).to have_content("Team 'valid-team' was created successfully")
     end
 
@@ -66,13 +62,11 @@ feature "Teams support" do
       expect(page).to_not have_css("#add_team_btn i.fa-minus-circle")
 
       find("#add_team_btn").click
-      wait_for_effect_on("#add_team_form")
 
       expect(page).to_not have_css("#add_team_btn i.fa-plus-circle")
       expect(page).to have_css("#add_team_btn i.fa-minus-circle")
 
       find("#add_team_btn").click
-      wait_for_effect_on("#add_team_form")
 
       expect(page).to have_css("#add_team_btn i.fa-plus-circle")
       expect(page).to_not have_css("#add_team_btn i.fa-minus-circle")
@@ -82,7 +76,7 @@ feature "Teams support" do
       visit teams_path
       expect(page).to have_content(team.name)
       find("#teams a").click
-      expect(current_path).to eq team_path(team)
+      expect(page).to have_current_path(team_path(team))
     end
 
     scenario "Disabled users do not count" do
@@ -107,13 +101,12 @@ feature "Teams support" do
       visit team_path(team)
 
       click_button "Edit team"
-      expect(find("form.edit_team")).to be_visible
+      expect(page).to have_css("form.edit_team")
 
       new_team_name = "New #{team}"
       fill_in "team[name]", with: new_team_name
       click_button "Save"
       wait_for_ajax
-      wait_for_effect_on("#float-alert")
 
       expect(page).to have_content("Team '#{new_team_name}' was updated successfully")
       expect(find(".team_name").text).to eq(new_team_name)
@@ -130,10 +123,12 @@ feature "Teams support" do
 
     scenario "A namespace can be created from the team page", js: true do
       # The form appears after clicking the "Add namespace" link.
-      expect(find("#add_namespace_form", visible: false)).to_not be_visible
+      expect(page).to have_css("#add_namespace_form", visible: false)
+
       find("#add_namespace_btn").click
       wait_for_effect_on("#add_namespace_form")
-      expect(find("#add_namespace_form")).to be_visible
+
+      expect(page).to have_css("#add_namespace_form")
       expect(focused_element_id).to eq "namespace_namespace"
 
       # Fill the form and wait for the AJAX response.
@@ -144,19 +139,16 @@ feature "Teams support" do
       # See the response.
       namespace = Namespace.find_by(name: "new-namespace")
       expect(page).to have_css("#namespace_#{namespace.id}")
-      wait_for_effect_on("#add_namespace_form")
-      expect(find("#add_namespace_form", visible: false)).to_not be_visible
+      expect(page).to have_css("#add_namespace_form", visible: false)
     end
 
     scenario "An user can be added as a team member", js: true do
       find("#add_team_user_btn").click
-      wait_for_effect_on("#add_team_user_form")
       find("#team_user_role").select "Contributor"
       find("#team_user_user").set another.username
       find("#add_team_user_form .btn").click
 
       wait_for_ajax
-      wait_for_effect_on("#float-alert")
 
       expect(page).to have_content(/User '.+' was added to the team/)
       expect(page).to have_content("Contributor")
@@ -164,13 +156,11 @@ feature "Teams support" do
 
     scenario "An admin can only be added as a team owner", js: true do
       find("#add_team_user_btn").click
-      wait_for_effect_on("#add_team_user_form")
       find("#team_user_role").select "Contributor"
       find("#team_user_user").set another_admin.username
       find("#add_team_user_form .btn").click
 
       wait_for_ajax
-      wait_for_effect_on("#float-alert")
 
       expect(page).to have_content(
         /User '.+' was added to the team \(promoted to owner because it is a Portus admin\)\./
@@ -180,13 +170,11 @@ feature "Teams support" do
 
     scenario "New team members have to exist on the system", js: true do
       find("#add_team_user_btn").click
-      wait_for_effect_on("#add_team_user_form")
       find("#team_user_role").select "Contributor"
       find("#team_user_user").set "grumpy"
       find("#add_team_user_form .btn").click
 
       wait_for_ajax
-      wait_for_effect_on("#float-alert")
 
       expect(page).to have_content("User cannot be found")
     end
@@ -202,7 +190,6 @@ feature "Teams support" do
       find(".popover-content .btn-primary").click
 
       wait_for_ajax
-      wait_for_effect_on("#float-alert")
 
       expect(page).to have_content(/User '.+' was removed from the team/)
     end
@@ -215,7 +202,6 @@ feature "Teams support" do
       find(".popover-content .btn-primary").click
 
       wait_for_ajax
-      wait_for_effect_on("#float-alert")
 
       expect(page).to have_content("Cannot remove the only owner of the team")
     end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,21 +1,27 @@
-
 require "capybara/rails"
 require "capybara/rspec"
 require "capybara/poltergeist"
 
+WAIT_TIME = 3.minutes
+
 Capybara.register_driver :poltergeist do |app|
-  Capybara::Poltergeist::Driver.new(
-    app,
-    js_errors:         false,
-    phantomjs_options: ["--load-images=no"]
-  )
+  options = {
+    timeout:           WAIT_TIME,
+    js_errors:         true,
+    phantomjs_options: [
+      "--proxy-type=none"
+    ]
+  }
+  # NOTE: uncomment the line below to get more info on the current run.
+  # options[:debug] = true
+  Capybara::Poltergeist::Driver.new(app, options)
 end
 
 Capybara.javascript_driver = :poltergeist
 
 Capybara.configure do |config|
   config.javascript_driver = :poltergeist
-  config.default_wait_time = 5
+  config.default_max_wait_time = WAIT_TIME
   config.match = :one
   config.exact_options = true
   config.ignore_hidden_elements = true

--- a/spec/support/wait_for_events.rb
+++ b/spec/support/wait_for_events.rb
@@ -6,7 +6,7 @@
 #
 # Therefore, we add some methods for waiting that will be used for these
 # corner cases. All the public methods respect a timeout of
-# `Capybara.default_wait_time`.
+# `Capybara.default_max_wait_time`.
 module WaitForEvents
   # Wait for all the AJAX requests to have concluded.
   def wait_for_ajax
@@ -21,7 +21,7 @@ module WaitForEvents
   # This method will loop until the given block evaluates to true. It will
   # respect to default timeout as specifyied by Capybara.
   def wait_until
-    Timeout.timeout(Capybara.default_wait_time) do
+    Timeout.timeout(Capybara.default_max_wait_time) do
       loop until yield
     end
   end
@@ -29,7 +29,7 @@ module WaitForEvents
   private
 
   # Wait until the given JS snippet evaluates to zero. This is done while
-  # respecting the set `Capybara.default_wait_time` timeout.
+  # respecting the set `Capybara.default_max_wait_time` timeout.
   def wait_until_zero(js)
     wait_until { page.evaluate_script(js).zero? }
   end


### PR DESCRIPTION
- Moved from `precise` to `trusty` in travis
  - https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming
- Updated `.travis.yml`
- Updated `capybara` gem
- Updated `poltergeist` gem
- Removed `phantomjs`gem 
- Removed unnecessary `wait_until`
- Removed unnecessary `wait_for_effect_on`
- Using `have_current_path` matcher instead of `eq`
- Fixed poltergeist js error on sign in/up pages fadeIn
- Fixed two failing tests after capybara update
- Fixed `admin/activities_controller_spec.rb` flaky test
- Many minor enhancements
- Fixed webmock dependency tree 
  - It was blocking the tests after .travis.yml changes 
  - Also causing `ruby-head` to fail
- Updated `mysql2`gem
  -  It was causing conflict in travis for some reason after caching bundle