### PR TITLE
packaging: polishing how asset gems are handled

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ source "https://rubygems.org"
 
 gem "active_record_union"
 gem "base32"
-gem "bootstrap-sass", "~> 3.3.4"
 gem "devise"
 gem "font-awesome-rails", "~> 4.7.0.1"
 gem "grape"
@@ -26,7 +25,6 @@ gem "rails", "~> 4.2.10"
 gem "rails_stdout_logging", "~> 0.0.5", group: %i[development staging production]
 gem "redcarpet", "~> 3.4.0"
 gem "sass", "~> 3.4.23"
-gem "sass-rails", "~> 5.0.6"
 gem "search_cop"
 gem "slim", "~> 3.0.8"
 gem "webpack-rails"
@@ -68,7 +66,9 @@ gem "temple", "= 0.7.7"
 # The following groups will *not* be included on the production installation.
 
 group :assets do
-  gem "uglifier"
+  gem "bootstrap-sass", "~> 3.3.4"
+  gem "sass-rails", "~> 5.0.6"
+  gem "uglifier", "~> 4.1.3"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -392,9 +392,8 @@ GEM
       ethon (>= 0.9.0)
     tzinfo (1.2.4)
       thread_safe (~> 0.1)
-    uglifier (2.7.2)
-      execjs (>= 0.3.0)
-      json (>= 1.8.0)
+    uglifier (4.1.3)
+      execjs (>= 0.3.0, < 3)
     unicode-display_width (1.3.0)
     uri_template (0.5.3)
     vcr (3.0.3)
@@ -506,7 +505,7 @@ DEPENDENCIES
   thor (~> 0.19.4)
   timecop
   typhoeus (~> 1.0.2)
-  uglifier
+  uglifier (~> 4.1.3)
   vcr
   web-console (~> 2.1.3)
   webmock (~> 2.3.2)

--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -96,7 +96,7 @@ pushd build/$packagename-$branch/
   export BUNDLE_GEMFILE=$PWD/Gemfile
   cp Gemfile.lock Gemfile.lock.orig
   bundle config build.nokogiri --use-system-libraries
-  bundle install --retry=3 --deployment --without assets test development
+  bundle install --retry=3 --deployment --without test development
 
   debug "Diff of old and new Gemfile.lock file"
   diff Gemfile.lock Gemfile.lock.orig

--- a/packaging/suse/portus.spec.in
+++ b/packaging/suse/portus.spec.in
@@ -87,17 +87,23 @@ tar xzvf node_modules.tar.gz
 install -d vendor/cache
 cp %{_libdir}/ruby/gems/%{rb_ver}/cache/*.gem vendor/cache
 
-# Deploy gems
+# Deploy gems for compiling the assets.
 bundle config build.nokogiri --use-system-libraries
-bundle install --retry=3 --local --deployment --without assets test development
-
-# Install bundler
+bundle install --retry=3 --local --deployment --without test development
 gem.ruby2.5 install --no-rdoc --no-ri --install-dir vendor/bundle/ruby/%{rb_ver}/ vendor/cache/bundler-*.gem
 
 # Compile assets
 PORTUS_SECRET_KEY_BASE="ap" PORTUS_KEY_PATH="ap" PORTUS_PASSWORD="ap" \
   RAILS_ENV=production NODE_ENV=production \
   bundle exec rake portus:assets:compile
+
+# Install the final gems (i.e. exclude the `assets` group from the final
+# bundle). Unfortunately, bundler does not have a way to remove gems from a
+# given group. So, we have to remove all of them, and then install the ones we
+# want...
+rm -r vendor/bundle/ruby/%{rb_ver}/*
+gem.ruby2.5 install --no-rdoc --no-ri --install-dir vendor/bundle/ruby/%{rb_ver}/ vendor/cache/bundler-*.gem
+bundle install --retry=3 --local --deployment --without test development
 
 # Patch landing_page
 APPLICATION_CSS=$(find . -name application-*.css 2>/dev/null)


### PR DESCRIPTION
Two gems (bootstrap-sass & sass-rails) are only needed for compiling the
assets, so we will include them now in the `assets` group.

Moreover, we need to have the gems from the `assets` group as a
BuildRequires, otherwise the assets compilation might fail. That being
said, this commit also excludes these gems from the final bundle (i.e.
it discards these gems once assets have been compiled).

Finally, I've upgraded the `uglifier` gem to match the one from openSUSE
Factory.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>