### PR TITLE
js: added inline validation for namespace's new form

### DIFF
--- a/app/assets/javascripts/modules/namespaces/services/namespaces.js
+++ b/app/assets/javascripts/modules/namespaces/services/namespaces.js
@@ -8,6 +8,14 @@ const customActions = {
     method: 'PUT',
     url: '/namespaces/{id}/change_visibility',
   },
+  teamTypeahead: {
+    method: 'GET',
+    url: '/namespaces/typeahead/{teamName}',
+  },
+  existsByName: {
+    method: 'HEAD',
+    url: '/namespaces',
+  },
 };
 
 const resource = Vue.resource('/namespaces{/id}.json', {}, customActions);
@@ -20,6 +28,22 @@ function changeVisibility(id, params = {}) {
   return resource.changeVisibility({ id }, params);
 }
 
+function searchTeam(teamName) {
+  return resource.teamTypeahead({ teamName });
+}
+
+function existsByName(name) {
+  return resource.existsByName({ name })
+    .then(() => true)
+    .catch((response) => {
+      if (response.status === 404) {
+        return false;
+      }
+
+      return null;
+    });
+}
+
 function get(id) {
   return resource.get({ id });
 }
@@ -28,9 +52,28 @@ function save(namespace) {
   return resource.save({}, namespace);
 }
 
+function teamExists(value) {
+  return searchTeam(value)
+    .then((response) => {
+      const collection = response.data;
+
+      if (Array.isArray(collection)) {
+        return collection.some(e => e.name === value);
+      }
+
+      // some unexpected response from the api,
+      // leave it for the back-end validation
+      return null;
+    })
+    .catch(() => null);
+}
+
 export default {
   get,
   all,
   save,
   changeVisibility,
+  searchTeam,
+  teamExists,
+  existsByName,
 };

--- a/app/assets/javascripts/vue-shared.js
+++ b/app/assets/javascripts/vue-shared.js
@@ -1,6 +1,8 @@
 import Vue from 'vue';
 import VueResource from 'vue-resource';
+import Vuelidate from 'vuelidate';
 
+Vue.use(Vuelidate);
 Vue.use(VueResource);
 
 Vue.http.interceptors.push((_request, next) => {

--- a/app/assets/stylesheets/includes/forms.scss
+++ b/app/assets/stylesheets/includes/forms.scss
@@ -47,3 +47,18 @@ textarea.fixed-size {
 .twitter-typeahead, .tt-dropdown-menu {
   width: 100%;
 }
+
+// help block
+.form-group {
+  .help-block {
+    display: none;
+    margin-bottom: 0;
+  }
+}
+.has-success,
+.has-warning,
+.has-error {
+  .help-block {
+    display: block;
+  }
+}

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -28,7 +28,7 @@ html
     meta content="/favicon/browserconfig.xml" name="msapplication-config"
     meta content="#205683" name="theme-color"
 
-    script src="//cdn.polyfill.io/v2/polyfill.js?features=Array.prototype.findIndex,Array.from"
+    script src="//cdn.polyfill.io/v2/polyfill.js?features=Array.prototype.some,Array.prototype.findIndex,Array.from"
     = javascript_include_tag(*webpack_asset_paths("application"))
     = yield :js_header
 

--- a/app/views/namespaces/components/_form.html.slim
+++ b/app/views/namespaces/components/_form.html.slim
@@ -2,17 +2,30 @@ div ref="form" class="collapse"
   = form_for :namespace, url: namespaces_path, html: {id: "new-namespace-form", class: "form-horizontal", role: "form", name: "form", "@submit.prevent" => "onSubmit", novalidate: true} do |f|
     = f.hidden_field(:team, "v-model" => "namespace.namespace.team", "v-if" => "teamName")
 
-    .form-group
+    .form-group :class=="{ 'has-error': $v.namespace.namespace.name.$error }"
       = f.label :name, {class: "control-label col-md-2"}
       .col-md-7
-        = f.text_field(:name, class: "form-control", required: true, placeholder: "New namespace's name".html_safe, ref: "firstField", "v-model" => "namespace.namespace.name")
+        = f.text_field(:name, class: "form-control", placeholder: "New namespace's name".html_safe, ref: "firstField", "@input" => "$v.namespace.namespace.name.$touch()", "v-model.trim" => "namespace.namespace.name")
+        span.help-block
+          span v-if="!$v.namespace.namespace.name.required"
+            | Name can't be blank
+          span v-if="!$v.namespace.namespace.name.format"
+            | Name can only contain lower case alphanumeric characters, with optional underscores and dashes in the middle
+          span v-if="!$v.namespace.namespace.name.available"
+            | Name has already been taken
 
-    .form-group.has-feedback v-if="!teamName"
+    .form-group.has-feedback :class=="{ 'has-error': $v.namespace.namespace.team.$error }" v-if="!teamName"
       = f.label :team, {class: "control-label col-md-2"}
       .col-md-7
         .remote
-          = f.text_field(:team, class: "form-control typeahead", required: true, placeholder: "Name of the team", "v-model" => "namespace.namespace.team")
+          = f.text_field(:team, class: "form-control typeahead", required: true, placeholder: "Name of the team", "@input" => "$v.namespace.namespace.team.$touch()", "v-model.trim" => "namespace.namespace.team")
         span.fa.fa-search.form-control-feedback
+        span.help-block
+          span v-if="!$v.namespace.namespace.team.required"
+            | Team can't be blank
+            br
+          span v-if="!$v.namespace.namespace.team.available"
+            | Selected team does not exist
 
     .form-group
       = f.label :description, {class: "control-label col-md-2"}
@@ -21,4 +34,4 @@ div ref="form" class="collapse"
 
     .form-group
       .col-md-offset-2.col-md-7
-        = f.submit("Create", class: "btn btn-primary")
+        = f.submit("Create", class: "btn btn-primary", ":disabled" => "$v.$invalid")

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "vue-loader": "^12.0.3",
     "vue-resource": "^1.3.1",
     "vue-template-compiler": "^2.3.3",
+    "vuelidate": "^0.5.0",
     "webpack": "^2.2.1"
   },
   "babel": {

--- a/spec/features/namespaces_spec.rb
+++ b/spec/features/namespaces_spec.rb
@@ -13,58 +13,65 @@ feature "Namespaces support" do
   end
 
   describe "Namespaces#index" do
-    scenario "An user cannot create an empty namespace", js: true do
-      namespaces_count = Namespace.count
-
+    scenario "An user cannot submit with invalid form", js: true do
       visit namespaces_path
+
       find(".toggle-link-new-namespace").click
+      wait_for_effect_on("#new-namespace-form")
 
-      click_button "Create"
-
-      wait_for_ajax
-
-      expect(Namespace.count).to eql namespaces_count
-      expect(page).to have_current_path(namespaces_path)
+      expect(page).to have_button("Create", disabled: true)
     end
 
-    scenario "An user cannot create a namespace that already exists", js: true do
-      namespaces_count = Namespace.count
-
+    scenario "A user cannot leave name field empty", js: true do
       visit namespaces_path
+
       find(".toggle-link-new-namespace").click
       wait_for_effect_on("#new-namespace-form")
 
       fill_in "Name", with: Namespace.first.name
-      fill_in "Team", with: Team.where(hidden: false).first.name
-      click_button "Create"
+      fill_in "Name", with: ""
 
+      expect(page).to have_content("Name can't be blank")
+      expect(page).to have_button("Create", disabled: true)
+    end
+
+    scenario "A user cannot fill field with an invalid name", js: true do
+      visit namespaces_path
+
+      find(".toggle-link-new-namespace").click
+      wait_for_effect_on("#new-namespace-form")
+
+      fill_in "Name", with: "!@#!@#"
+
+      expect(page).to have_content("Name can only contain lower case alphanumeric characters")
+      expect(page).to have_button("Create", disabled: true)
+    end
+
+    scenario "An user cannot create a namespace that already exists", js: true do
+      visit namespaces_path
+
+      find(".toggle-link-new-namespace").click
+      wait_for_effect_on("#new-namespace-form")
+
+      fill_in "Name", with: Namespace.first.name
       wait_for_ajax
-      wait_for_effect_on("#float-alert")
 
-      expect(page).to have_current_path(namespaces_path)
-      expect(page).to have_css("#float-alert")
       expect(page).to have_content("Name has already been taken")
-      expect(Namespace.count).to eql namespaces_count
+      expect(page).to have_button("Create", disabled: true)
     end
 
     scenario "An user cannot create a namespace for a hidden team", js: true do
-      namespaces_count = Namespace.count
-
       visit namespaces_path
+
       find(".toggle-link-new-namespace").click
       wait_for_effect_on("#new-namespace-form")
 
       fill_in "Name", with: Namespace.first.name
       fill_in "Team", with: Team.where(hidden: true).first.name
-      click_button "Create"
-
       wait_for_ajax
-      wait_for_effect_on("#float-alert")
 
-      expect(page).to have_current_path(namespaces_path)
-      expect(page).to have_css("#float-alert")
       expect(page).to have_content("Selected team does not exist")
-      expect(Namespace.count).to eql namespaces_count
+      expect(page).to have_button("Create", disabled: true)
     end
 
     scenario "A namespace can be created from the index page", js: true do

--- a/yarn.lock
+++ b/yarn.lock
@@ -4300,6 +4300,10 @@ vue@^2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.3.3.tgz#d1eaa8fde5240735a4563e74f2c7fead9cbb064c"
 
+vuelidate@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/vuelidate/-/vuelidate-0.5.0.tgz#c315659a023e760d0fb11b6b42b6c3cdf08306c3"
+
 watchpack@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.3.1.tgz#7d8693907b28ce6013e7f3610aa2a1acf07dad87"


### PR DESCRIPTION
The validation so far was fully done on the server side and
the feedback was through the float alert that disappears in 5 seconds.
Not the best experience for the users.

Now, for each field (name and team), we have an inline feedback validation.
User will only see a validation message on the float alert in unexpected
situations.

Fixes #1376

![inline-validation](https://user-images.githubusercontent.com/188554/29563752-548c1124-8715-11e7-91c1-070d86888ec4.gif)
