### PR TITLE
Updated gem versions to match supported ones

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem "base32"
 gem "bootstrap-sass", "~> 3.3.4"
 gem "crono"
 gem "devise"
-gem "font-awesome-rails"
+gem "font-awesome-rails", "= 4.7.0.1"
 gem "grape"
 gem "grape-entity"
 gem "grape-swagger"
@@ -26,10 +26,10 @@ gem "pundit"
 gem "rails", "~> 4.2.10"
 gem "rails_stdout_logging", "~> 0.0.5", group: %i[development staging production]
 gem "redcarpet", "~> 3.4.0"
-gem "sass-rails", ">= 3.2"
+gem "sass", "~> 3.4.23"
+gem "sass-rails", "~> 5.0.6"
 gem "search_cop"
 gem "slim", "~> 3.0.8"
-gem "sprockets", "~> 2.12.3"
 gem "webpack-rails"
 
 gem "rack-cors", "~> 1.0.1"
@@ -71,6 +71,17 @@ gem "puma", "~> 3.10.0" if ENV["PORTUS_PUMA_DEPLOYMENT"] == "yes" || !packaging?
 
 # Configuration management
 gem "cconfig", "~> 1.2.0"
+
+# Pinning some versions
+gem "concurrent-ruby", "= 1.0.4"
+gem "i18n", "= 0.8.0"
+gem "ice_nine", "= 0.11.1"
+gem "loofah", "= 2.0.3"
+gem "minitest", "= 5.10.1"
+gem "multi_json", "= 1.12.1"
+gem "sprockets", "= 3.7.1"
+gem "sprockets-rails", "= 3.2.0"
+gem "temple", "= 0.7.7"
 
 # In order to create the Gemfile.lock required for packaging
 # meaning that it should contain only the production packages

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,10 +79,9 @@ GEM
     coderay (1.1.2)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.0.4)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    crass (1.0.2)
     crono (0.9.0)
       activerecord (~> 4.0)
       activesupport (~> 4.0)
@@ -117,8 +116,8 @@ GEM
       multipart-post (>= 1.2, < 3)
     ffaker (2.0.0)
     ffi (1.9.18)
-    font-awesome-rails (4.7.0.2)
-      railties (>= 3.2, < 5.2)
+    font-awesome-rails (4.7.0.1)
+      railties (>= 3.2, < 5.1)
     formatador (0.2.5)
     git-review (2.0.0)
       gli (~> 2.8.0)
@@ -168,11 +167,9 @@ GEM
     hashie (3.5.6)
     hashie-forbidden_attributes (0.1.1)
       hashie (>= 3.0)
-    hike (1.2.3)
     hirb (0.7.3)
-    i18n (0.9.0)
-      concurrent-ruby (~> 1.0)
-    ice_nine (0.11.2)
+    i18n (0.8.0)
+    ice_nine (0.11.1)
     json (2.1.0)
     json-schema (2.5.1)
       addressable (~> 2.3.7)
@@ -186,8 +183,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.1.1)
-      crass (~> 1.0.2)
+    loofah (2.0.3)
       nokogiri (>= 1.5.9)
     lumberjack (1.0.12)
     mail (2.6.6)
@@ -201,8 +197,8 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mini_portile2 (2.3.0)
-    minitest (5.10.3)
-    multi_json (1.12.2)
+    minitest (5.10.1)
+    multi_json (1.12.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
     mustermann (1.0.1)
@@ -296,8 +292,8 @@ GEM
       sprockets-rails
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)
-    rails-dom-testing (1.0.8)
-      activesupport (>= 4.2.0.beta, < 5.0)
+    rails-dom-testing (1.0.9)
+      activesupport (>= 4.2.0, < 5.0)
       nokogiri (~> 1.6)
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-erd (1.4.6)
@@ -356,17 +352,13 @@ GEM
     ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
     safe_yaml (1.0.4)
-    sass (3.5.2)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (5.0.3)
-      railties (>= 4.0.0, < 5.0)
+    sass (3.4.25)
+    sass-rails (5.0.7)
+      railties (>= 4.0.0, < 6)
       sass (~> 3.1)
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
-      tilt (~> 1.1)
+      tilt (>= 1.1, < 3)
     sawyer (0.3.0)
       faraday (~> 0.8, < 0.10)
       uri_template (~> 0.5.0)
@@ -384,28 +376,26 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    slim (3.0.8)
+    slim (3.0.9)
       temple (>= 0.7.6, < 0.9)
       tilt (>= 1.3.3, < 2.1)
-    sprockets (2.12.4)
-      hike (~> 1.2)
-      multi_json (~> 1.0)
-      rack (~> 1.0)
-      tilt (~> 1.1, != 1.3.0)
-    sprockets-rails (2.3.3)
-      actionpack (>= 3.0)
-      activesupport (>= 3.0)
-      sprockets (>= 2.8, < 4.0)
-    temple (0.8.0)
+    sprockets (3.7.1)
+      concurrent-ruby (~> 1.0)
+      rack (> 1, < 3)
+    sprockets-rails (3.2.0)
+      actionpack (>= 4.0)
+      activesupport (>= 4.0)
+      sprockets (>= 3.0.0)
+    temple (0.7.7)
     thor (0.19.4)
     thread_safe (0.3.6)
-    tilt (1.4.1)
+    tilt (2.0.8)
     timecop (0.7.4)
     treetop (1.6.8)
       polyglot (~> 0.3)
     typhoeus (1.0.2)
       ethon (>= 0.9.0)
-    tzinfo (1.2.3)
+    tzinfo (1.2.4)
       thread_safe (~> 0.1)
     uglifier (2.7.2)
       execjs (>= 0.3.0)
@@ -458,6 +448,7 @@ DEPENDENCIES
   capybara (~> 2.14.3)
   cconfig (~> 1.2.0)
   codeclimate-test-reporter
+  concurrent-ruby (= 1.0.4)
   crono
   database_cleaner
   devise
@@ -465,7 +456,7 @@ DEPENDENCIES
   ethon (~> 0.9.0)
   factory_girl_rails
   ffaker
-  font-awesome-rails
+  font-awesome-rails (= 4.7.0.1)
   git-review
   grape
   grape-entity
@@ -478,10 +469,15 @@ DEPENDENCIES
   guard-rubocop
   hashie-forbidden_attributes
   hirb
+  i18n (= 0.8.0)
+  ice_nine (= 0.11.1)
   json-schema
   jwt
   kaminari
+  loofah (= 2.0.3)
   md2man (~> 5.1.1)
+  minitest (= 5.10.1)
+  multi_json (= 1.12.1)
   mysql2 (= 0.4.7)
   net-ldap
   omniauth-github
@@ -504,12 +500,15 @@ DEPENDENCIES
   rspec-core (~> 3.7.0)
   rspec-rails
   rubocop (~> 0.51.0)
-  sass-rails (>= 3.2)
+  sass (~> 3.4.23)
+  sass-rails (~> 5.0.6)
   search_cop
   shoulda
   simplecov (= 0.15.1)
   slim (~> 3.0.8)
-  sprockets (~> 2.12.3)
+  sprockets (= 3.7.1)
+  sprockets-rails (= 3.2.0)
+  temple (= 0.7.7)
   thor (~> 0.19.4)
   timecop
   typhoeus (~> 1.0.2)
@@ -522,4 +521,4 @@ DEPENDENCIES
   wirble
 
 BUNDLED WITH
-   1.15.4
+   1.16.0


### PR DESCRIPTION
A first step to fix the packaging breakage is to pin down exactly which
gems we have to support. This commit updates the Gemfile so we pick the
gem versions that we agreed to support.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>