### PR TITLE
Sort tags by updated_at date not by created_at

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -64,7 +64,7 @@ class Repository < ActiveRecord::Base
   # digest.
   def groupped_tags
     tags.group_by(&:digest).values.sort do |x, y|
-      y.first.created_at <=> x.first.created_at
+      y.first.updated_at <=> x.first.updated_at
     end
   end
 


### PR DESCRIPTION
If a tag will be overwritten its created_at date stays the same. So sorting the tags by this date results in a wrong order. The updated_at date will be changed anytime a tag is overwritten. So such a tag will appear at the top of the tag list if they are sorted by this date.