### PR TITLE
Reduced the size of the dev Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,27 @@
-FROM library/ruby:2.3.1
-MAINTAINER Flavio Castelli <fcastelli@suse.com>
+FROM opensuse/ruby:2.3
+MAINTAINER SUSE Containers Team <containers@suse.com>
 
 ENV COMPOSE=1
 EXPOSE 3000
 
 WORKDIR /srv/Portus
 COPY Gemfile* ./
-RUN bundle install --retry=3
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends nodejs
+
+# Let's explain this RUN command:
+#   1. First of all we refresh, since opensuse/ruby does a zypper clean -a in
+#      the end.
+#   2. Then we install dev. dependencies and the devel_basis pattern (used for
+#      building stuff like nokogiri). With that we can run bundle install.
+#   3. We then proceed to remove unneeded clutter: first we remove some packages
+#      installed with the devel_basis pattern, and finally we zypper clean -a.
+RUN zypper ref && \
+    zypper -n in --no-recommends ruby2.3-devel ruby2.3-rubygem-bundler \
+           libxml2-devel nodejs libmysqlclient-devel libxslt1 && \
+    zypper -n in --no-recommends -t pattern devel_basis && \
+    bundle install --retry=3 && \
+    zypper -n rm wicked wicked-service autoconf automake \
+           binutils bison cpp cvs flex gdbm-devel gettext-tools \
+           libtool m4 make makeinfo && \
+    zypper clean -a
 
 ADD . .

--- a/examples/development/compose/init
+++ b/examples/development/compose/init
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Wait for mariadb
 while true; do


### PR DESCRIPTION
The image being used by the docker-compose dev setup has been reduced
from almost 1GiB to 586MiB. This has been done by:

- Switching from library/ruby:2.3.1 to opensuse/ruby:2.3.
- Removing unneeded clutter that is only needed when building.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>