### PR TITLE
Properly check SSL usage requirements

### DIFF
--- a/config/initializers/swagger.rb
+++ b/config/initializers/swagger.rb
@@ -1,5 +1,5 @@
 unless Rails.env.production?
-  protocol = ENV["PORTUS_CHECK_SSL_USAGE_ENABLED"] ? "https://" : "http://"
+  protocol = ::APP_CONFIG.enabled?("check_ssl_usage") ? "https://" : "http://"
 
   GrapeSwaggerRails.options.url      = "/api/swagger_doc.json"
   GrapeSwaggerRails.options.app_url  = "#{protocol}#{APP_CONFIG["machine_fqdn"]["value"]}"

--- a/lib/api/root_api.rb
+++ b/lib/api/root_api.rb
@@ -51,7 +51,6 @@ module API
     mount ::API::V1::Teams
     mount ::API::V1::Users
 
-    schemes = ENV["PORTUS_CHECK_SSL_USAGE_ENABLED"] ? [:https] : [:http, :https]
     add_swagger_documentation \
       security_definitions: {
         api_key: {
@@ -66,7 +65,6 @@ module API
         description:   "Portus CRUD API",
         contact_name:  "Portus authors",
         contact_email: "portus-dev@googlegroups.com"
-      },
-      schemes:              schemes
+      }
   end
 end


### PR DESCRIPTION
In a couple of places (around the API) there was a check for the
PORTUS_CHECK_SSL_USAGE_ENABLED environment variable. Doing this is wrong
because it skips the fact that this is the default behavior as defined
in the main config.yml file. So, the `APP_CONFIG.enabled?` method should
be used instead.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>