### PR TITLE
crono: don't let crono run the migrations

### DIFF
--- a/bin/crono
+++ b/bin/crono
@@ -6,6 +6,8 @@ _timeout=150
 _count=0
 _status=0
 
+export SKIP_MIGRATION=true
+
 # Use portusctl if available. When installing the RPM, bundle might be in an
 # unknown path otherwise.
 if stat /usr/sbin/portusctl &> /dev/null; then


### PR DESCRIPTION
In production it might happen that the crono process is started before
the portus process (e.g. a containerized setup with docker-compose or
Kubernetes). In such a case, we have to be sure that the process running
the migration is the main Portus one, because otherwise the `init`
script from portus won't be able to run successfully, and thus it won't
ever run `rake db:seed` on initialization.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>