### PR TITLE
js: changed eventbus to plugin

### DIFF
--- a/app/assets/javascripts/modules/namespaces/components/edit-form.js
+++ b/app/assets/javascripts/modules/namespaces/components/edit-form.js
@@ -4,7 +4,6 @@ import { required } from 'vuelidate/lib/validators';
 
 import { setTypeahead } from '~/utils/typeahead';
 
-import EventBus from '~/utils/eventbus';
 import Alert from '~/shared/components/alert';
 
 import NamespacesService from '../services/namespaces';
@@ -38,7 +37,7 @@ export default {
         const namespace = response.data;
 
         Alert.show(`Namespace '${namespace.name}' was updated successfully`);
-        EventBus.$emit('namespaceUpdated', namespace);
+        this.$bus.$emit('namespaceUpdated', namespace);
       }).catch((response) => {
         let errors = response.data;
 

--- a/app/assets/javascripts/modules/namespaces/components/new-form.js
+++ b/app/assets/javascripts/modules/namespaces/components/new-form.js
@@ -4,7 +4,6 @@ import { required } from 'vuelidate/lib/validators';
 
 import { setTypeahead } from '~/utils/typeahead';
 
-import EventBus from '~/utils/eventbus';
 import Alert from '~/shared/components/alert';
 import FormMixin from '~/shared/mixins/form';
 
@@ -50,7 +49,7 @@ export default {
         });
 
         Alert.show(`Namespace '${namespace.name}' was created successfully`);
-        EventBus.$emit('namespaceCreated', namespace);
+        this.$bus.$emit('namespaceCreated', namespace);
       }).catch((response) => {
         let errors = response.data;
 

--- a/app/assets/javascripts/modules/namespaces/pages/index.js
+++ b/app/assets/javascripts/modules/namespaces/pages/index.js
@@ -1,7 +1,6 @@
 import Vue from 'vue';
 
 import ToggleLink from '~/shared/components/toggle-link';
-import EventBus from '~/utils/eventbus';
 
 import NamespacesPanel from '../components/panel';
 import NewNamespaceForm from '../components/new-form';
@@ -64,7 +63,7 @@ $(() => {
     mounted() {
       set(this.state, 'isLoading', true);
       this.loadData();
-      EventBus.$on('namespaceCreated', namespace => this.onCreate(namespace));
+      this.$bus.$on('namespaceCreated', namespace => this.onCreate(namespace));
     },
   });
 });

--- a/app/assets/javascripts/modules/namespaces/pages/show.js
+++ b/app/assets/javascripts/modules/namespaces/pages/show.js
@@ -1,7 +1,6 @@
 import Vue from 'vue';
 
 import ToggleLink from '~/shared/components/toggle-link';
-import EventBus from '~/utils/eventbus';
 
 import NamespaceInfo from '../components/info';
 import EditNamespaceForm from '../components/edit-form';
@@ -42,7 +41,7 @@ $(() => {
     },
 
     mounted() {
-      EventBus.$on('namespaceUpdated', namespace => this.onUpdate(namespace));
+      this.$bus.$on('namespaceUpdated', namespace => this.onUpdate(namespace));
     },
   });
 });

--- a/app/assets/javascripts/modules/repositories/components/delete-tag-action.vue
+++ b/app/assets/javascripts/modules/repositories/components/delete-tag-action.vue
@@ -8,8 +8,6 @@
 </template>
 
 <script>
-  import EventBus from '~/utils/eventbus';
-
   export default {
     props: ['state'],
 
@@ -28,7 +26,7 @@
 
     methods: {
       deleteTags() {
-        EventBus.$emit('deleteTags');
+        this.$bus.$emit('deleteTags');
       },
     },
   };

--- a/app/assets/javascripts/modules/repositories/pages/show.js
+++ b/app/assets/javascripts/modules/repositories/pages/show.js
@@ -2,7 +2,6 @@ import Vue from 'vue';
 
 import LoadingIcon from '~/shared/components/loading-icon';
 import Alert from '~/shared/components/alert';
-import EventBus from '~/utils/eventbus';
 
 import TagsTable from '../components/tags-table';
 import TagsNotLoaded from '../components/tags-not-loaded';
@@ -135,7 +134,7 @@ $(() => {
     mounted() {
       set(this, 'isLoading', true);
       this.loadData();
-      EventBus.$on('deleteTags', () => this.deleteTags());
+      this.$bus.$on('deleteTags', () => this.deleteTags());
       // eslint-disable-next-line no-new
       new CommentsPanel($('.comments-wrapper'));
     },

--- a/app/assets/javascripts/modules/teams/components/new-form.js
+++ b/app/assets/javascripts/modules/teams/components/new-form.js
@@ -2,7 +2,6 @@ import Vue from 'vue';
 
 import { required } from 'vuelidate/lib/validators';
 
-import EventBus from '~/utils/eventbus';
 import Alert from '~/shared/components/alert';
 import FormMixin from '~/shared/mixins/form';
 
@@ -38,7 +37,7 @@ export default {
         });
 
         Alert.show(`Team '${team.name}' was created successfully`);
-        EventBus.$emit('teamCreated', team);
+        this.$bus.$emit('teamCreated', team);
       }).catch((response) => {
         let errors = response.data;
 

--- a/app/assets/javascripts/modules/teams/pages/index.js
+++ b/app/assets/javascripts/modules/teams/pages/index.js
@@ -1,7 +1,6 @@
 import Vue from 'vue';
 
 import ToggleLink from '~/shared/components/toggle-link';
-import EventBus from '~/utils/eventbus';
 
 import NewTeamForm from '../components/new-form';
 import TeamsTable from '../components/table';
@@ -44,7 +43,7 @@ $(() => {
     },
 
     mounted() {
-      EventBus.$on('teamCreated', team => this.onCreate(team));
+      this.$bus.$on('teamCreated', team => this.onCreate(team));
     },
   });
 });

--- a/app/assets/javascripts/modules/teams/pages/show.js
+++ b/app/assets/javascripts/modules/teams/pages/show.js
@@ -1,7 +1,6 @@
 import Vue from 'vue';
 
 import ToggleLink from '~/shared/components/toggle-link';
-import EventBus from '~/utils/eventbus';
 
 import NamespacesPanel from '../../namespaces/components/panel';
 import NewNamespaceForm from '../../namespaces/components/new-form';
@@ -49,7 +48,7 @@ $(() => {
     },
 
     mounted() {
-      EventBus.$on('namespaceCreated', namespace => this.onCreate(namespace));
+      this.$bus.$on('namespaceCreated', namespace => this.onCreate(namespace));
 
       // legacy
       const $teamDetails = $(this.$refs.details);

--- a/app/assets/javascripts/plugins/eventbus.js
+++ b/app/assets/javascripts/plugins/eventbus.js
@@ -1,0 +1,14 @@
+/* eslint-disable no-shadow */
+import Vue from 'vue';
+
+const bus = new Vue();
+
+export default function install(Vue) {
+  Object.defineProperties(Vue.prototype, {
+    $bus: {
+      get() {
+        return bus;
+      },
+    },
+  });
+}

--- a/app/assets/javascripts/utils/eventbus.js
+++ b/app/assets/javascripts/utils/eventbus.js
@@ -1,3 +1,0 @@
-import Vue from 'vue';
-
-export default new Vue({});

--- a/app/assets/javascripts/vue-shared.js
+++ b/app/assets/javascripts/vue-shared.js
@@ -2,8 +2,11 @@ import Vue from 'vue';
 import VueResource from 'vue-resource';
 import Vuelidate from 'vuelidate';
 
+import EventBus from './plugins/eventbus';
+
 Vue.use(Vuelidate);
 Vue.use(VueResource);
+Vue.use(EventBus);
 
 Vue.http.options.root = window.API_ROOT_URL;
 


### PR DESCRIPTION
More elegant way of using event bus pattern. This will avoid us to be importing eventbus all the time.

I'll do the same with `Alert`.