### PR TITLE
[WIP] Handle registry events in the background

### DIFF
--- a/app/controllers/api/v2/events_controller.rb
+++ b/app/controllers/api/v2/events_controller.rb
@@ -3,7 +3,7 @@ class Api::V2::EventsController < Api::BaseController
   # A new notification is coming, register it if valid.
   def create
     body = JSON.parse(request.body.read)
-    Portus::RegistryNotification.process!(body, Repository, Webhook)
+    Portus::RegistryNotification.process!(body)
     head status: :accepted
   end
 end

--- a/app/models/registry_event.rb
+++ b/app/models/registry_event.rb
@@ -3,15 +3,37 @@
 # Table name: registry_events
 #
 #  id         :integer          not null, primary key
-#  event_id   :string(255)      default(""), not null
+#  event_id   :string(255)      default("")
 #  repository :string(255)      default("")
 #  tag        :string(255)      default("")
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  handled    :integer          default("0")
 #
 
 # RegistryEvent represents an event coming from the Registry. This model stores
 # events that are being handled by Portus or that have been handled before. This
 # way we avoid duplication of registry events
+# TODO: update documentation
 class RegistryEvent < ActiveRecord::Base
+  HANDLERS = [Repository, Webhook].freeze
+
+  # TODO: documentation
+  enum status: [:done, :progress, :fresh]
+
+  # TODO: documentation
+  def self.handle!(event)
+    # TODO: maybe this one should be called outside ?
+    RegistryEvent.where(event_id: event["id"]).update_all(handled: :progress)
+
+    action = event["action"]
+    Rails.logger.info "Handling '#{event["action"]}' event:\n#{JSON.pretty_generate(event)}"
+
+    # Delegate the handling to the known handlers.
+    HANDLERS.each { |handler| handler.send("handle_#{action}_event".to_sym, event) }
+
+    # Finally mark this event as handled, so a background job does not pick it
+    # up again.
+    RegistryEvent.where(event_id: event["id"]).update_all(handled: :done)
+  end
 end

--- a/app/models/registry_event.rb
+++ b/app/models/registry_event.rb
@@ -4,11 +4,10 @@
 #
 #  id         :integer          not null, primary key
 #  event_id   :string(255)      default("")
-#  repository :string(255)      default("")
-#  tag        :string(255)      default("")
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  handled    :integer          default("0")
+#  data       :text(65535)
 #
 
 # RegistryEvent represents an event coming from the Registry. This model stores
@@ -24,7 +23,7 @@ class RegistryEvent < ActiveRecord::Base
   # TODO: documentation
   def self.handle!(event)
     # TODO: maybe this one should be called outside ?
-    RegistryEvent.where(event_id: event["id"]).update_all(handled: :progress)
+    RegistryEvent.where(event_id: event["id"]).update_all(handled: RegistryEvent.statuses[:progress])
 
     action = event["action"]
     Rails.logger.info "Handling '#{event["action"]}' event:\n#{JSON.pretty_generate(event)}"
@@ -34,6 +33,6 @@ class RegistryEvent < ActiveRecord::Base
 
     # Finally mark this event as handled, so a background job does not pick it
     # up again.
-    RegistryEvent.where(event_id: event["id"]).update_all(handled: :done)
+    RegistryEvent.where(event_id: event["id"]).update_all(handled: RegistryEvent.statuses[:done])
   end
 end

--- a/bin/background_job.rb
+++ b/bin/background_job.rb
@@ -1,0 +1,26 @@
+require "portus/db"
+
+count = 0
+TIMEOUT = 90
+
+while Portus.database_exists? != "DB_READY"
+  if count >= TIMEOUT
+    puts "Timeout reached, exiting with error. Check the logs..."
+    exit 1
+  end
+
+  puts "Waiting for DB to be ready"
+  sleep 5
+  count += 5
+end
+
+loop do
+  RegistryEvent.where(handled: RegistryEvent.statuses[:fresh]).find_each do |e|
+    data = JSON.parse(e.data)
+    RegistryEvent.handle!(data)
+  end
+
+  sleep 5 if RegistryEvent.where(handled: RegistryEvent.statuses[:fresh]).empty?
+end
+
+exit 0

--- a/bin/check_db.rb
+++ b/bin/check_db.rb
@@ -1,0 +1,14 @@
+# This is a rails runner that will print the status of Portus' database
+# Possible outcomes:
+#
+#   * `DB_READY`: the database has been created and initialized
+#   * `DB_EMPTY`: the database has been created but has not been initialized
+#   * `DB_MISSING`: the database has not been created
+#   * `DB_DOWN`: cannot connect to the database
+#
+# Originally included in the https://github.com/openSUSE/docker-containers
+# repository under the same license.
+
+require "portus/db"
+
+puts Portus.database_exists?

--- a/config/config.yml
+++ b/config/config.yml
@@ -130,6 +130,10 @@ registry:
   catalog_page:
     value: 100
 
+  # TODO: documentation
+  fetch_info_in_background:
+    enabled: false
+
 # The FQDN of the machine where Portus is being deployed.
 machine_fqdn:
   value: "portus.test.lan"

--- a/db/migrate/20170728143806_add_handled_to_registry_events.rb
+++ b/db/migrate/20170728143806_add_handled_to_registry_events.rb
@@ -1,0 +1,5 @@
+class AddHandledToRegistryEvents < ActiveRecord::Migration
+  def change
+    add_column :registry_events, :handled, :integer, default: RegistryEvent.statuses[:done]
+  end
+end

--- a/db/migrate/20170728152014_add_data_to_registry_event.rb
+++ b/db/migrate/20170728152014_add_data_to_registry_event.rb
@@ -1,0 +1,5 @@
+class AddDataToRegistryEvent < ActiveRecord::Migration
+  def change
+    add_column :registry_events, :data, :text
+  end
+end

--- a/db/migrate/20170728152154_remove_repository_and_tag_from_registry_event.rb
+++ b/db/migrate/20170728152154_remove_repository_and_tag_from_registry_event.rb
@@ -1,0 +1,6 @@
+class RemoveRepositoryAndTagFromRegistryEvent < ActiveRecord::Migration
+  def change
+    remove_column :registry_events, :repository, :string
+    remove_column :registry_events, :tag, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170728143806) do
+ActiveRecord::Schema.define(version: 20170728152154) do
 
   create_table "activities", force: :cascade do |t|
     t.integer  "trackable_id",   limit: 4
@@ -90,12 +90,11 @@ ActiveRecord::Schema.define(version: 20170728143806) do
   add_index "registries", ["name"], name: "index_registries_on_name", unique: true, using: :btree
 
   create_table "registry_events", force: :cascade do |t|
-    t.string   "event_id",   limit: 255, default: ""
-    t.string   "repository", limit: 255, default: ""
-    t.string   "tag",        limit: 255, default: ""
-    t.datetime "created_at",                          null: false
-    t.datetime "updated_at",                          null: false
-    t.integer  "handled",    limit: 4,   default: 0
+    t.string   "event_id",   limit: 255,   default: ""
+    t.datetime "created_at",                            null: false
+    t.datetime "updated_at",                            null: false
+    t.integer  "handled",    limit: 4,     default: 0
+    t.text     "data",       limit: 65535
   end
 
   create_table "repositories", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160927141850) do
+ActiveRecord::Schema.define(version: 20170728143806) do
 
   create_table "activities", force: :cascade do |t|
     t.integer  "trackable_id",   limit: 4
@@ -95,6 +95,7 @@ ActiveRecord::Schema.define(version: 20160927141850) do
     t.string   "tag",        limit: 255, default: ""
     t.datetime "created_at",                          null: false
     t.datetime "updated_at",                          null: false
+    t.integer  "handled",    limit: 4,   default: 0
   end
 
   create_table "repositories", force: :cascade do |t|

--- a/lib/portus/db.rb
+++ b/lib/portus/db.rb
@@ -1,0 +1,15 @@
+# TODO
+module Portus
+  def self.database_exists?
+    ActiveRecord::Base.connection
+    if ActiveRecord::Base.connection.table_exists? "schema_migrations"
+      "DB_READY"
+    else
+      "DB_EMPTY"
+    end
+  rescue ActiveRecord::NoDatabaseError
+    "DB_MISSING"
+  rescue Mysql2::Error
+    "DB_DOWN"
+  end
+end

--- a/lib/portus/registry_notification.rb
+++ b/lib/portus/registry_notification.rb
@@ -21,7 +21,7 @@ module Portus
           RegistryEvent.create!(
             event_id: event["id"],
             data:     event.to_json,
-            handled:  :fresh
+            handled:  RegistryEvent.statuses[:fresh]
           )
         end
 

--- a/lib/portus/registry_notification.rb
+++ b/lib/portus/registry_notification.rb
@@ -9,25 +9,26 @@ module Portus
     # parsed JSON body as given by the registry. A handler is a class that can
     # call the `handle_#{event}_event` method. This method receives an `event`
     # object, which is the event object as given by the registry.
-    def self.process!(data, *handlers)
+    def self.process!(data)
       data["events"].each do |event|
         Rails.logger.debug "Incoming event:\n#{JSON.pretty_generate(event)}"
 
+        # Skipp irrelevant or already-handled events.
         next unless should_handle?(event)
-        action = event["action"]
 
-        # Only register pushes, since they are the conflicting actions since 2.5
-        if action == "push"
+        # Only register relevant events.
+        if HANDLED_EVENTS.include? event["action"]
           RegistryEvent.create!(
-            event_id:   event["id"],
-            repository: event["target"]["repository"],
-            tag:        event["target"]["tag"]
+            event_id: event["id"],
+            data:     event.to_json,
+            handled:  :fresh
           )
         end
 
-        # Now it's time to delegate the handling to the proper handler.
-        Rails.logger.info "Handling '#{action}' event:\n#{JSON.pretty_generate(event)}"
-        handlers.each { |handler| handler.send("handle_#{action}_event".to_sym, event) }
+        # Depending on the configuration, the event will be handled right now,
+        # or in the background by someone else.
+        next if APP_CONFIG["registry"]["fetch_info_in_background"].enabled?
+        RegistryEvent.handle!(event)
       end
     end
 


### PR DESCRIPTION
As some issues have pointed out (#940 and #1235), Portus can freeze if it doesn't have enough Puma workers. The solution is to either increase the value of available Puma workers, or setup an HA setup with multiple Portus instances.

Sometimes this is not possible, so this WIP PR handles events differently:

- Events are not handled directly, but pushed into the DB.
- Another process will pick up events not handled and do the rest.

This way, Portus should not freeze even if there are no workers. This is configurable and disabled by default, since it makes the deployment of Portus more complex, and it's riskier imho than what we currently have.