### PR TITLE
background: added registry event handling

### DIFF
--- a/app/controllers/api/v2/events_controller.rb
+++ b/app/controllers/api/v2/events_controller.rb
@@ -5,7 +5,7 @@ class Api::V2::EventsController < Api::BaseController
   # A new notification is coming, register it if valid.
   def create
     body = JSON.parse(request.body.read)
-    Portus::RegistryNotification.process!(body, Repository, Webhook)
+    Portus::RegistryNotification.process!(body)
     head status: :accepted
   end
 end

--- a/app/models/registry_event.rb
+++ b/app/models/registry_event.rb
@@ -6,14 +6,36 @@
 #
 #  id         :integer          not null, primary key
 #  event_id   :string(255)      default("")
-#  repository :string(255)      default("")
-#  tag        :string(255)      default("")
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  status     :integer          default(0)
+#  data       :text(65535)
 #
 
 # RegistryEvent represents an event coming from the Registry. This model stores
 # events that are being handled by Portus or that have been handled before. This
 # way we avoid duplication of registry events
 class RegistryEvent < ActiveRecord::Base
+  HANDLERS = [Repository, Webhook].freeze
+
+  # NOTE: as a Hash because in Rails 5 we'll be able to pass a proper prefix.
+  enum status: { done: 0, progress: 1, fresh: 2 }
+
+  # Processes the notification data with the given handlers. The data is the
+  # parsed JSON body as given by the registry. A handler is a class that can
+  # call the `handle_#{event}_event` method. This method receives an `event`
+  # object, which is the event object as given by the registry.
+  def self.handle!(event)
+    RegistryEvent.where(event_id: event["id"]).update_all(status: RegistryEvent.statuses[:progress])
+
+    action = event["action"]
+    Rails.logger.info "Handling '#{event["action"]}' event:\n#{JSON.pretty_generate(event)}"
+
+    # Delegate the handling to the known handlers.
+    HANDLERS.each { |handler| handler.send("handle_#{action}_event".to_sym, event) }
+
+    # Finally mark this event as handled, so a background job does not pick it
+    # up again.
+    RegistryEvent.where(event_id: event["id"]).update_all(status: RegistryEvent.statuses[:done])
+  end
 end

--- a/db/migrate/20171213093923_add_status_and_data_to_registry_event.rb
+++ b/db/migrate/20171213093923_add_status_and_data_to_registry_event.rb
@@ -1,0 +1,6 @@
+class AddStatusAndDataToRegistryEvent < ActiveRecord::Migration
+  def change
+    add_column :registry_events, :status, :integer, default: RegistryEvent.statuses[:done]
+    add_column :registry_events, :data, :text
+  end
+end

--- a/db/migrate/20171213094038_remove_repository_and_tag_from_registry_event.rb
+++ b/db/migrate/20171213094038_remove_repository_and_tag_from_registry_event.rb
@@ -1,0 +1,6 @@
+class RemoveRepositoryAndTagFromRegistryEvent < ActiveRecord::Migration
+  def change
+    remove_column :registry_events, :repository, :string
+    remove_column :registry_events, :tag, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171130095821) do
+ActiveRecord::Schema.define(version: 20171213094038) do
 
   create_table "activities", force: :cascade do |t|
     t.integer  "trackable_id",   limit: 4
@@ -90,11 +90,11 @@ ActiveRecord::Schema.define(version: 20171130095821) do
   add_index "registries", ["name"], name: "index_registries_on_name", unique: true, using: :btree
 
   create_table "registry_events", force: :cascade do |t|
-    t.string   "event_id",   limit: 255, default: ""
-    t.string   "repository", limit: 255, default: ""
-    t.string   "tag",        limit: 255, default: ""
-    t.datetime "created_at",                          null: false
-    t.datetime "updated_at",                          null: false
+    t.string   "event_id",   limit: 255,   default: ""
+    t.datetime "created_at",                            null: false
+    t.datetime "updated_at",                            null: false
+    t.integer  "status",     limit: 4,     default: 0
+    t.text     "data",       limit: 65535
   end
 
   create_table "repositories", force: :cascade do |t|

--- a/lib/portus/background/registry.rb
+++ b/lib/portus/background/registry.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Portus
+  module Background
+    # Registry represents a task that syncs pending registry events into Portus.
+    class Registry
+      # Returns how many seconds has to pass between each loop for this
+      # background service.
+      def sleep_value
+        2
+      end
+
+      # Returns always true because this does not depend on some configuration
+      # options and because the `execute!` method will deal with valid rows
+      # already.
+      def work?
+        true
+      end
+
+      def execute!
+        RegistryEvent.where(status: RegistryEvent.statuses[:fresh]).find_each do |e|
+          data = JSON.parse(e.data)
+          RegistryEvent.handle!(data)
+        end
+      end
+
+      def to_s
+        "Registry events"
+      end
+    end
+  end
+end

--- a/lib/portus/background/security_scanning.rb
+++ b/lib/portus/background/security_scanning.rb
@@ -7,6 +7,12 @@ module Portus
     # SecurityScanning represents a task for checking vulnerabilities of tags that
     # have not been scanned yet.
     class SecurityScanning
+      # Returns how many seconds has to pass between each loop for this
+      # background service.
+      def sleep_value
+        10
+      end
+
       def work?
         ::Portus::Security.enabled? && Tag.exists?(scanned: Tag.statuses[:scan_none])
       end

--- a/spec/lib/portus/background/registry_spec.rb
+++ b/spec/lib/portus/background/registry_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "portus/background/registry"
+
+describe ::Portus::Background::Registry do
+  describe "#sleep_value" do
+    it "returns always 2" do
+      expect(subject.sleep_value).to eq 2
+    end
+  end
+
+  describe "#work?" do
+    it "always return true" do
+      expect(subject.work?).to be_truthy
+    end
+  end
+
+  describe "#execute!" do
+    let(:delete)    { ::Portus::Fixtures::RegistryEvent::DELETE.dup }
+    let(:version23) { ::Portus::Fixtures::RegistryEvent::VERSION23.dup }
+
+    it "calls RegistryEvent.handle! with the given events" do
+      data = '{ "key": "value" }'.to_json
+      RegistryEvent.create!(event_id: 1, data: data, status: RegistryEvent.statuses[:fresh])
+
+      count = 0
+      parsed = JSON.parse(data)
+      allow(RegistryEvent).to receive(:handle!).with(parsed) { count += 1 }
+      subject.execute!
+      expect(count).to eq 1
+    end
+
+    it "does nothing if no events happened" do
+      RegistryEvent.create!(event_id: 1, status: RegistryEvent.statuses[:done])
+
+      count = 0
+      allow(RegistryEvent).to receive(:handle!) { count += 1 }
+      subject.execute!
+      expect(count).to eq 0
+    end
+
+    it "performs well in an overall example" do
+      data = { "events" => [delete, version23] }
+
+      # All notifications are properly registered.
+      ::Portus::RegistryNotification.process!(data)
+      expect(RegistryEvent.count).to eq 2
+      expect(RegistryEvent.all.all? { |e| e.status == "fresh" }).to be_truthy
+
+      # And finally it processes the notifications.
+      expect(Webhook).to receive(:handle_delete_event).with(delete)
+      expect(Repository).to receive(:handle_delete_event).with(delete)
+      expect(Webhook).to receive(:handle_push_event).with(version23)
+      expect(Repository).to receive(:handle_push_event).with(version23)
+      subject.execute!
+
+      expect(RegistryEvent.all.all? { |e| e.status == "done" }).to be_truthy
+    end
+  end
+
+  describe "#to_s" do
+    it "works" do
+      expect(subject.to_s).to eq "Registry events"
+    end
+  end
+end

--- a/spec/lib/portus/background/security_scanning_spec.rb
+++ b/spec/lib/portus/background/security_scanning_spec.rb
@@ -17,6 +17,12 @@ describe ::Portus::Background::SecurityScanning do
     }
   end
 
+  describe "#sleep_value" do
+    it "returns always 10" do
+      expect(subject.sleep_value).to eq 10
+    end
+  end
+
   describe "#work?" do
     it "returns false if security scanning is not enabled" do
       APP_CONFIG["security"]["clair"]["server"] = ""

--- a/spec/lib/portus/registry_notification_spec.rb
+++ b/spec/lib/portus/registry_notification_spec.rb
@@ -3,115 +3,32 @@
 require "rails_helper"
 
 describe Portus::RegistryNotification do
-  let(:body) do
-    {
-      "events" => [
-        { "action" => "push" },
-        { "action" => "push", "target" => { "mediaType" => "some" } },
-        {
-          "action" => "pull", "target" => {
-            "mediaType" => "application/vnd.docker.distribution.manifest.v1+json"
-          }
-        }
-      ]
-    }
-  end
+  let(:body)      { ::Portus::Fixtures::RegistryEvent::BODY.dup }
+  let(:relevant)  { ::Portus::Fixtures::RegistryEvent::RELEVANT.dup }
+  let(:delete)    { ::Portus::Fixtures::RegistryEvent::DELETE.dup }
+  let(:version23) { ::Portus::Fixtures::RegistryEvent::VERSION23.dup }
 
-  let(:relevant) do
-    {
-      "action" => "push",
-      "target" => {
-        "mediaType"  => "application/vnd.docker.distribution.manifest.v1+json",
-        "digest"     => "sha256:1977980aad73e19f918c676de1860b0ee56167b07c20641ecda3f9d74b69627d",
-        "repository" => "mssola/busybox",
-        "url"        => "http://registry.test.lan/v2/mssola/busybox/manifests/sha256:1977980aad7"
-      }
-    }
-  end
+  it "processes all the relevant events", focus: true do
+    evaluated_events = [relevant, delete, version23]
+    evaluated_events.each { |e| body["events"] << e }
 
-  let(:delete) do
-    {
-      "id"        => "6d673710-06b5-48b5-a7d9-94cbaacf776b",
-      "timestamp" => "2016-04-13T15:03:39.595901492+02:00",
-      "action"    => "delete",
-      "target"    => {
-        "digest"     => "sha256:03d564cd8008f956c844cd3e52affb49bc0b65e451087a1ac9013c0140c595df",
-        "repository" => "registry"
-      },
-      "request"   => {
-        "id"        => "fae66612-ef48-4157-8994-bd146fbdd951",
-        "addr"      => "127.0.0.1:55452",
-        "host"      => "registry.mssola.cat:5000",
-        "method"    => "DELETE",
-        "useragent" => "Ruby"
-      },
-      "actor"     => {
-        "name" => "portus"
-      },
-      "source"    => {
-        "addr"       => "bucket:5000",
-        "instanceID" => "741bc03b-6ebe-4ffc-b6b1-4b33d5fc2090"
-      }
-    }
-  end
+    described_class.process!(body)
 
-  # This is a real even notification as given by docker distribution v2.3
-  let(:version23) do
-    sha = "sha256:b9c8a3839b2754e0fc4309e0f994f617d43814996805388e2f9d977db3fa7967"
-    ua  = "docker/1.9.1 go/go1.5.2 git-commit/a34a1d5 kernel/4.4.0-1-default os/linux arch/amd64"
+    events = RegistryEvent.order(:event_id)
+    expect(events.size).to eq 3
+    events.each_with_index do |e, idx|
+      data = JSON.parse(e.data)
 
-    {
-      "id"        => "7dc1c55c-dfe2-4699-ab0b-8f32e89882ce",
-      "timestamp" => "2016-02-05T11:16:14.917994087+01:00",
-      "action"    => "push",
-      "target"    => {
-        "mediaType"  => "application/vnd.docker.distribution.manifest.v1+prettyjws",
-        "size"       => 2739,
-        "digest"     => "sha256:b9c8a3839b2754e0fc4309e0f994f617d43814996805388e2f9d977db3fa7967",
-        "length"     => 2739,
-        "repository" => "mssola/lala",
-        "url"        => "https://registry.mssola.cat:5000/v2/mssola/lala/manifests/#{sha}"
-      },
-      "request"   => {
-        "id"        => "e30471d8-39c3-41c0-abc2-775ed43e81c9",
-        "addr"      => "127.0.0.1:54032",
-        "host"      => "registry.mssola.cat:5000",
-        "method"    => "PUT",
-        "useragent" => ua
-      },
-      "actor"     => {
-        "name" => "mssola"
-      },
-      "source"    => {
-        "addr"       => "g67:5000",
-        "instanceID" => "18771ece-0887-40f8-ad53-ee46451b4d8b"
-      }
-    }
-  end
-
-  it "processes all the relevant events" do
-    body["events"] << relevant
-    body["events"] << delete
-    body["events"] << version23
-    expect(Repository).to receive(:handle_push_event).with(relevant)
-    expect(Repository).to receive(:handle_delete_event).with(delete)
-    expect(Repository).to receive(:handle_push_event).with(version23)
-    described_class.process!(body, Repository)
+      expect(data).to eq evaluated_events[idx]
+      expect(e.status).to eq "fresh"
+    end
   end
 
   it "does not process the same event multiple times" do
     body["events"] = [version23]
-    expect(Repository).to receive(:handle_push_event).with(version23)
-    described_class.process!(body, Repository)
+    expect { described_class.process!(body) }.to(change { RegistryEvent.count }.from(0).to(1))
 
-    expect(RegistryEvent.count).to eq 1
-    event = RegistryEvent.find_by(event_id: version23["id"])
-    expect(event.event_id).to eq version23["id"]
-    expect(event.repository).to eq version23["target"]["repository"]
-
-    expect(Repository).not_to receive(:handle_push_event).with(version23)
-    described_class.process!(body, Repository)
-
-    expect(RegistryEvent.count).to eq 1
+    body["events"] = [version23]
+    expect { described_class.process!(body) }.to_not(change { RegistryEvent.count })
   end
 end

--- a/spec/support/registry_events.rb
+++ b/spec/support/registry_events.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+module Portus
+  module Fixtures
+    # Shared fixture data dealing with registry events.
+    module RegistryEvent
+      SHA = "sha256:b9c8a3839b2754e0fc4309e0f994f617d43814996805388e2f9d977db3fa7967"
+
+      BODY =
+        {
+          "events" => [
+            { "action" => "push" },
+            { "action" => "push", "target" => { "mediaType" => "some" } },
+            {
+              "action" => "pull", "target" => {
+                "mediaType" => "application/vnd.docker.distribution.manifest.v1+json"
+              }
+            }
+          ]
+        }.freeze
+
+      RELEVANT =
+        {
+          "id"     => "5d673710-06b5-48b5-a7d9-94cbaacf776b",
+          "action" => "push",
+          "target" => {
+            "mediaType"  => "application/vnd.docker.distribution.manifest.v1+json",
+            "digest"     => SHA,
+            "repository" => "mssola/busybox",
+            "url"        => "http://registry.test.lan/v2/mssola/busybox/manifests/#{SHA}"
+          }
+        }.freeze
+
+      DELETE =
+        {
+          "id"        => "6d673710-06b5-48b5-a7d9-94cbaacf776b",
+          "timestamp" => "2016-04-13T15:03:39.595901492+02:00",
+          "action"    => "delete",
+          "target"    => {
+            "digest"     => SHA,
+            "repository" => "registry"
+          },
+          "request"   => {
+            "id"        => "fae66612-ef48-4157-8994-bd146fbdd951",
+            "addr"      => "127.0.0.1:55452",
+            "host"      => "registry.mssola.cat:5000",
+            "method"    => "DELETE",
+            "useragent" => "Ruby"
+          },
+          "actor"     => {
+            "name" => "portus"
+          },
+          "source"    => {
+            "addr"       => "bucket:5000",
+            "instanceID" => "741bc03b-6ebe-4ffc-b6b1-4b33d5fc2090"
+          }
+        }.freeze
+
+      UA = "docker/1.9.1 go/go1.5.2 git-commit/a34a1d5 kernel/4.4.0-1-default os/linux arch/amd64"
+      VERSION23 =
+        {
+          "id"        => "7dc1c55c-dfe2-4699-ab0b-8f32e89882ce",
+          "timestamp" => "2016-02-05T11:16:14.917994087+01:00",
+          "action"    => "push",
+          "target"    => {
+            "mediaType"  => "application/vnd.docker.distribution.manifest.v1+prettyjws",
+            "size"       => 2739,
+            "digest"     => SHA,
+            "length"     => 2739,
+            "repository" => "mssola/lala",
+            "url"        => "https://registry.mssola.cat:5000/v2/mssola/lala/manifests/#{SHA}"
+          },
+          "request"   => {
+            "id"        => "e30471d8-39c3-41c0-abc2-775ed43e81c9",
+            "addr"      => "127.0.0.1:54032",
+            "host"      => "registry.mssola.cat:5000",
+            "method"    => "PUT",
+            "useragent" => UA
+          },
+          "actor"     => {
+            "name" => "mssola"
+          },
+          "source"    => {
+            "addr"       => "g67:5000",
+            "instanceID" => "18771ece-0887-40f8-ad53-ee46451b4d8b"
+          }
+        }.freeze
+    end
+  end
+end


### PR DESCRIPTION
From now on, registry notifications (image got pushed, image deleted)
will be handled entirely in the background. Portus itself will only
create the event on the DB, and it will expect for it to be handled
automatically by the background process.

Fixes #940
See #1353 and #1526

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>