### PR TITLE
Avoid error on nil Feature key - fixes #1351

### DIFF
--- a/lib/portus/security_backends/clair.rb
+++ b/lib/portus/security_backends/clair.rb
@@ -40,7 +40,7 @@ module Portus
 
         res = []
         known = []
-        layer["Features"].each do |f|
+        Array(layer["Features"]).each do |f|
           vulns = f["Vulnerabilities"]
           next if vulns.nil?
 


### PR DESCRIPTION
This pull request fixes a bug in iterating over a nil array when returning the Clair anaylsis results