### PR TITLE
Get red of console warnings when running as Container in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -42,4 +42,7 @@ Rails.application.configure do
 
   # Set this to true when debugging a mailer.
   config.action_mailer.raise_delivery_errors = false
+
+  # Control which IP's have access to the console. In Dev mode we can allow all private networks
+  config.web_console.whitelisted_ips = %w[127.0.0.1/1 ::1 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16]
 end


### PR DESCRIPTION
When running the in container and development mode this message is displayed

```
portus_1      | Cannot render console from 172.18.0.1! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
```

the PR will make sure this message is not displayed and allow also debugging from local networks.


more about the option 
https://github.com/rails/web-console#configweb_consolewhitelisted_ips