### PR TITLE
production: make the log level configurable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,9 +36,10 @@ points if your issue is about Portus behaving in an unexpected manner:
 - If possible, try to reproduce the same issue with logging set to `:debug`. You
   can set this by modifying `config/environment/production.rb` (or whatever
   environment you are in) and setting `config.log_level` to `:debug`. This will
-  give us more detailed logs. Remember to restart Portus when doing this.
-  And remember to set that value to `:info` back again once you're done,
-  otherwise your logs will grow quite rapidly!
+  give us more detailed logs. Another way to set this in production is by
+  setting the `PORTUS_LOG_LEVEL` environment variable to `debug`. Remember to
+  restart Portus when doing this.  And remember to set that value to `:info`
+  back again once you're done, otherwise your logs will grow quite rapidly!
 
 ## Check for assigned people
 

--- a/app/jobs/catalog_job.rb
+++ b/app/jobs/catalog_job.rb
@@ -8,6 +8,7 @@ class CatalogJob < ActiveJob::Base
     Registry.find_each do |registry|
       begin
         cat = registry.client.catalog
+        Rails.logger.debug "Catalog:\n #{cat}"
 
         # Update the registry in a transaction, since we don't want to leave
         # the DB in an unknown state because of an update failure.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,8 +46,13 @@ Rails.application.configure do
   # config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
-  # when problems arise.
-  config.log_level = :info
+  # when problems arise by default. Otherwise, the user might specify its own
+  # log level through the `PORTUS_LOG_LEVEL` environment variable.
+  config.log_level = if ENV["PORTUS_LOG_LEVEL"]
+    ENV["PORTUS_LOG_LEVEL"].to_sym
+  else
+    :info
+  end
 
   # Prepend all log lines with the following tags.
   # config.log_tags = [:subdomain, :uuid]

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -46,8 +46,13 @@ Rails.application.configure do
   # config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
-  # when problems arise.
-  config.log_level = :info
+  # when problems arise by default. Otherwise, the user might specify its own
+  # log level through the `PORTUS_LOG_LEVEL` environment variable.
+  config.log_level = if ENV["PORTUS_LOG_LEVEL"]
+    ENV["PORTUS_LOG_LEVEL"].to_sym
+  else
+    :info
+  end
 
   # Prepend all log lines with the following tags.
   # config.log_tags = [:subdomain, :uuid]


### PR DESCRIPTION
With this commit administrators will be able to set the log level of
their Portus instance through the `PORTUS_LOG_LEVEL`. This will be
possible in production and staging, and it's meant to be used in
exceptional cases (e.g. something is really wrong with the `crono`
process and the administrator wants to restart it with `debug` mode for
a while).

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>