### PR TITLE
js: added table paginated mixin; namespaces using it

### DIFF
--- a/app/assets/javascripts/modules/namespaces/components/panel.js
+++ b/app/assets/javascripts/modules/namespaces/components/panel.js
@@ -8,7 +8,7 @@ import NamespacesStore from '../store';
 export default {
   template: '#js-namespaces-panel-tmpl',
 
-  props: ['namespaces', 'tableSortable'],
+  props: ['namespaces', 'tableSortable', 'prefix'],
 
   data() {
     return {

--- a/app/assets/javascripts/modules/namespaces/components/table.js
+++ b/app/assets/javascripts/modules/namespaces/components/table.js
@@ -2,8 +2,8 @@ import getProperty from 'lodash/get';
 
 import Comparator from '~/utils/comparator';
 
-import TablePagination from '~/shared/components/table-pagination';
 import TableSortableMixin from '~/shared/mixins/table-sortable';
+import TablePaginatedMixin from '~/shared/mixins/table-paginated';
 
 import NamespaceTableRow from './table-row';
 
@@ -20,25 +20,13 @@ export default {
     },
   },
 
-  mixins: [TableSortableMixin],
+  mixins: [TableSortableMixin, TablePaginatedMixin],
 
   components: {
     NamespaceTableRow,
-    TablePagination,
-  },
-
-  data() {
-    return {
-      limit: 3,
-      currentPage: 1,
-    };
   },
 
   computed: {
-    offset() {
-      return (this.currentPage - 1) * this.limit;
-    },
-
     filteredNamespaces() {
       const order = this.sorting.asc ? 1 : -1;
       const sortedNamespaces = [...this.namespaces];
@@ -60,6 +48,4 @@ export default {
       return slicedNamespaces;
     },
   },
-
-
 };

--- a/app/assets/javascripts/shared/components/table-pagination.vue
+++ b/app/assets/javascripts/shared/components/table-pagination.vue
@@ -14,7 +14,7 @@
         <li
           v-for="(page, index) in displayedPages"
           :key="index"
-          :class="{'active': currentPage == page}">
+          :class="{ 'active': currentPage == page }">
             <a href="#" @click.prevent="setCurrentPage(page)">{{ page }}</a>
         </li>
         <li :class="{ 'disabled': nextDisabled }">
@@ -92,7 +92,7 @@
           return;
         }
 
-        this.$emit('update:currentPage', page);
+        this.$emit('update', page);
       },
     },
   };

--- a/app/assets/javascripts/shared/mixins/table-paginated.js
+++ b/app/assets/javascripts/shared/mixins/table-paginated.js
@@ -1,0 +1,56 @@
+import Vue from 'vue';
+import queryString from 'query-string';
+
+import TablePagination from '~/shared/components/table-pagination';
+
+const { set } = Vue;
+
+export default {
+  props: {
+    limit: {
+      type: Number,
+      default: 3,
+    },
+  },
+
+  components: {
+    TablePagination,
+  },
+
+  data() {
+    return {
+      currentPage: 1,
+    };
+  },
+
+  computed: {
+    offset() {
+      return (this.currentPage - 1) * this.limit;
+    },
+  },
+
+  methods: {
+    updateCurrentPage(page) {
+      set(this, 'currentPage', page);
+
+      this.updateUrlPaginationState();
+    },
+
+    updateUrlPaginationState() {
+      const queryObject = queryString.parse(window.location.search);
+
+      queryObject[this.prefix + 'page'] = this.currentPage;
+
+      const queryParams = queryString.stringify(queryObject);
+      const url = [location.protocol, '//', location.host, location.pathname].join('');
+      history.pushState('', '', `${url}?${queryParams}`);
+    },
+  },
+
+  beforeMount() {
+    const queryObject = queryString.parse(window.location.search);
+    const pageQuery = parseInt(queryObject[this.prefix + 'page'], 10) || this.currentPage;
+
+    set(this, 'currentPage', pageQuery);
+  },
+};

--- a/app/assets/javascripts/shared/mixins/table-sortable.js
+++ b/app/assets/javascripts/shared/mixins/table-sortable.js
@@ -1,5 +1,4 @@
 import Vue from 'vue';
-
 import queryString from 'query-string';
 
 const { set } = Vue;
@@ -32,19 +31,6 @@ export default {
     };
   },
 
-  beforeMount() {
-    if (!this.sortable) {
-      return;
-    }
-
-    const queryObject = queryString.parse(window.location.search);
-    const sortByQuery = queryObject[this.prefix + 'sort_by'] || this.sorting.by;
-    const sortAscQuery = (queryObject[this.prefix + 'sort_asc'] || this.sorting.asc) === 'true';
-
-    set(this.sorting, 'by', sortByQuery);
-    set(this.sorting, 'asc', sortAscQuery);
-  },
-
   methods: {
     sort(attribute) {
       if (!this.sortable) {
@@ -61,10 +47,10 @@ export default {
 
       set(this.sorting, 'by', attribute);
 
-      this.updateUrlState();
+      this.updateUrlSortingState();
     },
 
-    updateUrlState() {
+    updateUrlSortingState() {
       const queryObject = queryString.parse(window.location.search);
 
       queryObject[this.prefix + 'sort_asc'] = this.sorting.asc;
@@ -74,5 +60,18 @@ export default {
       const url = [location.protocol, '//', location.host, location.pathname].join('');
       history.pushState('', '', `${url}?${queryParams}`);
     },
+  },
+
+  beforeMount() {
+    if (!this.sortable) {
+      return;
+    }
+
+    const queryObject = queryString.parse(window.location.search);
+    const sortByQuery = queryObject[this.prefix + 'sort_by'] || this.sorting.by;
+    const sortAscQuery = (queryObject[this.prefix + 'sort_asc'] || this.sorting.asc) === 'true';
+
+    set(this.sorting, 'by', sortByQuery);
+    set(this.sorting, 'asc', sortAscQuery);
   },
 };

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -28,7 +28,7 @@ html
     meta content="/favicon/browserconfig.xml" name="msapplication-config"
     meta content="#205683" name="theme-color"
 
-    script src="//cdn.polyfill.io/v2/polyfill.js?features=Array.prototype.findIndex"
+    script src="//cdn.polyfill.io/v2/polyfill.js?features=Array.prototype.findIndex,Array.from"
     = javascript_include_tag(*webpack_asset_paths("application"))
     = yield :js_header
 

--- a/app/views/namespaces/components/_panel.html.slim
+++ b/app/views/namespaces/components/_panel.html.slim
@@ -11,4 +11,4 @@
 
     .table-responsive
       <namespaces-not-loaded v-if="state.notLoaded"></namespaces-not-loaded>
-      <namespaces-table v-if="!state.isLoading && !state.notLoaded" :namespaces="namespaces" :sortable="tableSortable" sort-by="attributes.clean_name"></namespaces-table>
+      <namespaces-table v-if="!state.isLoading && !state.notLoaded" :namespaces="namespaces" :sortable="tableSortable" sort-by="attributes.clean_name" :prefix="prefix"></namespaces-table>

--- a/app/views/namespaces/components/_table.html.slim
+++ b/app/views/namespaces/components/_table.html.slim
@@ -51,4 +51,4 @@ div
     tbody
       <namespace-table-row v-for="namespace in filteredNamespaces" :key="namespace.id" :namespace="namespace"></namespace-table-row>
 
-  <table-pagination :total.sync="namespaces.length" :current-page.sync="currentPage" :itens-per-page.sync="limit"></table-pagination>
+  <table-pagination :total.sync="namespaces.length" :current-page="currentPage" :itens-per-page.sync="limit" @update="updateCurrentPage"></table-pagination>

--- a/app/views/namespaces/partials/_special_namespaces.html.slim
+++ b/app/views/namespaces/partials/_special_namespaces.html.slim
@@ -1,4 +1,4 @@
-<namespaces-panel :namespaces="specialNamespaces">
+<namespaces-panel :namespaces="specialNamespaces" prefix="sns_">
   h5 slot="name"
     a[data-placement="right"
       data-toggle="popover"

--- a/spec/features/namespaces_spec.rb
+++ b/spec/features/namespaces_spec.rb
@@ -196,6 +196,40 @@ feature "Namespaces support" do
       path = namespaces_path(ns_sort_asc: false, ns_sort_by: "attributes.created_at")
       expect(page).to have_current_path(path)
     end
+
+    scenario "Namespace table pagination is reachable through url", js: true do
+      create_list(:namespace, 5, team: team, registry: registry)
+
+      # page 2
+      visit namespaces_path(ns_page: 2)
+
+      expect(page).to have_css(".namespaces-panel .pagination li.active:nth-child(3)")
+
+      # page 1
+      visit namespaces_path(ns_page: 1)
+
+      expect(page).to have_css(".namespaces-panel .pagination li.active:nth-child(2)")
+    end
+
+    scenario "URL is updated when page is changed", js: true do
+      create_list(:namespace, 5, team: team, registry: registry)
+
+      visit namespaces_path
+
+      expect(page).to have_css(".namespaces-panel:last-of-type .pagination li:nth-child(3)")
+
+      # page 2
+      find(".namespaces-panel:last-of-type .pagination li:nth-child(3) a").click
+
+      expect(page).to have_css(".namespaces-panel:last-of-type .pagination li.active:nth-child(3)")
+      expect(page).to have_current_path(namespaces_path(ns_page: 2))
+
+      # page 1
+      find(".namespaces-panel:last-of-type .pagination li:nth-child(2) a").click
+
+      expect(page).to have_css(".namespaces-panel:last-of-type .pagination li.active:nth-child(2)")
+      expect(page).to have_current_path(namespaces_path(ns_page: 1))
+    end
   end
 
   describe "#update" do

--- a/spec/features/teams_spec.rb
+++ b/spec/features/teams_spec.rb
@@ -194,6 +194,40 @@ feature "Teams support" do
       expect(page).to have_current_path(path)
     end
 
+    scenario "Namespace table pagination is reachable through url", js: true do
+      create_list(:namespace, 5, team: team, registry: registry)
+
+      # page 2
+      visit team_path(team, ns_page: 2)
+
+      expect(page).to have_css(".namespaces-panel .pagination li.active:nth-child(3)")
+
+      # page 1
+      visit team_path(team, ns_page: 1)
+
+      expect(page).to have_css(".namespaces-panel .pagination li.active:nth-child(2)")
+    end
+
+    scenario "URL is updated when page is changed", js: true do
+      create_list(:namespace, 5, team: team, registry: registry)
+
+      visit team_path(team)
+
+      expect(page).to have_css(".namespaces-panel:last-of-type .pagination li:nth-child(3)")
+
+      # page 2
+      find(".namespaces-panel:last-of-type .pagination li:nth-child(3) a").click
+
+      expect(page).to have_css(".namespaces-panel:last-of-type .pagination li.active:nth-child(3)")
+      expect(page).to have_current_path(team_path(team, ns_page: 2))
+
+      # page 2
+      find(".namespaces-panel:last-of-type .pagination li:nth-child(2) a").click
+
+      expect(page).to have_css(".namespaces-panel:last-of-type .pagination li.active:nth-child(2)")
+      expect(page).to have_current_path(team_path(team, ns_page: 1))
+    end
+
     scenario "An user can be added as a team member", js: true do
       find("#add_team_user_btn").click
       find("#team_user_role").select "Contributor"


### PR DESCRIPTION
So far the pagination was possible but user wasn't able
to share the state of it with someone by copying and pasting url.

Now every pagination action the user makes on the namespaces table,
for example, will create a new url state that can be visited and
navigated back and forth.

Fixes #1390