### PR TITLE
Fixed the namespace and team name clashes

### DIFF
--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -51,4 +51,23 @@ class Team < ActiveRecord::Base
   def self.search_from_query(valid_teams, query)
     all_non_special.where(id: valid_teams).where(arel_table[:name].matches(query))
   end
+
+  # Tries to transform the given name to a valid team name without
+  # clashing with existent teams.
+  # Checks if it clashes with others teams and finds one until it's not
+  # being used and returns it.
+  def self.make_valid(name)
+    # To avoid any name conflict we append an incremental number to the end
+    # of the name returns it as the name that will be used on both Namespace
+    # and Team on the User#create_personal_namespace! method
+    # TODO: workaround until we implement the namespace/team removal
+    increment = 0
+    original_name = name
+    while Team.exists?(name: name)
+      name = "#{original_name}#{increment}"
+      increment += 1
+    end
+
+    name
+  end
 end

--- a/app/policies/namespace_policy.rb
+++ b/app/policies/namespace_policy.rb
@@ -80,10 +80,10 @@ class NamespacePolicy
         .where(
           "(namespaces.visibility = :public OR namespaces.visibility = :protected " \
           "OR team_users.user_id = :user_id) AND " \
-          "namespaces.global = :global AND namespaces.name != :username",
+          "namespaces.global = :global AND namespaces.id != :namespace_id",
           public: Namespace.visibilities[:visibility_public],
           protected: Namespace.visibilities[:visibility_protected],
-          user_id: user.id, global: false, username: user.username
+          user_id: user.id, global: false, namespace_id: user.namespace_id
         )
         .distinct
     end

--- a/spec/features/admin/users_spec.rb
+++ b/spec/features/admin/users_spec.rb
@@ -10,6 +10,43 @@ feature "Admin - Users panel" do
     visit admin_users_path
   end
 
+  describe "create users", js: true do
+    scenario "admin creates a user" do
+      visit new_admin_user_path
+
+      fill_in "Username",              with: "username"
+      fill_in "Email",                 with: "email@email.com"
+      fill_in "user[password]",        with: "password123"
+      fill_in "Password confirmation", with: "password123"
+
+      click_button "Create"
+
+      expect(page).to have_current_path(admin_users_path)
+      expect(page).to have_content("User 'username' was created successfully")
+    end
+
+    scenario "admin adds back a removed user" do
+      expect(page).to have_css("#user_#{user.id}")
+
+      find("#user_#{user.id} .remove-btn").click
+      find("#user_#{user.id} .btn-confirm-remove").click
+
+      expect(page).to have_content("User '#{user.username}' was removed successfully")
+
+      visit new_admin_user_path
+
+      fill_in "Username",              with: user.username
+      fill_in "Email",                 with: user.email
+      fill_in "user[password]",        with: "password123"
+      fill_in "Password confirmation", with: "password123"
+
+      click_button "Create"
+
+      expect(page).to have_current_path(admin_users_path)
+      expect(page).to have_content("User '#{user.username}' was created successfully")
+    end
+  end
+
   describe "remove users" do
     scenario "allows the admin to remove other users", js: true do
       expect(page).to have_css("#user_#{user.id}")

--- a/spec/models/namespace_spec.rb
+++ b/spec/models/namespace_spec.rb
@@ -159,6 +159,9 @@ describe Namespace do
   end
 
   describe "make_valid" do
+    let!(:team)      { create(:team) }
+    let!(:namespace) { create(:namespace, team: team) }
+
     it "does nothing on already valid names" do
       ["name", "a", "a_a", "45", "n4", "h2o", "flavio.castelli"].each do |name|
         expect(Namespace.make_valid(name)).to eq name
@@ -183,6 +186,13 @@ describe Namespace do
       expect(Namespace.make_valid("Miquel.Sabate.")).to eq "miquel.sabate"
       expect(Namespace.make_valid("M")).to eq "m"
       expect(Namespace.make_valid("_M_")).to eq "m"
+    end
+
+    it "adds an increment if a team with the name already exists" do
+      expect(Namespace.make_valid(namespace.name)).to eq "#{namespace.name}0"
+
+      create(:namespace, name: "#{namespace.name}0", team: team)
+      expect(Namespace.make_valid(namespace.name)).to eq "#{namespace.name}1"
     end
   end
 end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -42,9 +42,26 @@ describe Team do
     expect(Team.count).to be(3)
 
     # Personal namespaces don't count.
-    user = create(:user)
-    user.create_personal_namespace!
+    create(:user)
     expect(Team.all_non_special.count).to be(1)
     expect(Team.count).to be(4)
+  end
+
+  describe "make_valid" do
+    it "does nothing if there's no team with the name" do
+      name = "something"
+
+      expect(Team.make_valid(name)).to eq name
+    end
+
+    it "adds an increment if a team with the name already exists" do
+      name = "something"
+
+      create(:team, name: name)
+      expect(Team.make_valid(name)).to eq "#{name}0"
+
+      create(:team, name: "#{name}0")
+      expect(Team.make_valid(name)).to eq "#{name}1"
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -54,39 +54,6 @@ describe User do
           "valid namespace name"])
     end
 
-    it "adds an error if the namespace name clashes" do
-      name = "coolname"
-      team = create(:team, owners: [subject])
-      create(:namespace, team: team, name: name)
-
-      user = build(:user, username: name)
-      expect(user.save).to be false
-      expect(user.errors.size).to eq(1)
-      expect(user.errors.first)
-        .to match_array([:username, "cannot be used: there is already a " \
-          "namespace named 'coolname'"])
-
-      user = build(:user, username: name + "_")
-      expect(user.save).to be false
-      expect(user.errors.size).to eq(1)
-      expect(user.errors.first)
-        .to match_array([:username, "cannot be used: there is already a " \
-          "namespace named 'coolname' (modified so it's valid)"])
-    end
-
-    it "adds an error if there's a team named like that" do
-      name = "coolname"
-      team = create(:team, name: name, owners: [subject])
-      create(:namespace, team: team, name: "somethingelse")
-
-      user = build(:user, username: name)
-      expect(user.save).to be false
-      expect(user.errors.size).to eq(1)
-      expect(user.errors.first)
-        .to match_array([:username, "cannot be used: there is already a " \
-          "team named like this"])
-    end
-
     it "works beautifully if everything was fine" do
       name = "coolname"
       team = create(:team, owners: [subject])


### PR DESCRIPTION
Currently we have a problem when a user is removed and added back
to Portus. The team and namespace associated with that user are not
removed. So, when an admin tries to create a user or an user tries
to create an account, an error mentioning that there's already a
namespace with that username is shown.

With this patch we avoid that by adding an incremental number to the
end of the name. For example, if username is `brian` and there's
already a namespace/team with that name, `brian0` namespace and team
will be created instead. If `brian` gets removed again, next time it
will be `brian1` for both namespace and team.

Remembering that we should remove this once we implement the
namespace/team removal.

Fixes #1269