### PR TITLE
Improved recent activities sql queries performance

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -2,7 +2,7 @@ class DashboardController < ApplicationController
   def index
     @recent_activities = policy_scope(PublicActivity::Activity)
                          .limit(20)
-                         .order("created_at desc")
+                         .order(id: :desc)
     @repositories = policy_scope(Repository)
 
     # The personal namespace could not exist, that happens when portus

--- a/app/policies/public_activity/activity_policy.rb
+++ b/app/policies/public_activity/activity_policy.rb
@@ -7,68 +7,74 @@ class PublicActivity::ActivityPolicy
       @scope = scope
     end
 
-    def resolve
+    def resolve(count = 20)
+      teams_ids = @user.teams.collect(&:id)
+      public_visibility = Namespace.visibilities[:visibility_public]
+
       # Show Team events only if user is a member of the team
       team_activities = @scope
-                        .joins("INNER JOIN teams ON activities.trackable_id = teams.id " \
-               "INNER JOIN team_users ON teams.id = team_users.team_id")
-                        .where("activities.trackable_type = ? AND team_users.user_id = ?",
-               "Team", user.id)
+                        .where("activities.trackable_type = ? AND activities.trackable_id IN (?)",
+                               "Team", teams_ids)
+                        .order(id: :desc)
+                        .limit(count)
 
       # Show Namespace events only if user is a member of the team controlling
       # the namespace or if the event is a public <-> private switch.
       namespace_activities = @scope
                              .joins("INNER JOIN namespaces " \
-                                    "ON activities.trackable_id = namespaces.id " \
-                                    "INNER JOIN teams ON teams.id = namespaces.team_id " \
-                                    "INNER JOIN team_users ON teams.id = team_users.team_id")
+                                    "ON activities.trackable_id = namespaces.id")
                              .where("activities.trackable_type = ? AND " \
-                                    "(team_users.user_id = ? OR " \
-                                    "( activities.key = ? AND namespaces.visibility = ?))",
-                                    "Namespace", user.id, "namespace.change_visibility",
-                                    Namespace.visibilities[:visibility_public])
+                                    "(namespaces.team_id IN (?) OR " \
+                                    "(activities.key = ? AND namespaces.visibility = ?))",
+                                    "Namespace", teams_ids, "namespace.change_visibility",
+                                    public_visibility)
+                             .order(id: :desc)
+                             .limit(count)
 
       # Show tag events for repositories inside of namespaces controller by
       # a team the user is part of, or tags part of public namespaces.
       repository_activities = @scope
                               .joins("INNER JOIN repositories " \
                                      "ON activities.trackable_id = repositories.id " \
-                                     "INNER JOIN namespaces ON " \
-                                        "namespaces.id = repositories.namespace_id " \
-                                     "INNER JOIN teams ON namespaces.team_id = teams.id " \
-                                     "INNER JOIN team_users ON teams.id = team_users.team_id")
+                                     "INNER JOIN namespaces " \
+                                     "ON namespaces.id = repositories.namespace_id")
                               .where("activities.trackable_type = ? AND " \
-                                     "(team_users.user_id = ? OR namespaces.visibility = ?)",
-                                     "Repository", user.id,
-                                     Namespace.visibilities[:visibility_public])
+                                     "(namespaces.team_id IN (?) OR namespaces.visibility = ?)",
+                                     "Repository", teams_ids, public_visibility)
+                              .order(id: :desc)
+                              .limit(count)
 
       # Show application tokens activities related only to the current user
       application_token_activities = @scope
                                      .where("activities.trackable_type = ? " \
                                             "AND activities.owner_id = ?",
                                             "ApplicationToken", user.id)
+                                     .order(id: :desc)
+                                     .limit(count)
 
       team_activities
         .union_all(namespace_activities)
         .union_all(repository_activities)
         .union_all(application_token_activities)
-        .union_all(webhook_activities)
+        .union_all(webhook_activities(count))
         .distinct
     end
 
     # webhook_activities returns all webhook activities which are accessibly to
     # the user.
-    def webhook_activities
+    def webhook_activities(count)
       # Show webhook events only if user is a member of the team controlling
       # the namespace.
       # Note: this works only for existing webhooks
       activities = @scope
                    .joins("INNER JOIN webhooks ON activities.trackable_id = webhooks.id " \
-               "INNER JOIN namespaces ON namespaces.id = webhooks.namespace_id " \
-               "INNER JOIN teams ON teams.id = namespaces.team_id " \
-               "INNER JOIN team_users ON teams.id = team_users.team_id")
+                          "INNER JOIN namespaces ON namespaces.id = webhooks.namespace_id " \
+                          "INNER JOIN teams ON teams.id = namespaces.team_id " \
+                          "INNER JOIN team_users ON teams.id = team_users.team_id")
                    .where("activities.trackable_type = ? AND team_users.user_id = ?",
-               "Webhook", user.id)
+                          "Webhook", user.id)
+                   .order(id: :desc)
+                   .limit(count)
 
       # Convert relation to array since we want to add single objects, and objects
       # cannot be added to relations.
@@ -84,13 +90,16 @@ class PublicActivity::ActivityPolicy
       # there is no (easy) way to match these webhooks with their corresponding
       # namespace.
       @scope
-        .where("activities.trackable_type = ?", "Webhook").distinct.find_each do |webhook|
-        unless webhook.parameters.empty?
-          if user_namespaces.include? webhook.parameters[:namespace_id]
-            activities << webhook
+        .where("activities.trackable_type = ?", "Webhook")
+        .order(id: :desc)
+        .limit(count)
+        .distinct.find_each do |webhook|
+          unless webhook.parameters.empty?
+            if user_namespaces.include? webhook.parameters[:namespace_id]
+              activities << webhook
+            end
           end
         end
-      end
 
       # "convert" array back to relation in order to use `union_all`.
       @scope.where(id: activities.map(&:id))

--- a/db/migrate/20171014192702_add_indexes_to_activities.rb
+++ b/db/migrate/20171014192702_add_indexes_to_activities.rb
@@ -1,0 +1,9 @@
+class AddIndexesToActivities < ActiveRecord::Migration
+  def self.up
+    add_index :activities, [:trackable_type]
+  end
+
+  def self.down
+    remove_index :activities, [:trackable_type]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170630194953) do
+ActiveRecord::Schema.define(version: 20171014192702) do
 
   create_table "activities", force: :cascade do |t|
     t.integer  "trackable_id",   limit: 4
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 20170630194953) do
   add_index "activities", ["owner_id", "owner_type"], name: "index_activities_on_owner_id_and_owner_type", using: :btree
   add_index "activities", ["recipient_id", "recipient_type"], name: "index_activities_on_recipient_id_and_recipient_type", using: :btree
   add_index "activities", ["trackable_id", "trackable_type"], name: "index_activities_on_trackable_id_and_trackable_type", using: :btree
+  add_index "activities", ["trackable_type"], name: "index_activities_on_trackable_type", using: :btree
 
   create_table "application_tokens", force: :cascade do |t|
     t.string  "application", limit: 255, null: false


### PR DESCRIPTION
We had a performance issue with the recent activities in
the dashboard page.

A new index was added and the queries were also improved
with less JOINs, an order and limit.

Previous query

`
SELECT  DISTINCT `activities`.* FROM ( (SELECT `activities`.* FROM ( (SELECT `activities`.* FROM ( (SELECT `activities`.* FROM ( (SELECT `activities`.* FROM `activities` INNER JOIN teams ON activities.trackable_id = teams.id INNER JOIN team_users ON teams.id = team_users.team_id WHERE (activities.trackable_type = 'Team' AND team_users.user_id = 2)) UNION ALL (SELECT `activities`.* FROM `activities` INNER JOIN namespaces ON activities.trackable_id = namespaces.id INNER JOIN teams ON teams.id = namespaces.team_id INNER JOIN team_users ON teams.id = team_users.team_id WHERE (activities.trackable_type = 'Namespace' AND (team_users.user_id = 2 OR ( activities.key = 'namespace.change_visibility' AND namespaces.visibility = 2)))) ) activities) UNION ALL (SELECT `activities`.* FROM `activities` INNER JOIN repositories ON activities.trackable_id = repositories.id INNER JOIN namespaces ON namespaces.id = repositories.namespace_id INNER JOIN teams ON namespaces.team_id = teams.id INNER JOIN team_users ON teams.id = team_users.team_id WHERE (activities.trackable_type = 'Repository' AND (team_users.user_id = 2 OR namespaces.visibility = 2))) ) activities) UNION ALL (SELECT `activities`.* FROM `activities` WHERE (activities.trackable_type = 'ApplicationToken' AND activities.owner_id = 2)) ) activities) UNION ALL (SELECT `activities`.* FROM `activities` WHERE 1=0) ) activities  ORDER BY created_at desc LIMIT 20
`

takes ~5.8 segs.

Current query

`
SELECT  DISTINCT `activities`.* FROM ( (SELECT `activities`.* FROM ( (SELECT `activities`.* FROM ( (SELECT `activities`.* FROM ( (SELECT  `activities`.* FROM `activities` WHERE (activities.trackable_type = 'Team' AND activities.trackable_id IN (1,3,4))  ORDER BY `activities`.`id` DESC LIMIT 20) UNION ALL (SELECT  `activities`.* FROM `activities` INNER JOIN namespaces ON activities.trackable_id = namespaces.id WHERE (activities.trackable_type = 'Namespace' AND (namespaces.team_id IN (1,3,4) OR (activities.key = 'namespace.change_visibility' AND namespaces.visibility = 2)))  ORDER BY `activities`.`id` DESC LIMIT 20) ) activities) UNION ALL (SELECT  `activities`.* FROM `activities` INNER JOIN repositories ON activities.trackable_id = repositories.id INNER JOIN namespaces ON namespaces.id = repositories.namespace_id WHERE (activities.trackable_type = 'Repository' AND (namespaces.team_id IN (1,3,4) OR namespaces.visibility = 2))  ORDER BY `activities`.`id` DESC LIMIT 20) ) activities) UNION ALL (SELECT  `activities`.* FROM `activities` WHERE (activities.trackable_type = 'ApplicationToken' AND activities.owner_id = 2)  ORDER BY `activities`.`id` DESC LIMIT 20) ) activities) UNION ALL (SELECT `activities`.* FROM `activities` WHERE 1=0) ) activities  ORDER BY `activities`.`id` DESC LIMIT 20
`

takes between 7~15ms.

Both times were measured directly on MariaDB in my computer with ~113k rows.

**UPDATE:**

The example above were using only team activities, that's why the improvement was so significant since I removed the JOIN for the team activities query.

I tried with 110k namespaces activities and I got:

* before: ~5.8 segs
* after: 800~900ms

It wasn't that significant 😞  as the other but still an improvement. 