### PR TITLE
development: update the alternatives for bundler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN zypper ref && \
            libxml2-devel nodejs libmysqlclient-devel postgresql-devel libxslt1 && \
     zypper -n in --no-recommends -t pattern devel_basis && \
     gem install bundler --no-ri --no-rdoc -v 1.15.4 && \
+    update-alternatives --install /usr/bin/bundle bundle /usr/bin/bundle.ruby2.5 3 && \
+    update-alternatives --install /usr/bin/bundler bundler /usr/bin/bundler.ruby2.5 3 && \
     bundle install --retry=3 && \
     zypper -n rm wicked wicked-service autoconf automake \
            binutils bison cpp cvs flex gdbm-devel gettext-tools \


### PR DESCRIPTION
We were getting the bundler.ruby2.5 binary, but everyone expects
`bundler` instead.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>