### PR TITLE
packaging: changed how we build dependencies

### DIFF
--- a/packaging/suse/README.install
+++ b/packaging/suse/README.install
@@ -1,9 +1,0 @@
-You just installed Portus for the first time.
-
-You can configure Portus by running:
-  portusctl setup
-
-This tool will setup all the components required to run Portus.
-
-A list of parameters to be used during the setup phase can be obtained running:
-  portusctl help setup

--- a/packaging/suse/package_and_push_to_obs.sh
+++ b/packaging/suse/package_and_push_to_obs.sh
@@ -15,11 +15,16 @@ if [ $TRAVIS_PULL_REQUEST == "false" ] && [ $OBS_BRANCH ] && [ $TRAVIS_COMMIT ] 
   rm -r *.orig
   git checkout -- .
 
+  # Generate the spec file and submit it.
   packaging/suse/make_spec.sh portus
   curl -X PUT -T packaging/suse/portus.spec -u $OSC_CREDENTIALS https://api.opensuse.org/source/$OBS_REPO/portus/portus.spec?comment=update_portus.spec\_to_commit_$TRAVIS_COMMIT\_from_branch_$OBS_BRANCH
-  for p in packaging/suse/patches/*.patch;do
-      curl -X PUT -T $p -u $OSC_CREDENTIALS https://api.opensuse.org/source/$OBS_REPO/portus/$(basename $p)?comment=update_patches\_to_commit_$TRAVIS_COMMIT\_from_branch_$OBS_BRANCH
-  done
+
+  # Submit patches if they exist.
+  if ls packaging/suse/patches/*.patch >/dev/null 2>&1 ;then
+      for p in packaging/suse/patches/*.patch;do
+          curl -X PUT -T $p -u $OSC_CREDENTIALS https://api.opensuse.org/source/$OBS_REPO/portus/$(basename $p)?comment=update_patches\_to_commit_$TRAVIS_COMMIT\_from_branch_$OBS_BRANCH
+      done
+  fi
 
   # Get the yarn.lock file from OBS and compare it. If they differ, then push a
   # new node_modules.tar.gz file.

--- a/packaging/suse/portus.spec.in
+++ b/packaging/suse/portus.spec.in
@@ -15,30 +15,22 @@
 # Please submit bugfixes or comments via http://bugs.opensuse.org/
 #
 
+%define branch    __BRANCH__
+%define portusdir /srv/Portus
+
 Name:           portus
-
-# When you release a new version, set Version and branch accordingly.
-# For example:
-# Version:      1.0.0
-# %define branch 1.0.0
-
 Version:        __VERSION__
-%define branch __BRANCH__
 Release:        0.0.1
 License:        Apache-2.0
 Summary:        Authorization service and fronted for Docker registry (v2)
 Url:            https://github.com/SUSE/Portus
-Source0:        %{branch}.tar.gz
+Group:          System/Management
 
+Source0:        %{branch}.tar.gz
 # Generated with `yarn install` which produces a reproduceable `node_modules`
 # directory thanks to the yarn.lock file defined in the Portus repo.
 Source1:        node_modules.tar.gz
-
-# Dynamically defined patches.
 __PATCHSOURCES__
-
-Group:          System/Management
-%define portusdir /srv/Portus
 
 Requires:       ruby >= 2.4
 Requires:       timezone
@@ -59,22 +51,23 @@ Obsoletes:      Portus = 20151120162040
 BuildRequires:  nodejs6
 BuildRequires:  yarn
 
+# Base ruby engine.
 %define rb_build_versions ruby24
 %define rb_ver 2.4.0
 BuildRequires:  %{rubydevel}
 BuildRequires:  %{rubygem gem2rpm}
-BuildRequires:  %{rubygem bundler} >= 1.15.4
 
 __RUBYGEMS_BUILD_REQUIRES__
-
-
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 
 %description
-Portus targets version 2 of the Docker registry API. It aims to act both as an authoritzation server and as a user interface for the next generation of the Docker registry.
+Portus targets version 2 of the Docker registry API. It aims to act both as an
+authoritzation server and as a user interface for the next generation of the
+Docker registry.
 
-This package has been built with commit __COMMIT__ from branch __BRANCH__ on date __DATE__
+This package has been built with commit __COMMIT__ from branch __BRANCH__ on
+date __DATE__
 
 %prep
 %setup -q -n Portus-%{branch}
@@ -89,8 +82,14 @@ tar xzvf node_modules.tar.gz
 install -d vendor/cache
 cp %{_libdir}/ruby/gems/%{rb_ver}/cache/*.gem vendor/cache
 
+# Deploy gems
+bundle config build.nokogiri --use-system-libraries
+bundle install --retry=3 --local --deployment --without assets test development
+
+# Install bundler
+gem.ruby2.4 install --no-rdoc --no-ri --install-dir vendor/bundle/ruby/%{rb_ver}/ vendor/cache/bundler-*.gem
+
 # Compile assets
-export NOKOGIRI_USE_SYSTEM_LIBRARIES=1
 SKIP_MIGRATION="yes" \
   PORTUS_SECRET_KEY_BASE="ap" PORTUS_KEY_PATH="ap" PORTUS_PASSWORD="ap" \
   RAILS_ENV=production NODE_ENV=production \
@@ -100,15 +99,6 @@ SKIP_MIGRATION="yes" \
 APPLICATION_CSS=$(find . -name application-*.css 2>/dev/null)
 cp $APPLICATION_CSS public/landing.css
 
-# Run bundle list to redo the Gemfile.lock
-bundle list
-
-# Deploy gems
-bundle install --retry=3 --local --deployment --without assets test development
-
-# Install bundler
-gem install --no-rdoc --no-ri --install-dir vendor/bundle/ruby/%{rb_ver}/ vendor/cache/bundler-*.gem
-
 # Remove unneeded directories/files
 rm -rf \
    vendor/cache \
@@ -117,6 +107,23 @@ rm -rf \
    vendor/assets \
    examples \
    *.orig
+
+# Removing irrelevant files for production.
+declare -a ary=(
+  ".gitignore" ".travis.yml" ".pelusa.yml" ".keep" ".rspec" ".codeclimate.yml"
+  ".yardopts" ".ruby-gemset" ".rubocop.yml" ".document" ".eslintrc"
+  ".eslintignore" ".env" ".dockerignore" ".editorconfig" ".erdconfig"
+  ".ruby-version" "*.pem" ".rubocop_todo.yml" ".concourse.yml"
+)
+for i in "${ary[@]}"; do
+  find . -name "$i" -type f -delete
+done
+
+# Remove directories and empty files.
+find . -name ".bundle" -type d -exec rm -rv {} +
+find . -name ".github" -type d -exec rm -rv {} +
+find . -name ".empty_directory" -type d -delete
+find . -size 0 -delete
 
 %install
 install -d %{buildroot}/%{portusdir}
@@ -136,22 +143,6 @@ install -d %{buildroot}%{_mandir}/man1
 install -p -m 644 packaging/suse/portusctl/man/man1/*.1 %{buildroot}%{_mandir}/man1
 
 %fdupes %{buildroot}/%{portusdir}
-
-%pre
-
-%post
-if [ -d /srv/Portus/tmp ];then
-  chown -R wwwrun:www /srv/Portus/tmp
-fi
-
-if [ \! -e "/srv/Portus/config/config-local.yml" ]; then
-  # First installation of Portus
-  cat %{portusdir}/packaging/suse/README.install
-fi
-
-%preun
-
-%postun
 
 %files
 %defattr(-,root,root)


### PR DESCRIPTION
This commit is a follow-up of bd383fba329b6256fdd0bb6d1a07fa98b12aeff0,
and it adapts all the packaging scripts on the idea that the Gemfile and
the Gemfile.lock files cannot be touched. After this commit, the portus
RPM builds again and it's cleaner than ever.

First of all, the `make_spec.sh` has been heavily modified, while
polishing some rough edges (e.g. proper debug functions). It will
require a specific bundler version, because now it will be taken from
the gem requirements instead of the `spec.in` file. The biggest change
is to only use `bundler` for anything related to gems. To list the gems
to be added as dependencies we are using now `bundle show`, which has
the knowledge of gem groups as defined in the previous commit. This way,
without modifying the Gemfile.lock file, we can properly filter the
dependencies. As a side-effect, this simplifies quite a lot the script.

As for the `portus.spec.in`, I have updated it so it uses gem groups,
and it will compile assets after fetching all gems (since it's the proper
order). Finally, I also added a couple of lines to remove all the
unneeded files/directories coming from vendored gems.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>