### PR TITLE
Registry Client should probe the /v2/ path and accept more return codes

### DIFF
--- a/lib/portus/registry_client.rb
+++ b/lib/portus/registry_client.rb
@@ -32,13 +32,16 @@ module Portus
     # Returns whether the registry is reachable with the given credentials or
     # not. This might raise a RequestError on failure.
     def reachable?
-      res = safe_request("", "get", false)
+      res = safe_request("/v2/", "get", false)
 
-      # If a 401 was retrieved, it means that at least the registry has been
-      # contacted. In order to get a 200, this registry should be created and
+      # The 'Docker-Distribution-Api-Version' header indicates that we are connected to a
+      # Docker Registry endpoint.
+      # 401 means that the registry requires authentication
+      # In order to get a 200, this registry should be created and
       # an authorization requested. The former can be inconvenient, because we
       # might want to test whether the registry is reachable.
-      !res.nil? && res.code.to_i == 401
+      !res.nil? && res.header.key?("Docker-Distribution-Api-Version") &&
+        (res.code.to_i == 401 || res.code.to_i == 200)
     end
 
     # Calls the `/:repository/manifests/:tag` endpoint from the registry. It

--- a/spec/lib/portus/registry_client_spec.rb
+++ b/spec/lib/portus/registry_client_spec.rb
@@ -23,7 +23,7 @@ class RegistryPerformRequest < Portus::RegistryClient
     # We don't care about the given parameters.
 
     return nil if @status.nil?
-    OpenStruct.new(code: @status)
+    OpenStruct.new(code: @status, header: { "Docker-Distribution-Api-Version" => "registry/2.0" })
   end
 end
 
@@ -175,7 +175,7 @@ describe Portus::RegistryClient do
 
   context "is reachable or not" do
     it "returns the proper thing in all the scenarios" do
-      [[nil, false], [200, false], [401, true]].each do |cs|
+      [[nil, false], [404, false], [200, true], [401, true]].each do |cs|
         r = RegistryPerformRequest.new(cs.first)
         expect(r.reachable?).to be cs.last
       end

--- a/spec/models/registry_spec.rb
+++ b/spec/models/registry_spec.rb
@@ -113,7 +113,8 @@ describe Registry, type: :model do
     end
 
     it "returns the proper message for each scenario" do
-      GOOD_RESPONSE = OpenStruct.new(code: 401)
+      GOOD_RESPONSE = OpenStruct.new(code: 401, header:
+        { "Docker-Distribution-Api-Version" => "registry/2.0" })
 
       [
         [nil, GOOD_RESPONSE, true, /^$/],

--- a/spec/vcr_cassettes/health/clair-bad.yml
+++ b/spec/vcr_cassettes/health/clair-bad.yml
@@ -42,9 +42,11 @@ http_interactions:
       - d0865133-bb26-4eac-ac26-370f66bc457c
       X-Runtime:
       - '0.006993'
+      Docker-Distribution-Api-Version:
+      - 'registry/2.0'
     body:
       encoding: UTF-8
       string: '{"error":"You need to sign in or sign up before continuing."}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 03 Aug 2017 15:50:16 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/health/clair-ok.yml
+++ b/spec/vcr_cassettes/health/clair-ok.yml
@@ -42,10 +42,12 @@ http_interactions:
       - d6e6ff71-6077-4797-b255-f806857fff9c
       X-Runtime:
       - '0.107929'
+      Docker-Distribution-Api-Version:
+      - 'registry/2.0'
     body:
       encoding: UTF-8
       string: '{"error":"You need to sign in or sign up before continuing."}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 03 Aug 2017 15:47:26 GMT
 - request:
     method: get
@@ -76,6 +78,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Thu, 03 Aug 2017 15:47:26 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/health/ok.yml
+++ b/spec/vcr_cassettes/health/ok.yml
@@ -42,9 +42,12 @@ http_interactions:
       - 9eed8ef5-8c52-4673-af54-afb6534925b0
       X-Runtime:
       - '0.190492'
+      Docker-Distribution-Api-Version:
+      - 'registry/2.0'
+
     body:
       encoding: UTF-8
       string: '{"error":"You need to sign in or sign up before continuing."}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 03 Aug 2017 15:36:22 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
Registry Client should probe that the /v2/ path reachable and that we accept 200 responses as well.

fixes #1486

Going straight to the /v2/ allows us to know we are targeting the right Registry.

We could also check for the header

```yml
  docker-distribution-api-version:
  - registry/2.0
```

to make sure we are really talking to the registry.

makes also https://github.com/SUSE/Portus/tree/master/examples/compose usable again.