### PR TITLE
Removed fixed width of search input

### DIFF
--- a/app/assets/stylesheets/components/layout.scss
+++ b/app/assets/stylesheets/components/layout.scss
@@ -31,7 +31,6 @@ header {
   .search-header {
     position: relative;
     display: inline-block;
-    width: 250px;
     vertical-align: top;
     margin-right: 15px;
     margin-top: 4px;


### PR DESCRIPTION
I wasn't able to reproduce #939 by just testing with smaller resolutions (chrome stable and firefox 57b). I decreased the width and I was able to have the same result as reported. 

So, I removed the fixed width that was probably the reason why that happened before. I'm not sure why the width was there but I think it was a problem in the past with old browsers but now it's safe to just remove it.

<img width="833" alt="screenshot 2017-10-26 11 11 16" src="https://user-images.githubusercontent.com/188554/32055184-d4ba5bf0-ba3f-11e7-9df6-15879118b4d4.png">
<img width="806" alt="screenshot 2017-10-26 11 16 43" src="https://user-images.githubusercontent.com/188554/32055188-d5b5003c-ba3f-11e7-94bc-fb0e9d3180ad.png">

Fixes #939 