### PR TITLE
Add name column for webhook and change dashboard messages for webhook

### DIFF
--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -92,6 +92,13 @@ class WebhooksController < ApplicationController
   end
 
   def webhook_params
-    params.require(:webhook).permit(:url, :request_method, :content_type, :username, :password)
+    params.require(:webhook).permit(
+      :name,
+      :url,
+      :request_method,
+      :content_type,
+      :username,
+      :password
+    )
   end
 end

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -14,6 +14,7 @@
 #  enabled        :boolean          default(FALSE)
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
+#  name           :string(255)
 #
 # Indexes
 #
@@ -152,7 +153,8 @@ class Webhook < ActiveRecord::Base
         namespace_id:   namespace.id,
         namespace_name: namespace.clean_name,
         webhook_url:    url,
-        webhook_host:   host
+        webhook_host:   host,
+        webhook_name:   name
       }
     )
   end

--- a/app/views/public_activity/webhook/_update.html.slim
+++ b/app/views/public_activity/webhook/_update.html.slim
@@ -9,7 +9,7 @@ li
         strong
           = "#{activity.owner.username} updated webhook "
         - if activity.trackable
-          = link_to activity.trackable.host, [activity.trackable.namespace, activity.trackable]
+          = link_to activity.trackable.name, [activity.trackable.namespace, activity.trackable]
         - else
           = activity.parameters[:webhook_host]
         = " under the "

--- a/app/views/webhooks/_detail.html.slim
+++ b/app/views/webhooks/_detail.html.slim
@@ -5,6 +5,9 @@
         col.col-80
     tbody
       tr
+        th Name
+        td= webhook.name
+      tr
         th Request method
         td= webhook.request_method
       tr

--- a/app/views/webhooks/_webhook.html.slim
+++ b/app/views/webhooks/_webhook.html.slim
@@ -1,4 +1,5 @@
 tr id="webhook_#{webhook.id}"
+  td= webhook.name
   td= link_to webhook.url, [namespace, webhook]
   td= webhook.request_method
   td= webhook.content_type

--- a/app/views/webhooks/create.js.erb
+++ b/app/views/webhooks/create.js.erb
@@ -2,7 +2,7 @@
   $('#float-alert p').html("<%= escape_javascript(@webhook.errors.full_messages.join('<br/>')) %>");
   $('#float-alert').fadeIn(setTimeOutAlertDelay());
 <% else %>
-  $('#float-alert p').html("Webhook '<%= @webhook.host %>' has been created successfully");
+  $('#float-alert p').html("Webhook '<%= @webhook.name %>' has been created successfully");
   $('#float-alert').fadeIn(setTimeOutAlertDelay());
 
   $('#add_webhook_form').fadeOut();

--- a/app/views/webhooks/index.html.slim
+++ b/app/views/webhooks/index.html.slim
@@ -2,6 +2,10 @@
   #add_webhook_form.collapse
     = form_for :webhook, url: namespace_webhooks_path(@namespace), remote: true, html: {id: 'new-webhook-form', class: 'form-horizontal', role: 'form'} do |f|
         .form-group
+          = f.label :name, {class: 'control-label col-md-2'}
+          .col-md-7
+            = f.text_field(:name, class: 'form-control', required: true, placeholder: "Name of the Webhook")
+        .form-group
           = f.label :url, {class: 'control-label col-md-2'}
           .col-md-7
             = f.text_field(:url, class: 'form-control', required: true, placeholder: "URL")
@@ -63,6 +67,7 @@
             col.col-20
           thead
             tr
+              th Name
               th URL
               th Request method
               th Content type

--- a/app/views/webhooks/show.html.slim
+++ b/app/views/webhooks/show.html.slim
@@ -12,6 +12,10 @@
                   | Edit webhook
           .panel-body
             .form-group
+              = f.label :name, {class: 'control-label col-md-2'}
+              .col-md-7
+                = f.text_field(:name, class: 'form-control', required: true, placeholder: "Name of the webhook")
+            .form-group
               = f.label :request_method, {class: 'control-label col-md-2'}
               .col-md-7
                 = f.select(:request_method, Webhook.request_methods.keys, {}, {class: 'form-control'})
@@ -39,7 +43,7 @@
           '#{@webhook.host}
         ' webhook
         small
-          a[data-placement="right" data-toggle="popover" data-container=".panel-heading" data-content="<b>Request method</b>: URL endpoint where the HTTP request is sent to.<br/><b>Content type</b>: Description of the webhook request content.<br/><b>Username</b>: Username used for basic HTTP auth.<br/><b>Password</b>: Password used for basic HTTP auth." data-original-title="What's this?" tabindex="0" data-html="true"]
+          a[data-placement="right" data-toggle="popover" data-container=".panel-heading" data-content="<b>Name</b>: Name of the webhook.<br><b>Request method</b>: URL endpoint where the HTTP request is sent to.<br/><b>Content type</b>: Description of the webhook request content.<br/><b>Username</b>: Username used for basic HTTP auth.<br/><b>Password</b>: Password used for basic HTTP auth." data-original-title="What's this?" tabindex="0" data-html="true"]
             i.fa.fa-info-circle
         - if can_manage_namespace?(@namespace)
           .pull-right

--- a/db/migrate/20180109114124_add_name_to_webhooks.rb
+++ b/db/migrate/20180109114124_add_name_to_webhooks.rb
@@ -1,0 +1,5 @@
+class AddNameToWebhooks < ActiveRecord::Migration
+  def change
+		add_column :webhooks, :name, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171220095321) do
+ActiveRecord::Schema.define(version: 20180109114124) do
 
   create_table "activities", force: :cascade do |t|
     t.integer  "trackable_id",   limit: 4
@@ -213,6 +213,7 @@ ActiveRecord::Schema.define(version: 20171220095321) do
     t.boolean  "enabled",                    default: false
     t.datetime "created_at",                                 null: false
     t.datetime "updated_at",                                 null: false
+    t.string   "name",           limit: 255
   end
 
   add_index "webhooks", ["namespace_id"], name: "index_webhooks_on_namespace_id", using: :btree

--- a/spec/controllers/webhooks_controller_spec.rb
+++ b/spec/controllers/webhooks_controller_spec.rb
@@ -14,6 +14,7 @@
 #  enabled        :boolean          default(FALSE)
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
+#  name           :string(255)
 #
 # Indexes
 #

--- a/spec/factories/webhooks.rb
+++ b/spec/factories/webhooks.rb
@@ -14,6 +14,7 @@
 #  enabled        :boolean          default(FALSE)
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
+#  name           :string(255)
 #
 # Indexes
 #
@@ -22,6 +23,7 @@
 
 FactoryGirl.define do
   factory :webhook do
+    name "webhook"
     url "http://www.example.com"
     request_method "POST"
     content_type "application/json"

--- a/spec/features/webhooks_spec.rb
+++ b/spec/features/webhooks_spec.rb
@@ -42,14 +42,15 @@ describe "Webhooks support" do
       find("#add_webhook_btn").click
       wait_for_effect_on("#add_webhook_form")
 
-      fill_in "Url", with: "url-here"
+      fill_in "Name", with: "name"
+      fill_in "Url", with: "http://url-here"
       click_button "Create"
 
       wait_for_ajax
       wait_for_effect_on("#float-alert")
 
       expect(page).to have_css("#float-alert")
-      expect(page).to have_content("Webhook 'url-here' has been created successfully")
+      expect(page).to have_content("Webhook 'name' has been created successfully")
 
       # Check that it created a link to it and that it's accessible.
       expect(namespace.webhooks.count).to eql webhooks_count + 1
@@ -115,12 +116,14 @@ describe "Webhooks support" do
       visit namespace_webhook_path(namespace, webhook)
 
       find(".edit-webhook-link").click
+      fill_in "Name", with: "new_name"
       fill_in "webhook_url", with: "http://new-webhook-url"
       fill_in "Username", with: "new-username"
       fill_in "Password", with: "password"
       click_button "Save"
       wait_for_ajax
 
+      expect(page).to have_content("new_name")
       expect(page).to have_content("new-webhook-url webhook")
       expect(page).to have_content("new-username")
       expect(page).to have_content("***********")

--- a/spec/models/webhook_spec.rb
+++ b/spec/models/webhook_spec.rb
@@ -14,6 +14,7 @@
 #  enabled        :boolean          default(FALSE)
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
+#  name           :string(255)
 #
 # Indexes
 #


### PR DESCRIPTION
Add a name column for webhook and change dashboard messages for webhook activities (e.g updating a webhook or creating a webhook).

Fix #1578 
Fix #1340 