### PR TITLE
Added a default_headers method for controllers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,9 @@ class ApplicationController < ActionController::Base
   before_action :authenticate_user!
   before_action :force_update_profile!
   before_action :force_registry_config!
+
+  include Headers
+
   protect_from_forgery with: :exception
 
   add_flash_types :float

--- a/app/controllers/concerns/headers.rb
+++ b/app/controllers/concerns/headers.rb
@@ -1,0 +1,14 @@
+# Concern which has methods dealing with headers that might be interesting for
+# controllers deriving directly from ActionController::Base.
+module Headers
+  extend ActiveSupport::Concern
+
+  included do
+    after_action :default_headers
+  end
+
+  # Adds some default headers.
+  def default_headers
+    headers["X-UA-Compatible"] = "IE=edge"
+  end
+end

--- a/app/controllers/explore_controller.rb
+++ b/app/controllers/explore_controller.rb
@@ -5,6 +5,8 @@ class ExploreController < ActionController::Base
 
   before_action :feature_enabled, only: [:index]
 
+  include Headers
+
   include Pundit
   rescue_from Pundit::NotAuthorizedError, with: :deny_access
 

--- a/examples/compose/nginx/nginx.conf
+++ b/examples/compose/nginx/nginx.conf
@@ -116,6 +116,9 @@ http {
     # website if it was disabled by the user.
     add_header X-XSS-Protection "1; mode=block";
 
+    # Add header for IE in compatibility mode.
+    add_header X-UA-Compatible "IE=edge";
+
 	# Redirect (most) requests to /v2/* to the Docker Registry
 	location /v2/ {
 	  # Do not allow connections from docker 1.5 and earlier

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -14,4 +14,11 @@ RSpec.describe DashboardController, type: :controller do
       expect(response).to have_http_status(:success)
     end
   end
+
+  describe "Headers" do
+    it "sets the X-UA-Compatible header" do
+      get :index
+      expect(response.headers["X-UA-Compatible"]).to eq("IE=edge")
+    end
+  end
 end

--- a/spec/controllers/explore_controller_spec.rb
+++ b/spec/controllers/explore_controller_spec.rb
@@ -16,4 +16,13 @@ RSpec.describe ExploreController, type: :controller do
       expect(response).to have_http_status(:found)
     end
   end
+
+  describe "Headers" do
+    it "sets the X-UA-Compatible header" do
+      APP_CONFIG["anonymous_browsing"] = { "enabled" => true }
+
+      get :index
+      expect(response.headers["X-UA-Compatible"]).to eq("IE=edge")
+    end
+  end
 end


### PR DESCRIPTION
For now we are adding the X-UA-Compatible header so it works well for IE
with compatibility mode on.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>