### PR TITLE
Add param for read response timeout setting

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -201,6 +201,11 @@ registry:
   # connection to your private Docker registry.
   timeout:
     value: 2
+  
+
+  #Set timeout in seconds for read response from registry.
+  read_timeout:
+    value: 120
 
 # The FQDN of the machine where Portus is being deployed.
 machine_fqdn:

--- a/config/config.yml
+++ b/config/config.yml
@@ -201,7 +201,6 @@ registry:
   # connection to your private Docker registry.
   timeout:
     value: 2
-  
 
   #Set timeout in seconds for read response from registry.
   read_timeout:

--- a/lib/portus/http_helpers.rb
+++ b/lib/portus/http_helpers.rb
@@ -152,7 +152,8 @@ module Portus
     def get_response_token(uri, req)
       options = {
         use_ssl:      uri.scheme == "https",
-        open_timeout: APP_CONFIG["registry"]["timeout"]["value"].to_i
+        open_timeout: APP_CONFIG["registry"]["timeout"]["value"].to_i,
+        read_timeout: APP_CONFIG["registry"]["read_timeout"]["value"].to_i
       }
 
       Net::HTTP.start(uri.hostname, uri.port, options) do |http|


### PR DESCRIPTION
Hi,
in my environment response for 
`# time curl -i -ks -H "Authorization: Bearer $token" https://example.ref.com/v2/_catalog?n=10000`
takes more than 60s:

```
real    1m18.917s
user    0m0.008s
sys     0m0.000s
```
That is fine for me, but not for Portus's background worker :)
I think it is quite nice idea to have that parameter in config.

Thanks

