### PR TITLE
Updated vulnerable development gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -269,8 +269,8 @@ GEM
     rack-accept (0.4.5)
       rack (>= 0.4)
     rack-cors (1.0.1)
-    rack-mini-profiler (0.9.3)
-      rack (>= 1.1.3)
+    rack-mini-profiler (0.10.7)
+      rack (>= 1.2.0)
     rack-openid (1.3.1)
       rack (>= 1.1.0)
       ruby-openid (>= 2.1.8)
@@ -427,7 +427,7 @@ GEM
     wirble (0.1.3)
     xpath (2.1.0)
       nokogiri (~> 1.3)
-    yajl-ruby (1.3.0)
+    yajl-ruby (1.3.1)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
Some development gems needed an upgrade because they were vulnerable and
Github was complaining about it (even if it's totally fine since it's
stuff that we don't care in production...)

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>