### PR TITLE
Changed autocomplete from false to off

### DIFF
--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -6,7 +6,7 @@ section.row-0
       = image_tag 'layout/portus-logo-login-page.png', class: 'login-picture'
       = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
         = f.text_field :username, class: 'input form-control input-lg first', placeholder: 'Username', autofocus: true, required: true
-        = f.password_field :password, class: 'input form-control input-lg last', placeholder: 'Password', autocomplete: false, required: true
+        = f.password_field :password, class: 'input form-control input-lg last', placeholder: 'Password', autocomplete: 'off', required: true
         = f.button id: "login-btn", class: 'classbutton btn btn-primary btn-block btn-lg' do
           - if Portus::LDAP.enabled?
             i.fa.fa-check


### PR DESCRIPTION
In app/views/devise/sessions/new.html.slim, the autocomplete attribute was set to false rather than 'off' (like in other files). 

It was also not compliant with W3C standards.
