### PR TITLE
ci: explicitely set the bundler version to be used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,17 @@ matrix:
     - rvm: ruby-head
 
 cache:
-  bundler: true
   directories:
     - $PWD/travis_phantomjs
 
 before_install:
+  # Remove the default bundler and install the expected one.
+  - rvm @global do gem uninstall bundler --all --executables
+  - gem uninstall bundler --all --executables
+  - gem install bundler --version '1.15.4'
+  - rvm reload
+  - bundle --version
+
   - phantomjs --version
   - export PATH=$PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH
   - if [ $(phantomjs --version) != '2.1.1' ]; then rm -rf $PWD/travis_phantomjs; mkdir -p $PWD/travis_phantomjs; fi

--- a/packaging/suse/package_and_push_to_obs.sh
+++ b/packaging/suse/package_and_push_to_obs.sh
@@ -11,8 +11,7 @@
 
 if [ $TRAVIS_PULL_REQUEST == "false" ] && [ $OBS_BRANCH ] && [ $TRAVIS_COMMIT ] && [ $OSC_CREDENTIALS ] && [ $OBS_REPO ] && [ $TRAVIS_BRANCH == $OBS_BRANCH ];then
   # Clean up the environment
-  rm -r build
-  rm -r *.orig
+  rm -rf build *.orig
   git checkout -- .
 
   # Generate the spec file and submit it.


### PR DESCRIPTION
This is important when generating the spec file and submitting it to
OBS.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>