### PR TITLE
js: fixed after namespace creation behavior

### DIFF
--- a/app/assets/javascripts/modules/namespaces/components/new-form.js
+++ b/app/assets/javascripts/modules/namespaces/components/new-form.js
@@ -44,7 +44,10 @@ export default {
 
         this.toggleForm();
         this.$v.$reset();
-        set(this.namespace, 'namespace', {});
+        set(this.namespace, 'namespace', {
+          name: '',
+          team: this.teamName || '',
+        });
 
         Alert.show(`Namespace '${name}' was created successfully`);
         EventBus.$emit('namespaceCreated', namespace);


### PR DESCRIPTION
After the refactoring of namespace's new form, the reset
of the fields were causing an unexpected behavior. Validation
was being fired again and causing ausing unnecessary ajax
requests and also breaking temporarily the name validation.

Fixes #1406