### PR TITLE
Implemented health checks for Portus

### DIFF
--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -1,0 +1,16 @@
+# HealthController contains endpoints that are relevant for checking the status
+# of either portus, or of the components relevant to it.
+class HealthController < ActionController::Base
+  protect_from_forgery with: :exception
+
+  # Simple ping.
+  def index
+    render nothing: true, status: 200
+  end
+
+  # Renders a JSON with the status of each component.
+  def health
+    response, success = ::Portus::Health.check
+    render json: response, status: success ? :ok : :service_unavailable
+  end
+end

--- a/config/config.yml
+++ b/config/config.yml
@@ -176,6 +176,10 @@ security:
   clair:
     server: ""
 
+    # Port being used by Clair to report its status. Taking the default from
+    # Clair.
+    health_port: 6061
+
   # zypper-docker can be run as a server with its `serve` command. This backend
   # fetches the information as given by zypper-docker. Note that this feature
   # from zypper-docker is experimental and only available through another branch

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,10 @@ Rails.application.routes.draw do
   resource :dashboard, only: [:index]
   resources :search, only: [:index]
 
+  # Health check
+  get "/_ping", to: "health#index"
+  get "/_health", to: "health#health"
+
   authenticated :user do
     root "dashboard#index", as: :authenticated_root
   end

--- a/lib/portus/db.rb
+++ b/lib/portus/db.rb
@@ -6,12 +6,15 @@ module Portus
     #   * empty: the database has been created but has not been initialized.
     #   * missing: the database has not been created.
     #   * down: cannot connect to the database.
+    #   * unknown: there has been an unexpected error.
     def self.ping
       ::Portus::DB.migrations? ? :ready : :empty
     rescue ActiveRecord::NoDatabaseError
       :missing
     rescue Mysql2::Error
       :down
+    rescue
+      :unknown
     end
 
     # Returns true if the migrations have been run. The implementation is pretty

--- a/lib/portus/health.rb
+++ b/lib/portus/health.rb
@@ -1,0 +1,30 @@
+require "portus/health_checks/db"
+require "portus/health_checks/registry"
+require "portus/health_checks/clair"
+
+module Portus
+  # Health contains methods for checking the status of the different relevant
+  # components.
+  class Health
+    CHECKS = [
+      Portus::HealthChecks::DB,
+      Portus::HealthChecks::Registry,
+      Portus::HealthChecks::Clair
+    ].freeze
+
+    # The check class method returns a two-sized array: the first element is a
+    # hash with the result of each component, and the last element is a boolean
+    # containing the overall result.
+    def self.check
+      success = true
+      results = CHECKS.map do |c|
+        ready, s = c.ready
+        next if ready.nil?
+        success = false unless s
+        [c.name, { msg: ready, success: s }]
+      end
+
+      [results.compact.to_h, success]
+    end
+  end
+end

--- a/lib/portus/health_checks/clair.rb
+++ b/lib/portus/health_checks/clair.rb
@@ -1,0 +1,40 @@
+require "portus/http_helpers"
+
+module Portus
+  module HealthChecks
+    # Clair offers health check support for CoreOS Clair.
+    class Clair
+      extend ::Portus::HttpHelpers
+
+      def self.name
+        "clair"
+      end
+
+      def self.ready
+        server = APP_CONFIG["security"]["clair"]["server"]
+        return [nil, false] if server.blank?
+
+        uri     = URI.join(health_endpoint(server), "/health")
+        req     = Net::HTTP::Get.new(uri)
+        res     = get_response_token(uri, req)
+        success = res.code.to_i == 200
+        ["clair is#{success ? "" : " not"} reachable", success]
+
+      rescue SocketError, Errno::ECONNREFUSED => e
+        ["clair is not reachable: #{e.message}", false]
+      end
+
+      # It corrects the endpoint of the Clair server so it can be used to check
+      # the health status.
+      def self.health_endpoint(server)
+        port = APP_CONFIG["security"]["clair"]["health_port"]
+
+        if server =~ /:(\d)+/
+          server.gsub(/:(\d)+/, ":#{port}")
+        else
+          "#{server}:#{port}"
+        end
+      end
+    end
+  end
+end

--- a/lib/portus/health_checks/db.rb
+++ b/lib/portus/health_checks/db.rb
@@ -1,0 +1,27 @@
+require "portus/db"
+
+module Portus
+  module HealthChecks
+    # DB offers health check support for the database.
+    class DB
+      def self.name
+        "database"
+      end
+
+      def self.ready
+        case ::Portus::DB.ping
+        when :ready
+          ["database is up-to-date", true]
+        when :empty
+          ["database is initializing", false]
+        when :missing
+          ["database has not been created", false]
+        when :down
+          ["cannot connect to database", false]
+        else
+          ["unknown error", false]
+        end
+      end
+    end
+  end
+end

--- a/lib/portus/health_checks/registry.rb
+++ b/lib/portus/health_checks/registry.rb
@@ -1,0 +1,19 @@
+module Portus
+  module HealthChecks
+    # Registry offers health check support for the configured Docker
+    # registry. Note that this will also fail if the registry is up and running
+    # but there's something wrong with the configuration (e.g. SSL problem).
+    class Registry
+      def self.name
+        "registry"
+      end
+
+      def self.ready
+        return ["no registry configured", false] unless ::Registry.any?
+
+        res = ::Registry.get.client.reachable?
+        ["registry is#{res ? "" : " not"} reachable", res]
+      end
+    end
+  end
+end

--- a/packaging/suse/portusctl/lib/cli.rb
+++ b/packaging/suse/portusctl/lib/cli.rb
@@ -165,6 +165,11 @@ Looks for the following required certificate files in the specified folder:
     desc:    "The URL allowing Portus to access your CoreOS Clair server",
     default: ""
 
+  option "security-clair-health-port",
+    desc:    "The port in which Clair exposes the /health endpoint",
+    type:    :numeric,
+    default: 6061
+
   option "security-zypper-server",
     desc:    "The URL allowing Portus to access your zypper-docker server",
     default: ""

--- a/packaging/suse/portusctl/man/man1/portusctl-setup.1
+++ b/packaging/suse/portusctl/man/man1/portusctl-setup.1
@@ -204,6 +204,10 @@ able to do this. This defaults to true.
 The URL allowing Portus to access your CoreOS Clair server. By default this
 has an empty value, meaning that there is no CoreOS Clair server configured.
 .TP
+\fB\-\-security\-clair\-health\-port\fP
+The Port in which Clair exposes the /health endpoint. It takes the same
+default as Clair: 6061.
+.TP
 \fB\-\-security\-zypper\-server\fP
 The URL allowing Portus to access your zypper\-docker server. By default this
 has an empty value, meaning that there is no CoreOS Clair server configured.

--- a/packaging/suse/portusctl/man/markdown/portusctl-setup.md
+++ b/packaging/suse/portusctl/man/markdown/portusctl-setup.md
@@ -206,6 +206,10 @@ first time.
   The URL allowing Portus to access your CoreOS Clair server. By default this
   has an empty value, meaning that there is no CoreOS Clair server configured.
 
+**--security-clair-health-port**
+  The Port in which Clair exposes the /health endpoint. It takes the same
+  default as Clair: 6061.
+
 **--security-zypper-server**
   The URL allowing Portus to access your zypper-docker server. By default this
   has an empty value, meaning that there is no CoreOS Clair server configured.

--- a/spec/controllers/health_controller_spec.rb
+++ b/spec/controllers/health_controller_spec.rb
@@ -1,0 +1,97 @@
+require "rails_helper"
+
+# Helper for the tests on the database that simply calls :health and returns the
+# JSON message for the database component.
+def db_helper_msg
+  get :health
+
+  data = JSON.parse(response.body)
+  data["database"]["msg"]
+end
+
+RSpec.describe HealthController, type: :controller do
+  describe "GET /_ping" do
+    it "gets an 200 response" do
+      get :index
+      expect(response.status).to eq 200
+    end
+  end
+
+  describe "GET /_health" do
+    describe "Basic functionality" do
+      it "has DB but no registry" do
+        get :health
+        expect(response.status).to eq 503
+      end
+
+      it "has both the DB and the registry" do
+        create(:registry, hostname: "registry.mssola.cat", use_ssl: true)
+
+        VCR.use_cassette("health/ok", record: :none) do
+          get :health
+          expect(response.status).to eq 200
+        end
+      end
+    end
+
+    describe "Database" do
+      it "returns ready in the usual case" do
+        expect(db_helper_msg).to eq "database is up-to-date"
+      end
+
+      it "returns empty when the database is initializing" do
+        allow(::Portus::DB).to receive(:migrations?).and_return(false)
+        expect(db_helper_msg).to eq "database is initializing"
+      end
+
+      it "returns missing when the database does not exist" do
+        allow(::Portus::DB).to receive(:migrations?).and_raise(ActiveRecord::NoDatabaseError, "a")
+        expect(db_helper_msg).to eq "database has not been created"
+      end
+
+      it "returns down if the DB is down" do
+        allow(::Portus::DB).to receive(:migrations?).and_raise(Mysql2::Error, "a")
+        expect(db_helper_msg).to eq "cannot connect to database"
+      end
+
+      it "returns unknown for unexpected errors" do
+        allow(::Portus::DB).to receive(:migrations?).and_raise(StandardError, "a")
+        expect(db_helper_msg).to eq "unknown error"
+      end
+    end
+
+    describe "Clair enabled" do
+      before :each do
+        APP_CONFIG["security"]["clair"]["server"] = "http://registry.mssola.cat"
+        APP_CONFIG["security"]["clair"]["health_port"] = "6061"
+        create(:registry, hostname: "registry.mssola.cat", use_ssl: true)
+      end
+
+      it "handles a proper 200 response" do
+        VCR.use_cassette("health/clair-ok", record: :none) do
+          get :health
+          expect(response.status).to eq 200
+        end
+      end
+
+      it "works even if the server contains another port" do
+        APP_CONFIG["security"]["clair"]["server"] = "http://registry.mssola.cat:6060"
+
+        VCR.use_cassette("health/clair-ok", record: :none) do
+          get :health
+          expect(response.status).to eq 200
+        end
+      end
+
+      it "handles errors as well" do
+        # Forcing a 404 from Clair.
+        expect(::Portus::HealthChecks::Clair).to receive(:health_endpoint).and_raise(SocketError)
+
+        VCR.use_cassette("health/clair-bad", record: :none) do
+          get :health
+          expect(response.status).to eq 503
+        end
+      end
+    end
+  end
+end

--- a/spec/vcr_cassettes/health/clair-bad.yml
+++ b/spec/vcr_cassettes/health/clair-bad.yml
@@ -1,0 +1,50 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://registry.mssola.cat/v2/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/vnd.docker.distribution.manifest.v2+json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 03 Aug 2017 15:50:16 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Www-Authenticate:
+      - Basic realm="Application"
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - d0865133-bb26-4eac-ac26-370f66bc457c
+      X-Runtime:
+      - '0.006993'
+    body:
+      encoding: UTF-8
+      string: '{"error":"You need to sign in or sign up before continuing."}'
+    http_version: 
+  recorded_at: Thu, 03 Aug 2017 15:50:16 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/health/clair-ok.yml
+++ b/spec/vcr_cassettes/health/clair-ok.yml
@@ -1,0 +1,81 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://registry.mssola.cat/v2/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/vnd.docker.distribution.manifest.v2+json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 03 Aug 2017 15:47:26 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Www-Authenticate:
+      - Basic realm="Application"
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - d6e6ff71-6077-4797-b255-f806857fff9c
+      X-Runtime:
+      - '0.107929'
+    body:
+      encoding: UTF-8
+      string: '{"error":"You need to sign in or sign up before continuing."}'
+    http_version: 
+  recorded_at: Thu, 03 Aug 2017 15:47:26 GMT
+- request:
+    method: get
+    uri: http://registry.mssola.cat:6061/health
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - clair
+      Date:
+      - Thu, 03 Aug 2017 15:47:26 GMT
+      Content-Length:
+      - '0'
+      Content-Type:
+      - text/plain; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 03 Aug 2017 15:47:26 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/health/ok.yml
+++ b/spec/vcr_cassettes/health/ok.yml
@@ -1,0 +1,50 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://registry.mssola.cat/v2/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/vnd.docker.distribution.manifest.v2+json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 03 Aug 2017 15:36:22 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Www-Authenticate:
+      - Basic realm="Application"
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 9eed8ef5-8c52-4673-af54-afb6534925b0
+      X-Runtime:
+      - '0.190492'
+    body:
+      encoding: UTF-8
+      string: '{"error":"You need to sign in or sign up before continuing."}'
+    http_version: 
+  recorded_at: Thu, 03 Aug 2017 15:36:22 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
Portus now provides two new endpoints:

- /_ping: used as a simple check. It will always return 200.
- /_health: returns a JSON response containing the status report of the
different configured components.

Fixes #1357 

- [x] Tests
- [x] Documentation (see #1368)

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>