### PR TITLE
Added a way to check the DB's status

### DIFF
--- a/bin/check_db.rb
+++ b/bin/check_db.rb
@@ -1,0 +1,26 @@
+# This is a rails runner that will print the status of Portus' database.
+# Possible outcomes:
+#
+#   * `DB_READY`: the database has been created and initialized.
+#   * `DB_EMPTY`: the database has been created but has not been initialized.
+#   * `DB_MISSING`: the database has not been created.
+#   * `DB_DOWN`: cannot connect to the database.
+#   * `DB_UNKNOWN`: unknown error.
+#
+# Originally included in the https://github.com/openSUSE/docker-containers
+# repository under the same license.
+
+require "portus/db"
+
+puts case Portus::DB.ping
+     when :ready
+       "DB_READY"
+     when :empty
+       "DB_EMPTY"
+     when :missing
+       "DB_MISSING"
+     when :down
+       "DB_DOWN"
+     else
+       "DB_UNKNOWN"
+end

--- a/lib/portus/db.rb
+++ b/lib/portus/db.rb
@@ -1,0 +1,24 @@
+module Portus
+  # The DB module has useful methods for DB purposes.
+  module DB
+    # Pings the DB and returns a proper symbol depending on the situation:
+    #   * ready: the database has been created and initialized.
+    #   * empty: the database has been created but has not been initialized.
+    #   * missing: the database has not been created.
+    #   * down: cannot connect to the database.
+    def self.ping
+      ::Portus::DB.migrations? ? :ready : :empty
+    rescue ActiveRecord::NoDatabaseError
+      :missing
+    rescue Mysql2::Error
+      :down
+    end
+
+    # Returns true if the migrations have been run. The implementation is pretty
+    # trivial, but this gives us a nice way to test this module.
+    def self.migrations?
+      ActiveRecord::Base.connection
+      ActiveRecord::Base.connection.table_exists? "schema_migrations"
+    end
+  end
+end

--- a/spec/lib/portus/db_spec.rb
+++ b/spec/lib/portus/db_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+describe Portus::DB do
+  it "returns :ready on the usual case" do
+    expect(Portus::DB.ping).to eq :ready
+  end
+
+  it "returns :empty if the DB is still initializing" do
+    allow(::Portus::DB).to receive(:migrations?).and_return(false)
+    expect(Portus::DB.ping).to eq :empty
+  end
+
+  it "returns :missing if the DB is missing" do
+    allow(::Portus::DB).to receive(:migrations?).and_raise(ActiveRecord::NoDatabaseError, "a")
+    expect(Portus::DB.ping).to eq :missing
+  end
+
+  it "returns :down if the DB is down" do
+    allow(::Portus::DB).to receive(:migrations?).and_raise(Mysql2::Error, "a")
+    expect(Portus::DB.ping).to eq :down
+  end
+end


### PR DESCRIPTION
This has been extracted both from
https://github.com/openSUSE/docker-containers and #1353, since it will
be useful for #1357 as well.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>