### PR TITLE
Added some registry validation and status

### DIFF
--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -13,13 +13,11 @@ import 'bootstrap/js/collapse';
 // Life it up
 import 'vendor/lifeitup_layout';
 
+import './bootstrap';
 import './vue-shared';
 
-// Require tree.
-// NOTE: This should be moved into proper modules.
-import './bootstrap';
-
-// new modules structure
+// modules
+import './modules/admin/registries';
 import './modules/users';
 import './modules/dashboard';
 import './modules/explore';

--- a/app/assets/javascripts/modules/admin/registries/components/form.js
+++ b/app/assets/javascripts/modules/admin/registries/components/form.js
@@ -1,0 +1,125 @@
+import Vue from 'vue';
+
+import { required } from 'vuelidate/lib/validators';
+
+import RegistriesService from '../service';
+
+const { set } = Vue;
+
+const timeouts = {};
+
+export default {
+  template: '#js-registry-form-tmpl',
+
+  props: {
+    canChangeHostname: {
+      type: Boolean,
+    },
+    edit: {
+      type: Boolean,
+      default: false,
+    },
+  },
+
+  data() {
+    return {
+      original: window.registry,
+      registry: {
+        name: window.registry.name || '',
+        hostname: window.registry.hostname || '',
+        external_hostname: window.registry.external_hostname || '',
+        use_ssl: window.registry.use_ssl || false,
+        force: false,
+      },
+      errors: {
+        name: [],
+        hostname: [],
+      },
+      display: {
+        force: window.showForce || false,
+      },
+    };
+  },
+
+  validations: {
+    registry: {
+      name: {
+        required,
+        remote(value) {
+          return this.validate('name', value);
+        },
+      },
+      hostname: {
+        required,
+        remote(value) {
+          // workaround to force validation when use_ssl changes
+          void this.registry.use_ssl;
+
+          set(this.display, 'force', false);
+
+          const promise = this.validate('hostname', value);
+
+          if (promise.then) {
+            promise.then(() => {
+              const hasHostnameErrors = (this.errors.hostname || []).length > 0;
+              set(this.display, 'force', hasHostnameErrors);
+            });
+          }
+
+          return promise;
+        },
+      },
+    },
+  },
+
+  methods: {
+    isReachableError(error) {
+      return error.indexOf('Error: ') === 0 ||
+             error.indexOf('SSL ') === 0;
+    },
+
+    hasReachableError() {
+      const errors = this.errors.hostname || [];
+
+      return errors.some(e => this.isReachableError(e));
+    },
+
+    validate(field, value) {
+      clearTimeout(timeouts[field]);
+
+      // required already taking care of this
+      if (value === '' || value === this.original[field]) {
+        set(this.errors, field, []);
+        return true;
+      }
+
+      return new Promise((resolve) => {
+        const validateRequest = () => {
+          const promise = RegistriesService.validate(this.registry, field);
+
+          promise.then(({ valid, messages }) => {
+            set(this.errors, field, messages[field]);
+
+            resolve(valid);
+          });
+        };
+
+        set(this.errors, field, []);
+        timeouts[field] = setTimeout(validateRequest, 1000);
+      });
+    },
+  },
+
+  computed: {
+    submitDisabled() {
+      const nameInvalid = this.$v.registry.name.$invalid;
+      const hostnameRequiredInvalid = !this.$v.registry.hostname.required;
+      const hostnameReachableInvalid = this.hasReachableError() && !this.registry.force;
+
+      return nameInvalid ||
+             hostnameRequiredInvalid ||
+             hostnameReachableInvalid ||
+             this.$v.$pending;
+    },
+  },
+};

--- a/app/assets/javascripts/modules/admin/registries/index.js
+++ b/app/assets/javascripts/modules/admin/registries/index.js
@@ -1,0 +1,2 @@
+import './pages/new';
+import './pages/edit';

--- a/app/assets/javascripts/modules/admin/registries/pages/edit.js
+++ b/app/assets/javascripts/modules/admin/registries/pages/edit.js
@@ -1,0 +1,18 @@
+import Vue from 'vue';
+
+import RegistryForm from '../components/form';
+
+$(() => {
+  if (!$('body[data-route="admin/registries/edit"]').length) {
+    return;
+  }
+
+  // eslint-disable-next-line no-new
+  new Vue({
+    el: 'body[data-route="admin/registries/edit"] .vue-root',
+
+    components: {
+      RegistryForm,
+    },
+  });
+});

--- a/app/assets/javascripts/modules/admin/registries/pages/new.js
+++ b/app/assets/javascripts/modules/admin/registries/pages/new.js
@@ -1,0 +1,18 @@
+import Vue from 'vue';
+
+import RegistryForm from '../components/form';
+
+$(() => {
+  if (!$('body[data-route="admin/registries/new"]').length) {
+    return;
+  }
+
+  // eslint-disable-next-line no-new
+  new Vue({
+    el: 'body[data-route="admin/registries/new"] .vue-root',
+
+    components: {
+      RegistryForm,
+    },
+  });
+});

--- a/app/assets/javascripts/modules/admin/registries/service.js
+++ b/app/assets/javascripts/modules/admin/registries/service.js
@@ -1,0 +1,29 @@
+import Vue from 'vue';
+import VueResource from 'vue-resource';
+
+Vue.use(VueResource);
+
+const customActions = {
+  validate: {
+    method: 'GET',
+    url: 'api/v1/registries/validate',
+  },
+};
+
+const resource = Vue.resource('api/v1/registries/{/id}.json', {}, customActions);
+
+function validate(registry, field = null) {
+  const data = registry;
+
+  if (field) {
+    data['only[]'] = field;
+  }
+
+  return resource.validate(data)
+    .then(response => response.data)
+    .catch(() => null);
+}
+
+export default {
+  validate,
+};

--- a/app/assets/stylesheets/pages/registries.scss
+++ b/app/assets/stylesheets/pages/registries.scss
@@ -1,0 +1,9 @@
+.registry-status {
+  .fa-chain {
+    color: #449d44;
+  }
+
+  .fa-chain-broken {
+    color: #c9302c;
+  }
+}

--- a/app/helpers/registries_helper.rb
+++ b/app/helpers/registries_helper.rb
@@ -1,0 +1,14 @@
+module RegistriesHelper
+  # Render registry status icon
+  def registry_status_icon(registry)
+    error = registry.reachable?
+    msg   = error.empty? ? "Reachable" : error
+    time  = Time.now.getlocal.to_s(:rfc822)
+    icon  = "chain"
+    icon << "-broken" unless error.empty?
+
+    title = "#{msg} - Checked at #{time}"
+
+    content_tag :i, "", class: "fa fa-lg fa-#{icon}", title: title
+  end
+end

--- a/app/services/base_validate_service.rb
+++ b/app/services/base_validate_service.rb
@@ -1,0 +1,26 @@
+class BaseValidateService
+  attr_accessor :params
+
+  def initialize(params = {})
+    @params = params.dup
+    @messages = {}
+  end
+
+  private
+
+  def only_params
+    params[:only]
+  end
+
+  def messages
+    return @messages if only_params.nil?
+
+    @messages.keep_if { |key| only_params.include?(key.to_s) }
+  end
+
+  def valid?
+    return @valid if only_params.nil?
+
+    only_params.all? { |field| @messages[field.to_sym].nil? }
+  end
+end

--- a/app/services/registries/validate_service.rb
+++ b/app/services/registries/validate_service.rb
@@ -1,0 +1,30 @@
+module Registries
+  class ValidateService < ::BaseValidateService
+    def execute
+      @registry = Registry.new(registry_params)
+      @valid    = @registry.valid?
+      @messages = @registry.errors.messages
+
+      check_reachability!
+
+      { valid: valid?, messages: messages }
+    end
+
+    private
+
+    def registry_params
+      params.reject { |key| key.to_sym == :only }
+    end
+
+    def check_reachability!
+      if only_params.nil? || only_params.include?("hostname")
+        reachable_msg = @registry.reachable?
+
+        unless reachable_msg.blank?
+          @valid = false
+          @messages[:hostname] = (@messages[:hostname] || []).push(reachable_msg)
+        end
+      end
+    end
+  end
+end

--- a/app/views/admin/registries/components/_form.html.slim
+++ b/app/views/admin/registries/components/_form.html.slim
@@ -1,0 +1,63 @@
+= form_for @registry, url: form_url, html: {class: 'form-horizontal', role: 'form'} do |f|
+  .form-group :class=="{ 'has-error': $v.registry.name.$error }"
+    = f.label :name, {class: 'control-label col-md-2'}
+    .col-md-7
+      = f.text_field(:name, class: 'form-control', autofocus: true, value: @registry.name, ref: "name", "v-model.trim" => "registry.name", "@input" => "$v.registry.name.$touch()")
+      span.help-block
+        span v-if="!$v.registry.name.required"
+          | Name can't be blank
+        span v-for="(error, index) in errors.name" :key="index"
+          | Name {{ error }}
+  .form-group :class=="{ 'has-error': $v.registry.hostname.$error }" v-if="canChangeHostname"
+    = f.label :hostname, {class: 'control-label col-md-2'}
+    .col-md-7
+      = f.text_field(:hostname, class: 'form-control', placeholder: 'registry.test.lan:5000', "v-model.trim" => "registry.hostname", "@input" => "$v.registry.hostname.$touch()")
+      span.help-block
+        span v-if="!$v.registry.hostname.required"
+          | Hostname can't be blank
+          br
+        span v-for="(error, index) in errors.hostname" :key="index"
+          span v-if="!isReachableError(error)"
+            | Hostname {{ error }}
+            br
+          span v-if="isReachableError(error)"
+            | {{ error }} You can skip this check by clicking on the "Skip remote checks" checkbox.
+            br
+  .form-group
+    = f.label :use_ssl, "Use SSL", {class: 'control-label col-md-2', title: 'Set this to enable SSL in the communication between Portus and the Registry'}
+    .col-md-7
+      = f.check_box(:use_ssl, "v-model" => "registry.use_ssl")
+  div.collapse#advanced
+    .form-group
+      = f.label :external_hostname, "External Registry Name", {class:'control-label col-md-2', title: 'Set this if the name that clients use to communicate with the registry is different than the name that Portus uses to connect'}
+      .col-md-7
+        = f.text_field(:external_hostname, class: 'form-control', placeholder: '(Optional)', "v-model" => "registry.external_hostname")
+        span.help-block
+          | Portus uses the hostname field to communicate with the registry,
+            but this may be on an internal network and inaccessible to the
+            client.
+            Clients may connect to the registry by a name different to the
+            hostname above, for example if it is behind a reverse proxy.
+            This field must be set to prevent Portus from ignoring registry
+            events originating from this external hostname.
+  .form-group.has-error v-if="display.force && !edit"
+    = label_tag :force, "Skip remote checks", {class: 'control-label col-md-2', title: "Force the creation of the registry, even if it's not reachable."}
+    .col-md-7
+      = check_box_tag(:force, true, false, { "v-model" => "registry.force" })
+  .form-group
+    .col-md-offset-2.col-md-7
+      div.btn-toolbar role='toolbar'
+        div.btn-group role='group'
+          = f.submit(submit_name, class: 'btn btn-primary', ":disabled" => "submitDisabled")
+        div.btn-group role='group'
+          span data-toggle='collapse' data-target='#advanced'
+            button.btn.btn-primary#advancedButton type='button' data-toggle='button' aria-expanded='false' aria-controls='advanced' Show Advanced
+
+- content_for :js_body do
+  javascript:
+    window.registry = #{raw @registry.to_json};
+    window.showForce = #{!flash[:alert].nil? && !flash[:alert].empty?};
+
+    $('body').on('click', '#advancedButton', function() {
+      $(this).text($(this).text() == 'Show Advanced' ? 'Hide Advanced' : 'Show Advanced');
+    });

--- a/app/views/admin/registries/edit.html.slim
+++ b/app/views/admin/registries/edit.html.slim
@@ -5,46 +5,8 @@
       strong
         = @registry.name
   .panel-body
-    = form_for @registry, url: admin_registry_path(@registry.id), html: {class: 'form-horizontal', role: 'form'} do |f|
-      .form-group
-        = f.label :name, {class: 'control-label col-md-2'}
-        .col-md-7
-          = f.text_field(:name, class: 'form-control', required: true, value: @registry.name)
-      - if @can_change_hostname
-        .form-group
-          = f.label :hostname, {class: 'control-label col-md-2'}
-          .col-md-7
-            = f.text_field(:hostname, class: 'form-control', placeholder: 'registry.test.lan', required: true)
-      .form-group
-        = f.label :use_ssl, "Use SSL", {class: 'control-label col-md-2', title: 'Set this to enable SSL in the communication between Portus and the Registry', checked: @registry.use_ssl?}
-        .col-md-7
-          = f.check_box(:use_ssl)
-      div.collapse#advanced
-        .form-group
-          = f.label :external_hostname, "External Registry Name", {class:'control-label col-md-2', title: 'Set this if the name that clients use to communicate with the registry is different than the name that Portus uses to connect'}
-          .col-md-7
-            - if params[:external_hostname]
-              = f.text_field(:external_hostname, class: 'form-control', value: params[:external_hostname], placeholder: '(Optional)', required: false)
-            - else
-              = f.text_field(:external_hostname, class: 'form-control', placeholder: '(Optional)', required: false)
-            span.help-block
-              | Portus uses the hostname field to communicate with the registry,
-                but this may be on an internal network and inaccessible to the
-                client.
-                Clients may connect to the registry by a name different to the
-                hostname above, for example if it is behind a reverse proxy.
-                This field must be set to prevent Portus from ignoring registry
-                events originating from this external hostname.
-      .form-group
-        .col-md-offset-2.col-md-7
-          div.btn-toolbar role='toolbar'
-            div.btn-group role='group'
-              = f.submit('Update', class: 'btn btn-primary')
-            div.btn-group role='group'
-              span data-toggle='collapse' data-target='#advanced'
-                button.btn.btn-primary#advancedButton type='button' data-toggle='button' aria-expanded='false' aria-controls='advanced' Show Advanced
-                javascript:
-                  $('#advancedButton').click(function() {
-                    $(this).text($(this).text() == 'Show Advanced' ? 'Hide Advanced' : 'Show Advanced');
-                  });
+    <registry-form :can-change-hostname="#{@can_change_hostname}" :edit="true"></registry-form>
 
+- content_for :js_body do
+  script#js-registry-form-tmpl type="text/x-template"
+    = render partial: 'admin/registries/components/form', locals: { form_url: admin_registry_path(@registry), submit_name: "Update" }

--- a/app/views/admin/registries/index.html.slim
+++ b/app/views/admin/registries/index.html.slim
@@ -24,6 +24,7 @@
               th Name
               th Hostname
               th SSL
+              th.text-center Reachable
               th
           tbody
             - @registries.each do |registry|
@@ -32,6 +33,9 @@
                 td= registry.hostname
                 td
                   i.fa.fa-lg class="fa-toggle-#{registry.use_ssl? ? 'on': 'off'}" title="SSL in the comunication between Portus and this registry is #{registry.use_ssl? ? "enabled" : "disabled"}"
+                td.text-center.registry-status
+                  - cache "registry#{registry.id}_status", expires_in: 30.minutes do
+                    = registry_status_icon(registry)
                 td
                   a href="#{edit_admin_registry_path(registry.id)}" Edit
 

--- a/app/views/admin/registries/new.html.slim
+++ b/app/views/admin/registries/new.html.slim
@@ -22,59 +22,8 @@
 
     br
 
-    = form_for @registry, url: admin_registries_path, html: {class: 'form-horizontal', role: 'form'} do |f|
-      .form-group
-        = f.label :name, {class: 'control-label col-md-2'}
-        .col-md-7
-          - if params[:name]
-            = f.text_field(:name, class: 'form-control', value: params[:name], required: true, autofocus: true)
-          - else
-            = f.text_field(:name, class: 'form-control', required: true, autofocus: true)
-      .form-group
-        = f.label :hostname, {class: 'control-label col-md-2'}
-        .col-md-7
-          - if params[:hostname]
-            = f.text_field(:hostname, class: 'form-control', value: params[:hostname], placeholder: 'registry.test.lan:5000', required: true)
-          - else
-            = f.text_field(:hostname, class: 'form-control', placeholder: 'registry.test.lan:5000', required: true)
-      .form-group
-        = f.label :use_ssl, "Use SSL", {class: 'control-label col-md-2', title: 'Set this to enable SSL in the communication between Portus and the Registry'}
-        .col-md-7
-          - if params[:use_ssl] == "true"
-            = f.check_box(:use_ssl, checked: true)
-          - else
-            = f.check_box(:use_ssl)
-      div.collapse#advanced
-        .form-group
-          = f.label :external_hostname, "External Registry Name", {class:'control-label col-md-2', title: 'Set this if the name that clients use to communicate with the registry is different than the name that Portus uses to connect'}
-          .col-md-7
-            - if params[:external_hostname]
-              = f.text_field(:external_hostname, class: 'form-control', value: params[:external_hostname], placeholder: '(Optional)', required: false)
-            - else
-              = f.text_field(:external_hostname, class: 'form-control', placeholder: '(Optional)', required: false)
-            span.help-block
-              | Portus uses the hostname field to communicate with the registry,
-                but this may be on an internal network and inaccessible to the
-                client.
-                Clients may connect to the registry by a name different to the
-                hostname above, for example if it is behind a reverse proxy.
-                This field must be set to prevent Portus from ignoring registry
-                events originating from this external hostname.
-      - unless flash[:alert].nil? || flash[:alert].empty?
-        .form-group.has-error
-          = label_tag :force, "Skip remote checks", {class: 'control-label col-md-2', title: "Force the creation of the registry, even if it's not reachable."}
-          .col-md-7
-            = check_box_tag(:force)
-      .form-group
-        .col-md-offset-2.col-md-7
-          div.btn-toolbar role='toolbar'
-            div.btn-group role='group'
-              = f.submit('Create', class: 'btn btn-primary')
-            div.btn-group role='group'
-              span data-toggle='collapse' data-target='#advanced'
-                button.btn.btn-primary#advancedButton type='button' data-toggle='button' aria-expanded='false' aria-controls='advanced' Show Advanced
-                javascript:
-                  $('#advancedButton').click(function() {
-                    $(this).text($(this).text() == 'Show Advanced' ? 'Hide Advanced' : 'Show Advanced');
-                  });
+    <registry-form :can-change-hostname="true"></registry-form>
 
+- content_for :js_body do
+  script#js-registry-form-tmpl type="text/x-template"
+    = render partial: 'admin/registries/components/form', locals: { form_url: admin_registries_path, submit_name: "Create" }

--- a/app/views/shared/_notifications.html.slim
+++ b/app/views/shared/_notifications.html.slim
@@ -1,4 +1,4 @@
-- if current_user && !current_page?(url_for new_admin_registry_path) && !Registry.any?
+- if current_user && controller_name != 'registries' && ['new', 'create'].include?(action_name) && !Registry.any?
   .alert.alert-danger.fade.in.text-left.alert-dismissible
     button.close data-dismiss="alert" type="button"
       span aria-hidden="true" &times;

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "vue-loader": "^12.0.3",
     "vue-resource": "^1.3.1",
     "vue-template-compiler": "^2.3.3",
-    "vuelidate": "^0.5.0",
+    "vuelidate": "^0.6.0",
     "webpack": "^2.2.1"
   },
   "babel": {

--- a/spec/api/grape_api/v1/registries_spec.rb
+++ b/spec/api/grape_api/v1/registries_spec.rb
@@ -28,27 +28,27 @@ describe API::V1::Registries do
     end
 
     it "returns valid on a proper registry" do
-      allow_any_instance_of(Registry).to receive(:reachable?).and_return(true)
+      allow_any_instance_of(Registry).to receive(:reachable?).and_return(nil)
       get "/api/v1/registries/validate", registry_data, @header
 
       data = JSON.parse(response.body)
-      expect(data["messages"]["reachable"]).to be_truthy
+      expect(data["messages"]["hostname"]).to be_falsey
       expect(data["valid"]).to be_truthy
     end
 
     it "returns unreachable accordingly" do
-      allow_any_instance_of(Registry).to receive(:reachable?).and_return(false)
+      allow_any_instance_of(Registry).to receive(:reachable?).and_return("Error message")
       get "/api/v1/registries/validate", registry_data, @header
 
       data = JSON.parse(response.body)
-      expect(data["messages"]["reachable"]).to be_falsey
+      expect(data["messages"]["hostname"]).to eq(["Error message"])
       expect(data["valid"]).to be_falsey
     end
 
     it "returns an error when the name is already taken" do
       create :registry, name: registry_data[:name]
 
-      allow_any_instance_of(Registry).to receive(:reachable?).and_return(true)
+      allow_any_instance_of(Registry).to receive(:reachable?).and_return("Error message")
       get "/api/v1/registries/validate", registry_data, @header
 
       data = JSON.parse(response.body)

--- a/spec/helpers/registries_helper_spec.rb
+++ b/spec/helpers/registries_helper_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe RegistriesHelper, type: :helper do
+  let!(:registry) { create(:registry) }
+
+  describe "#registry_status_icon" do
+    it "renders with chain icon if reachable" do
+      allow(registry).to receive(:reachable?).and_return("")
+
+      html = helper.registry_status_icon(registry)
+      expect(html).to include('<i class="fa fa-lg fa-chain" title="Reachable')
+    end
+
+    it "renders with chain-broken icon if unreachable" do
+      allow(registry).to receive(:reachable?).and_return("Something")
+
+      html = helper.registry_status_icon(registry)
+      expect(html).to include('<i class="fa fa-lg fa-chain-broken" title="Something')
+    end
+  end
+end

--- a/spec/services/registries/validate_service_spec.rb
+++ b/spec/services/registries/validate_service_spec.rb
@@ -1,0 +1,129 @@
+require "rails_helper"
+
+describe "Registries::ValidateService" do
+  describe "#execute" do
+    context "invalid without only param" do
+      subject(:service) { Registries::ValidateService.new }
+
+      before do
+        allow_any_instance_of(Registry).to receive(:reachable?).and_return("Error")
+      end
+
+      it "returns an object with validation messages on all the fields" do
+        validation = service.execute
+
+        expect(validation[:messages][:name]).to be_truthy
+        expect(validation[:messages][:hostname]).to be_truthy
+      end
+
+      it "returns object with valid false if validation fails" do
+        validation = service.execute
+
+        expect(validation[:valid]).to be_falsey
+      end
+    end
+
+    context "valid without only param" do
+      subject(:service) do
+        Registries::ValidateService.new(name: "name", hostname: "something", use_ssl: false)
+      end
+
+      before do
+        allow_any_instance_of(Registry).to receive(:reachable?).and_return(nil)
+      end
+
+      it "returns an object with empty validation on messages" do
+        validation = service.execute
+
+        expect(validation[:messages][:name]).to be_falsey
+        expect(validation[:messages][:hostname]).to be_falsey
+      end
+
+      it "returns object with valid false if validation succeeds" do
+        validation = service.execute
+
+        expect(validation[:valid]).to be_truthy
+      end
+    end
+
+    context "invalid with name param" do
+      subject(:service) { Registries::ValidateService.new(only: ["name"]) }
+
+      it "returns an object with validation messages only on name" do
+        validation = service.execute
+
+        expect(validation[:messages][:name]).to be_truthy
+        expect(validation[:messages][:hostname]).to be_falsey
+      end
+
+      it "returns object with valid false if validation fails" do
+        validation = service.execute
+
+        expect(validation[:valid]).to be_falsey
+      end
+    end
+
+    context "valid with name param" do
+      subject(:service) { Registries::ValidateService.new(name: "name", only: ["name"]) }
+
+      it "returns an object with empty validation on messages" do
+        validation = service.execute
+
+        expect(validation[:messages][:name]).to be_falsey
+        expect(validation[:messages][:hostname]).to be_falsey
+      end
+
+      it "returns object with valid false if validation succeeds" do
+        validation = service.execute
+
+        expect(validation[:valid]).to be_truthy
+      end
+    end
+
+    context "valid with hostname param" do
+      subject(:service) do
+        Registries::ValidateService.new(hostname: "hostname", only: ["hostname"])
+      end
+
+      before do
+        allow_any_instance_of(Registry).to receive(:reachable?).and_return(nil)
+      end
+
+      it "returns an object with empty validation on messages" do
+        validation = service.execute
+
+        expect(validation[:messages][:name]).to be_falsey
+        expect(validation[:messages][:hostname]).to be_falsey
+      end
+
+      it "returns object with valid false if validation succeeds" do
+        validation = service.execute
+
+        expect(validation[:valid]).to be_truthy
+      end
+    end
+
+    context "invalid with hostname param" do
+      subject(:service) do
+        Registries::ValidateService.new(hostname: "hostname", only: ["hostname"])
+      end
+
+      before do
+        allow_any_instance_of(Registry).to receive(:reachable?).and_return("Error")
+      end
+
+      it "returns an object with empty validation on messages" do
+        validation = service.execute
+
+        expect(validation[:messages][:name]).to be_falsey
+        expect(validation[:messages][:hostname]).to be_truthy
+      end
+
+      it "returns object with valid false if validation succeeds" do
+        validation = service.execute
+
+        expect(validation[:valid]).to be_falsey
+      end
+    end
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -4300,9 +4300,9 @@ vue@^2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.3.3.tgz#d1eaa8fde5240735a4563e74f2c7fead9cbb064c"
 
-vuelidate@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/vuelidate/-/vuelidate-0.5.0.tgz#c315659a023e760d0fb11b6b42b6c3cdf08306c3"
+vuelidate@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/vuelidate/-/vuelidate-0.6.0.tgz#e6233c3e7767c5bc503ab5ee533106974e3e87d6"
 
 watchpack@^1.2.0:
   version "1.3.1"


### PR DESCRIPTION
The registry validation was done completely on the server side. With
this, we bring some validation to the client side to antecipate and improve
the user's experience.

Also adds a hint in the registries#index pages to help the user know if the
registry that was set is reachable or not. The reachable status is cached for
30 minutes unless the user updates the registry.

Fixes #1355

### Screenshots

<img width="1411" alt="screenshot 2017-08-28 17 02 10" src="https://user-images.githubusercontent.com/188554/29791331-e9518fda-8c12-11e7-9dd0-d0bcd851fb89.png">
<img width="1410" alt="screenshot 2017-08-28 17 02 26" src="https://user-images.githubusercontent.com/188554/29791332-e951b046-8c12-11e7-9e1c-501ff3bdfccb.png">
<img width="1395" alt="screenshot 2017-08-28 17 05 51" src="https://user-images.githubusercontent.com/188554/29791399-2a1fccf2-8c13-11e7-903b-b32e5ff3f4e8.png">
<img width="1395" alt="screenshot 2017-08-28 17 05 07" src="https://user-images.githubusercontent.com/188554/29791379-10e0afe0-8c13-11e7-9ee6-cf9b045613f7.png">
<img width="1399" alt="screenshot 2017-08-28 17 06 41" src="https://user-images.githubusercontent.com/188554/29791427-489a7f4c-8c13-11e7-8c1a-0b543271159f.png">
