### PR TITLE
Fix concise model annotation

### DIFF
--- a/app/models/registry_event.rb
+++ b/app/models/registry_event.rb
@@ -3,7 +3,7 @@
 # Table name: registry_events
 #
 #  id         :integer          not null, primary key
-#  event_id   :string(255)      default(""), not null
+#  event_id   :string(255)      default("")
 #  repository :string(255)      default("")
 #  tag        :string(255)      default("")
 #  created_at :datetime         not null


### PR DESCRIPTION
This PR has no impact it just updates model annotation comment to the latest state of the annotation gem. Its quite annoying that the workspace is always dirty without actually doing anything in that particular file. 