### PR TITLE
js: prevent app token link to be clickable when disabled

### DIFF
--- a/app/assets/javascripts/modules/users/components/application-token-panel.js
+++ b/app/assets/javascripts/modules/users/components/application-token-panel.js
@@ -19,7 +19,11 @@ class ApplicationTokenPanel extends BaseComponent {
     this.$el.on('click', TOGGLE_LINK, e => this.onClick(e));
   }
 
-  onClick() {
+  onClick(e) {
+    if (this.$toggle.attr('disabled')) {
+      e.preventDefault();
+    }
+
     this.$form.toggle(400, 'swing', () => {
       const visible = this.$form.is(':visible');
 


### PR DESCRIPTION
This was a missing change done while fixing the profile form.