### PR TITLE
js: added default prefix value to sortable mixin

### DIFF
--- a/app/assets/javascripts/shared/mixins/table-sortable.js
+++ b/app/assets/javascripts/shared/mixins/table-sortable.js
@@ -20,6 +20,10 @@ export default {
       type: String,
       default: 'true',
     },
+    prefix: {
+      type: String,
+      default: '',
+    },
   },
 
   data() {


### PR DESCRIPTION
This will prevent an error if no prefix is declared when
using a component.