### PR TITLE
Added latest missing changes from security scanning PR (#1289)

### DIFF
--- a/app/assets/javascripts/modules/repositories/pages/show.js
+++ b/app/assets/javascripts/modules/repositories/pages/show.js
@@ -40,6 +40,7 @@ $(() => {
         state: store.state,
         isLoading: false,
         notLoaded: false,
+        unableToFetchBefore: false,
         tags: [],
       };
     },
@@ -51,14 +52,18 @@ $(() => {
         RepositoriesService.get(id).then((response) => {
           set(this, 'tags', response.body.tags);
           set(this, 'notLoaded', false);
+          set(this, 'unableToFetchBefore', false);
         }, () => {
           // if the data never came,
           // show message instead of table,
           // otherwise only the alert
           if (this.isLoading) {
             set(this, 'notLoaded', true);
-          } else {
+          }
+
+          if (!this.isLoading && !this.unableToFetchBefore) {
             Alert.show('Unable to fetch newer tags data');
+            set(this, 'unableToFetchBefore', true);
           }
         }).finally(() => {
           setTimeout(() => this.loadData(), POLLING_VALUE);

--- a/app/assets/javascripts/shared/components/alert.js
+++ b/app/assets/javascripts/shared/components/alert.js
@@ -2,16 +2,12 @@ const ALERT_ELEMENT = '#float-alert';
 const TEXT_ALERT_ELEMENT = '#float-alert p';
 const HIDE_TIMEOUT = 5000;
 
-function scheduleHide() {
-  setTimeout(() => $(ALERT_ELEMENT).fadeOut(), HIDE_TIMEOUT);
-}
-
 function show(text, autohide = true) {
   $(TEXT_ALERT_ELEMENT).html(text);
   $(ALERT_ELEMENT).fadeIn();
 
   if (autohide) {
-    scheduleHide();
+    setTimeout(() => $(ALERT_ELEMENT).fadeOut(), HIDE_TIMEOUT);
   }
 }
 

--- a/app/helpers/repositories_helper.rb
+++ b/app/helpers/repositories_helper.rb
@@ -133,4 +133,10 @@ module RepositoriesHelper
   def security_vulns_enabled?
     ::Portus::Security.new(nil, nil).enabled?
   end
+
+  # Returns true if any vulnerability is found
+  # Or false otherwise
+  def vulnerable?(vulnerabilities)
+    !vulnerabilities.select { |_, vulns| !vulns.empty? }.empty?
+  end
 end

--- a/app/views/tags/show.html.slim
+++ b/app/views/tags/show.html.slim
@@ -13,13 +13,17 @@
 
   .panel-body
     span
-      - @vulnerabilities.each do |backend, vulns|
-        - next if vulns.empty?
+      - if vulnerable?(@vulnerabilities)
+        - @vulnerabilities.each do |backend, vulns|
+          - next if vulns.empty?
 
-        h5= backend
-        ul
-          - vulns.each do |v|
-            li
-              a href="#{v['Link']}"
-                = v["Name"]
-              |  (severity: #{v["Severity"]})
+          h5= backend
+          ul
+            - vulns.each do |v|
+              li
+                a href="#{v['Link']}"
+                  = v["Name"]
+                |  (severity: #{v["Severity"]})
+
+      - else
+        p No vulnerabilities found

--- a/spec/helpers/repositories_helper_spec.rb
+++ b/spec/helpers/repositories_helper_spec.rb
@@ -161,4 +161,24 @@ RSpec.describe RepositoriesHelper, type: :helper do
       expect(helper.security_vulns_enabled?).to be_falsy
     end
   end
+
+  describe "#vulnerable?" do
+    it "returns true if any security vulnerability server is configured" do
+      vulnerabilities = {
+        one: [[]],
+        two: []
+      }
+
+      expect(helper.vulnerable?(vulnerabilities)).to be_truthy
+    end
+
+    it "returns false if no security vulnerability server is configured" do
+      vulnerabilities = {
+        one: [],
+        two: []
+      }
+
+      expect(helper.vulnerable?(vulnerabilities)).to be_falsy
+    end
+  end
 end


### PR DESCRIPTION
- Not showing the flashy message "Unable to fetch newer tags data" for every polling.
- Showing "No vulnerabilities found" on tags#show panel istead of an empty space.