### PR TITLE
Ruby 2.5 was released last Xmas and is the latest stable ruby version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 dist: trusty
 rvm:
   # Stable supported version
-  - 2.4.2
+  - 2.5.0
 
   # Future versions
   - ruby-head


### PR DESCRIPTION
let's enable it in travis to pass the tests