### PR TITLE
[Examples] Change storage path for registry container

### DIFF
--- a/examples/compose/docker-compose.insecure.yml
+++ b/examples/compose/docker-compose.insecure.yml
@@ -78,7 +78,7 @@ services:
           threshold: 5
           backoff: 1s
     volumes:
-      - /var/lib/portus/registry:/registry_data
+      - /var/lib/portus/registry:/var/lib/registry
       - ./secrets:/secrets:ro
       - ./registry/config.yml:/etc/docker/registry/config.yml:ro
     ports:

--- a/examples/compose/docker-compose.yml
+++ b/examples/compose/docker-compose.yml
@@ -98,7 +98,7 @@ services:
       - portus:portus
 
   nginx:
-    image: library/nginx
+    image: library/nginx:alpine
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./secrets:/secrets:ro

--- a/examples/compose/docker-compose.yml
+++ b/examples/compose/docker-compose.yml
@@ -87,7 +87,7 @@ services:
           threshold: 5
           backoff: 1s
     volumes:
-      - /var/lib/portus/registry:/registry_data
+      - /var/lib/portus/registry:/var/lib/registry
       - ./secrets:/secrets:ro
       - ./registry/config.yml:/etc/docker/registry/config.yml:ro
       - ./registry/init:/etc/docker/registry/init:ro

--- a/examples/compose/registry/config.yml
+++ b/examples/compose/registry/config.yml
@@ -1,7 +1,7 @@
 version: 0.1
 storage:
   filesystem:
-    rootdirectory: /registry_data
+    rootdirectory: /var/lib/registry
   delete:
     enabled: true
 http:


### PR DESCRIPTION
In the compose examples, the registry container defines the storage volume as `/registry_data`. However, the path that is exposed as a volume in the Registry Dockerfile is `/var/lib/registry`

Docker Compose automatically creates an anonymous volume if the `Volume` parameter defined in the Dockerfile is not mounted as a volume. This results in the creation of multiple anonymous empty volumes, and is a general annoyance.

This PR fixes that by changing the registry path to the one that is defined in the registry Dockerfile. Also I've changed the nginx image to use the alpine variant as well to save space.