### PR TITLE
fix period time

### DIFF
--- a/config/cronotab.rb
+++ b/config/cronotab.rb
@@ -2,4 +2,4 @@ require "portus/migrate"
 
 env = ENV["CATALOG_CRON"] || 10
 value = Portus::Migrate.from_humanized_time(env, 10)
-Crono.perform(CatalogJob).every value
+Crono.perform(CatalogJob).every value.seconds


### PR DESCRIPTION
This PR fixes #1483 

```
undefined method `from_now' for 600:Integer
/Users/vadim/.rvm/gems/ruby-2.4.2/gems/crono-0.9.0/lib/crono/period.rb:34:in `initial_next'
/Users/vadim/.rvm/gems/ruby-2.4.2/gems/crono-0.9.0/lib/crono/period.rb:14:in `next'
/Users/vadim/.rvm/gems/ruby-2.4.2/gems/crono-0.9.0/lib/crono/job.rb:16:in `initialize'
/Users/vadim/.rvm/gems/ruby-2.4.2/gems/crono-0.9.0/lib/crono/performer_proxy.rb:10:in `new'
/Users/vadim/.rvm/gems/ruby-2.4.2/gems/crono-0.9.0/lib/crono/performer_proxy.rb:10:in `every'
/Users/dev/code/Portus/config/cronotab.rb:5:in `<top (required)>'
```