### PR TITLE
packaging: adding bundled for JS libraries

### DIFF
--- a/packaging/suse/portus.spec.in
+++ b/packaging/suse/portus.spec.in
@@ -60,6 +60,8 @@ BuildRequires:  %{rubygem gem2rpm}
 
 __RUBYGEMS_BUILD_REQUIRES__
 
+__NODEJS_BUILD_PROVIDES__
+
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 
 %description


### PR DESCRIPTION
To ease up maintenance, we should add a `Provides: bundled(JS) =
VERSION` line for each JS library. This commit uses yarn to list all
dependencies.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>