### PR TITLE
Don't call bundle directly

### DIFF
--- a/lib/portus/db.rb
+++ b/lib/portus/db.rb
@@ -56,7 +56,23 @@ module Portus
 
       # If db:migrate:status does not return a migration as "down", then all
       # migrations are up and ready.
-      !`bundle exec rake db:migrate:status`.include?("down")
+      !`#{bundle} exec rake db:migrate:status`.include?("down")
+    end
+
+    # Returns the proper bundle command. This is important because is some cases
+    # (e.g. RPM or containerized production deployment), the `bundle` command
+    # might not be in an executable path.
+    def self.bundle
+      exec = nil
+      ENV["PATH"].split(File::PATH_SEPARATOR).each do |path|
+        x = File.join(path, "bundle")
+        if File.executable?(x) && !File.directory?(x)
+          exec = x
+          break
+        end
+      end
+
+      exec ? "bundle" : "portusctl"
     end
 
     # Returns true if the given configured adapter is MariaDB.

--- a/spec/lib/portus/db_spec.rb
+++ b/spec/lib/portus/db_spec.rb
@@ -78,4 +78,10 @@ describe Portus::DB do
       expect(described_class).not_to be_mysql
     end
   end
+
+  describe "bundle" do
+    it "returns 'bundle' if the executable exists" do
+      expect(described_class.bundle).to eq "bundle"
+    end
+  end
 end


### PR DESCRIPTION
In order to check whether there were migrations pending, the db.rb
library called bundle directly, which is not a good idea in some
environments (e.g. production containerized scenario), where the bundle
command is hidden and portusctl should be used instead.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>