### PR TITLE
Perform some checks on some environment variables

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ end
 gem "puma", "~> 3.10.0" if ENV["PORTUS_PUMA_DEPLOYMENT"] == "yes" || !packaging?
 
 # Configuration management
-gem "cconfig", "~> 1.1.0"
+gem "cconfig", "~> 1.2.0"
 
 # In order to create the Gemfile.lock required for packaging
 # meaning that it should contain only the production packages

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,7 +80,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    cconfig (1.1.1)
+    cconfig (1.2.0)
       safe_yaml (~> 1.0.0, >= 1.0.0)
     choice (0.2.0)
     cliver (0.3.2)
@@ -465,7 +465,7 @@ DEPENDENCIES
   brakeman
   byebug
   capybara (~> 2.14.3)
-  cconfig (~> 1.1.0)
+  cconfig (~> 1.2.0)
   codeclimate-test-reporter
   crono
   database_cleaner

--- a/config/initializers/environment_check.rb
+++ b/config/initializers/environment_check.rb
@@ -1,0 +1,28 @@
+# This file checks for important environment variables. Some of them have to be
+# set in order for Portus to work in certain scenarios (e.g. secret key base on
+# production), others are strong recommendations.
+
+# Checks that the secret value has been set either in `config/secrets.yml` or as
+# an environment variable. If this is not the case, then it raises an exception
+# with the proper message.
+def mandatory_secret!(env, value)
+  return unless value.blank?
+  return unless ENV["PORTUS_#{env}"].blank?
+
+  raise "Environment variable `PORTUS_#{env}` has not been set! This variable is " \
+        "mandatory in production because it's needed for the generation of secrets."
+end
+
+if Rails.env.production?
+  # Mandatory environment variables for production.
+  mandatory_secret!("SECRET_KEY_BASE", Rails.application.secrets.secret_key_base)
+  mandatory_secret!("KEY_PATH", Rails.application.secrets.encryption_private_key_path)
+  mandatory_secret!("PASSWORD", Rails.application.secrets.portus_password)
+
+  # Strongly recommended environment variables for production.
+  if ENV["PORTUS_MACHINE_FQDN_VALUE"].blank?
+    if APP_CONFIG["machine_fqdn"]["value"] == APP_CONFIG.default_of("machine_fqdn.value")
+      Rails.logger.warn "You have not changed the FQDN configuration. Are you sure about this?"
+    end
+  end
+end


### PR DESCRIPTION
Some environment variables are extremely important when deploying
Portus. This commit makes Portus raise an exception during
initialization process when there's something off about these
environment variables.

Fixes #580

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>