### PR TITLE
packaging: manually set the bundler version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,6 @@ cache:
     - $PWD/travis_phantomjs
 
 before_install:
-  # Remove the default bundler and install the expected one.
-  - rvm @global do gem uninstall bundler --all --executables
-  - gem uninstall bundler --all --executables
-  - gem install bundler --version '1.16.0'
-  - rvm reload
-  - bundle --version
-
   - phantomjs --version
   - export PATH=$PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH
   - if [ $(phantomjs --version) != '2.1.1' ]; then rm -rf $PWD/travis_phantomjs; mkdir -p $PWD/travis_phantomjs; fi

--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -41,11 +41,6 @@ fi
 
 packagename=$1
 
-bundler_version=$(bundle version 2>/dev/null | awk '{ print $3 }')
-if [ "$bundler_version" != "$BUNDLER_VERSION" ];then
-  error "Bundler $BUNDLER_VERSION required!"
-fi
-
 cd $(dirname $0)
 
 if [ $TRAVIS_BRANCH ];then
@@ -117,7 +112,12 @@ pushd build/$packagename-$branch/
   # with tr. This way, fetching the name and version is as easy as awk'ing again.
   for gem in $(bundle show | tail -n +2 | awk '{ print $2 " " $3 }' | tr -d '()');do
     gem_name=$(echo $gem | awk '{ print $1 }')
-    gem_version=$(echo $gem | awk '{ print $2 }')
+    if [[ "$gem_name" == "bundler" ]]; then
+        gem_version="$BUNDLER_VERSION"
+    else
+        gem_version=$(echo $gem | awk '{ print $2 }')
+    fi
+
     build_requires="$build_requires\nBuildRequires: %{rubygem $gem_name} = $gem_version"
     build_requires="$build_requires$(additional_native_build_requirements $gem_name)"
   done


### PR DESCRIPTION
The bundler version is determined by the one being used. This is the
ideal situation, but it turns out it's basically impossible to guarantee
that on Travis CI (we were using an ugly hack that does not work anymore
because they've updated stuff...).

So, the idea is that the bundler version being used doesn't matter that
much, and we are already using it on development, so we'll set it
directly when creating the spec file.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>