### PR TITLE
api: fixed crash on null author of a tag

### DIFF
--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -77,7 +77,7 @@ module API
       expose :author, documentation: {
         type: Integer,
         desc: "The ID of the user that pushed this tag"
-      } { |t| { id: t.author.id, name: t.author.username } }
+      } { |t| { id: t.author&.id, name: t.author&.username } }
       expose :digest, documentation: { type: String, desc: "The digest of the tag" }
       expose :image_id, documentation: { type: String, desc: "The internal image ID" }
       expose :created_at, :updated_at, documentation: { type: DateTime }

--- a/spec/api/grape_api/v1/tags_spec.rb
+++ b/spec/api/grape_api/v1/tags_spec.rb
@@ -25,12 +25,13 @@ describe API::V1::Tags do
 
     it "returns list of tags" do
       create(:tag, name: "taggg", repository: repository, digest: "1", author: admin)
+      create(:tag, name: "another_tag", repository: repository, digest: "1", author: nil)
       create_list(:tag, 4, repository: repository, digest: "123123", author: admin)
       get "/api/v1/tags", nil, @header
 
       tags = JSON.parse(response.body)
       expect(response).to have_http_status(:success)
-      expect(tags.length).to eq(5)
+      expect(tags.length).to eq(6)
     end
   end
 

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -83,7 +83,7 @@ describe Repository do
     end
 
     context "adding an existing repo/tag" do
-      it "adds a new activity when an already existing repo/tag already existed", focus: true do
+      it "adds a new activity when an already existing repo/tag already existed" do
         event = { "actor" => { "name" => user.username } }
 
         # First we create it, and make sure that it creates the activity.


### PR DESCRIPTION
It's not guaranteed from the DB that the author cannot be null.
Moreover, it happened to me that the author of a tag was nil, and so
Portus crashed when requesting this info through the API.

This commit simply sets the author info to null if the author is also
null.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>