### PR TITLE
packaging: added a script for checking gems

### DIFF
--- a/packaging/suse/rubygem_check.rb
+++ b/packaging/suse/rubygem_check.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+##
+# Get build dir.
+
+unless Dir.exist?("build")
+  puts <<~HERE
+    You are supposed to be running this script inside of packaging/suse and after a
+    successful run of `make_spec.sh`.
+HERE
+  exit 1
+end
+
+dir = ""
+Dir.entries("build").each do |d|
+  next if d == "." || d == ".."
+  dir = "build/#{d}"
+end
+
+##
+# Fetch current gems.
+
+cmd = "bundle show | tail -n +2 | awk '{ print $2 \" \" $3 }' | tr -d '()'"
+current = {}
+`cd #{dir} && #{cmd}`.split("\n").each do |row|
+  name, version = row.split(" ")
+  current[name.strip] = version.strip
+end
+
+##
+# Fetch the ones on OBS.
+
+list = `osc ls Virtualization:containers:Portus | grep rubygem`.split("\n")
+found = {}
+removed = {}
+
+list.each do |rg|
+  pkg = rg.gsub("rubygem-", "")
+  idx = pkg.index(/\-\d/)
+  name = idx ? pkg.slice(0..idx - 1) : pkg
+
+  if current[name]
+    found[rg] = name
+  elsif name != "gem2rpm"
+    removed[rg] = name
+  end
+end
+
+keys = current.keys - found.values
+unless keys.empty?
+  print "The following gems are missing from OBS:\n\n"
+  keys.each { |pkg| puts "  * #{pkg}" }
+  puts
+end
+
+unless removed.empty?
+  print "The following packages are not used by Portus:\n\n"
+  removed.each { |pkg| puts "  * #{pkg.first}" }
+end


### PR DESCRIPTION
This script will only work if you have previously run `make_spec.sh` and
you are on `packaging/suse`. Then, it will report:

1. Gems which are needed by Portus but are not available as RPMs.
2. RPMs which are on OBS but are not needed by Portus.

This script comes in handy because this project has changed quite a lot
its dependencies, and so some gems are on OBS when they shouldn't, etc.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>