### PR TITLE
Added custom validator for the uniqueness of tags 

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -139,7 +139,7 @@ class Repository < ActiveRecord::Base
       # Update digest if the given tag already exists.
       id, digest = Repository.id_and_digest_from_event(event, repository.full_name)
       tag = repository.tags.find_by(name: tag)
-      tag.update!(image_id: id, digest: digest, updated_at: Time.current)
+      tag.update_columns(image_id: id, digest: digest, updated_at: Time.current)
       repository.create_activity(:push, owner: actor, recipient: tag)
       return
     end
@@ -221,9 +221,8 @@ class Repository < ActiveRecord::Base
 
       # Let's update the tag, if it really changed,
       t = repository.tags.find_by(name: tag)
-      t.digest = digest
-      if t.changed.any?
-        t.save!
+      if t.digest != digest
+        t.update_column(:digest, digest)
         repository.create_activity(:push, owner: portus, recipient: t)
       end
     end

--- a/app/validators/unique_tag_validator.rb
+++ b/app/validators/unique_tag_validator.rb
@@ -1,0 +1,22 @@
+require "portus/db"
+
+# See https://github.com/SUSE/Portus/pull/1494 on why we didn't use the
+# `uniqueness` constraint directly.
+#
+# NOTE: if we ever remove MySQL support, replace this with the proper validator.
+class UniqueTagValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    if value.blank?
+      record.errors[attribute] << "Empty entry '#{value}'"
+      raise ActiveRecord::StatementInvalid, record
+    end
+
+    # Perform the select query with the proper collation on Mysql's case.
+    collate = ::Portus::DB.mysql? ? "COLLATE utf8_bin " : ""
+    tag = Tag.where("name #{collate}= ? AND repository_id = ?", value, record.repository_id)
+    return unless tag.any?
+
+    record.errors[attribute] << "Duplicate entry '#{value}' in repository '#{record.repository_id}'"
+    raise ActiveRecord::RecordInvalid, record
+  end
+end

--- a/db/migrate/20171031112721_remove_index_on_tag_name_repository_id.rb
+++ b/db/migrate/20171031112721_remove_index_on_tag_name_repository_id.rb
@@ -1,0 +1,5 @@
+class RemoveIndexOnTagNameRepositoryId < ActiveRecord::Migration
+  def change
+    remove_index :tags, name: "index_tags_on_name_and_repository_id"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171014192702) do
+ActiveRecord::Schema.define(version: 20171031112721) do
 
   create_table "activities", force: :cascade do |t|
     t.integer  "trackable_id",   limit: 4
@@ -130,7 +130,6 @@ ActiveRecord::Schema.define(version: 20171014192702) do
     t.string   "username",      limit: 255
   end
 
-  add_index "tags", ["name", "repository_id"], name: "index_tags_on_name_and_repository_id", unique: true, using: :btree
   add_index "tags", ["repository_id"], name: "index_tags_on_repository_id", using: :btree
   add_index "tags", ["user_id"], name: "index_tags_on_user_id", using: :btree
 

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -15,9 +15,8 @@
 #
 # Indexes
 #
-#  index_tags_on_name_and_repository_id  (name,repository_id) UNIQUE
-#  index_tags_on_repository_id           (repository_id)
-#  index_tags_on_user_id                 (user_id)
+#  index_tags_on_repository_id  (repository_id)
+#  index_tags_on_user_id        (user_id)
 #
 
 require "rails_helper"

--- a/spec/lib/portus/db_spec.rb
+++ b/spec/lib/portus/db_spec.rb
@@ -28,7 +28,7 @@ describe Portus::DB do
     end
 
     after :each do
-      ENV["PORTUS_DB_ADAPTER"] = nil
+      ENV["PORTUS_DB_ADAPTER"] = CONFIGURED_DB_ADAPTER
     end
 
     it "returns true if the adapter is mysql" do

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -83,7 +83,7 @@ describe Repository do
     end
 
     context "adding an existing repo/tag" do
-      it "adds a new activity when an already existing repo/tag already existed" do
+      it "adds a new activity when an already existing repo/tag already existed", focus: true do
         event = { "actor" => { "name" => user.username } }
 
         # First we create it, and make sure that it creates the activity.
@@ -104,7 +104,7 @@ describe Repository do
 
         # Making sure that the updated_at column is set in the past.
         tag = Repository.find_by(name: repository_name).tags.first
-        tag.update!(updated_at: 2.hours.ago)
+        tag.update_columns(updated_at: 2.hours.ago)
         ua = tag.updated_at
 
         event["target"]["digest"] = "bar"
@@ -122,7 +122,7 @@ describe Repository do
 
         # Making sure that the updated_at column is set in the past.
         tag = Repository.find_by(name: repository_name).tags.first
-        tag.update!(updated_at: 2.hours.ago)
+        tag.update_columns(updated_at: 2.hours.ago)
         ua = tag.updated_at
 
         allow(Repository).to receive(:id_and_digest_from_event).and_return(["id", "bar"])

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -15,9 +15,8 @@
 #
 # Indexes
 #
-#  index_tags_on_name_and_repository_id  (name,repository_id) UNIQUE
-#  index_tags_on_repository_id           (repository_id)
-#  index_tags_on_user_id                 (user_id)
+#  index_tags_on_repository_id  (repository_id)
+#  index_tags_on_user_id        (user_id)
 #
 
 require "rails_helper"
@@ -37,6 +36,33 @@ describe Tag do
 
   it { should belong_to(:repository) }
   it { should belong_to(:author) }
+
+  describe "creating tags" do
+    it "defaults to latest" do
+      t = Tag.create(repository: repository)
+      expect(t.name).to eq("latest")
+    end
+
+    it "does not accept nil names" do
+      expect do
+        Tag.create(name: nil, repository: repository)
+      end.to raise_error(ActiveRecord::StatementInvalid)
+    end
+
+    it "validates the uniqueness" do
+      create(:tag, name: "tag", repository: repository)
+      expect do
+        create(:tag, name: "tag", repository: repository)
+      end.to raise_error(ActiveRecord::RecordInvalid)
+    end
+
+    it "case sensitive for tag names" do
+      create(:tag, name: "tag", repository: repository)
+      expect do
+        create(:tag, name: "TAG", repository: repository)
+      end.not_to raise_error
+    end
+  end
 
   describe "#delete_by_digest!" do
     let!(:tag)  { create(:tag, name: "tag1", repository: repository, digest: "1") }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -17,6 +17,9 @@ ActiveRecord::Migration.maintain_test_schema!
 # been pushed into individual files inside the `spec/support` directory.
 Dir[Rails.root.join("spec", "support", "**", "*.rb")].each { |f| require f }
 
+# Keep the original value of the PORTUS_DB_ADAPTER env. variable.
+CONFIGURED_DB_ADAPTER = ENV["PORTUS_DB_ADAPTER"]
+
 # To avoid problems, the LDAP authenticatable is enabled always. Since this
 # means trouble for regular logins, we mock Portus::LDAP to implement a fake
 # authenticate method. This method will be used by everyone. Tests that really


### PR DESCRIPTION
Even if the case sensitivity is set to true when you add a uniqueness
constraint in Ruby on Rails, it happens that in MariaDB/MySQL this is
not correctly handled when this constraint is coupled with another
column. In our case, the uniqueness constraint was between tag name and
repository. In this case, in MariaDB the evaluated key for the
uniqueness index was case insensitive (while in PostgreSQL everything
went as expected). This means that for two tags named "tag" and "TAG"
and inside of the repository "4", the evaluated keys were "tag-4" and
"TAG-4", and in MariaDB they were considered equal, hence it failed.

I've tried multiple solutions, but they all failed:

- Explicitly setting the case_sensitive property on the Rails' side.
- Changing the collation for the table, column, and combinations. This
  was successful locally but not on the CI server. Moreover, it broke
  the schema:load task.

The only solution left to us was to drop the `uniqueness` validator (and
the index with it) and write a custom one. This will certainly be slightly
inefficient, but it looks like we have no other option. Just to be sure,
I've added tests for this whole constraint mess, and for the other
constraints.

In the future we might evaluate removing MySQL support, since it's not
the first time that it has some downsides for the overall source code.
This is something to consider on the next major versions (where
breakages and manual migrations are to be expected).

Fixes #1262

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>