### PR TITLE
js: fixed vue-resource root url based on rails root_url

### DIFF
--- a/app/assets/javascripts/modules/namespaces/services/namespaces.js
+++ b/app/assets/javascripts/modules/namespaces/services/namespaces.js
@@ -18,7 +18,7 @@ const customActions = {
   },
 };
 
-const resource = Vue.resource('/namespaces{/id}.json', {}, customActions);
+const resource = Vue.resource('namespaces{/id}.json', {}, customActions);
 
 function all(params = {}) {
   return resource.get({}, params);

--- a/app/assets/javascripts/modules/repositories/services/repositories.js
+++ b/app/assets/javascripts/modules/repositories/services/repositories.js
@@ -3,7 +3,7 @@ import VueResource from 'vue-resource';
 
 Vue.use(VueResource);
 
-const resource = Vue.resource('/repositories{/id}.json');
+const resource = Vue.resource('repositories{/id}.json');
 
 function get(id) {
   return resource.get({ id });

--- a/app/assets/javascripts/modules/repositories/services/tags.js
+++ b/app/assets/javascripts/modules/repositories/services/tags.js
@@ -3,7 +3,7 @@ import VueResource from 'vue-resource';
 
 Vue.use(VueResource);
 
-const resource = Vue.resource('/tags{/id}.json');
+const resource = Vue.resource('tags{/id}.json');
 
 function remove(id) {
   return resource.delete({ id });

--- a/app/assets/javascripts/vue-shared.js
+++ b/app/assets/javascripts/vue-shared.js
@@ -5,6 +5,8 @@ import Vuelidate from 'vuelidate';
 Vue.use(Vuelidate);
 Vue.use(VueResource);
 
+Vue.http.options.root = window.API_ROOT_URL;
+
 Vue.http.interceptors.push((_request, next) => {
   window.$.active = window.$.active || 0;
   window.$.active += 1;

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -28,6 +28,8 @@ html
     meta content="/favicon/browserconfig.xml" name="msapplication-config"
     meta content="#205683" name="theme-color"
 
+    javascript:
+      window.API_ROOT_URL = '#{root_url}';
     script src="//cdn.polyfill.io/v2/polyfill.js?features=Array.prototype.some,Array.prototype.findIndex,Array.from"
     = javascript_include_tag(*webpack_asset_paths("application"))
     = yield :js_header


### PR DESCRIPTION
VueResource was not considering any path to be included in
its root url. So when portus was set up using RAILS_RELATIVE_URL_ROOT,
the url requests were wrong and data didn't show up.

To fix this we are now setting VueResource root url based on
rails `root_url` value.

Fixes #1421