### PR TITLE
Dockerfile: updated ruby packages to 2.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY Gemfile* ./
 #   3. We then proceed to remove unneeded clutter: first we remove some packages
 #      installed with the devel_basis pattern, and finally we zypper clean -a.
 RUN zypper ref && \
-    zypper -n in --no-recommends ruby2.3-devel ruby2.3-rubygem-bundler \
+    zypper -n in --no-recommends ruby2.4-devel ruby2.4-rubygem-bundler \
            libxml2-devel nodejs libmysqlclient-devel postgresql-devel libxslt1 && \
     zypper -n in --no-recommends -t pattern devel_basis && \
     bundle install --retry=3 && \


### PR DESCRIPTION
I've tried to build portus image again from master with the docker-compose setup and I got

```
Your Ruby version is 2.3.3, but your Gemfile specified >= 2.4
```

I went to the Dockerfile and saw that there still some `2.3` references. Ruby is now `2.4.x` but the bundler gem installed is `1.10.6`. And now I get

```
Your Ruby version is 2.4.1, but your Gemfile specified >= 2.4
```

We need to package `ruby2.4-rubygem-bundler` with a recent version (1.12.x at least if my research wasn't wrong).