### PR TITLE
OpenID Connect & Active Session Storage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY Gemfile* ./
 #      installed with the devel_basis pattern, and finally we zypper clean -a.
 RUN zypper ref && \
     zypper -n in --no-recommends ruby2.5-devel \
-           libxml2-devel nodejs libmysqlclient-devel postgresql-devel libxslt1 && \
+           libxml2-devel nodejs libmysqlclient-devel postgresql-devel libxslt1 git && \
     zypper -n in --no-recommends -t pattern devel_basis && \
     gem install bundler --no-ri --no-rdoc -v 1.16.0 && \
     update-alternatives --install /usr/bin/bundle bundle /usr/bin/bundle.ruby2.5 3 && \

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,8 @@ gem "omniauth-github"
 gem "omniauth-gitlab"
 gem "omniauth-google-oauth2"
 gem "omniauth-openid"
+gem 'omniauth-openid-connect', :git => 'https://github.com/hhorikawa/omniauth-openid-connect'
+gem 'activerecord-session_store'
 gem "public_activity"
 gem "pundit"
 gem "rails", "~> 4.2.10"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: https://github.com/hhorikawa/omniauth-openid-connect
+  revision: 017be85ae66dbbd42c2ab59ada7531c6b980b533
+  specs:
+    omniauth-openid-connect (0.8.0.pre)
+      activesupport (>= 4.2)
+      jwt (~> 1.5)
+      omniauth (~> 1.6)
+      openid_connect (~> 1.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -32,6 +42,12 @@ GEM
       activemodel (= 4.2.10)
       activesupport (= 4.2.10)
       arel (~> 6.0)
+    activerecord-session_store (1.1.0)
+      actionpack (>= 4.0, < 5.2)
+      activerecord (>= 4.0, < 5.2)
+      multi_json (~> 1.11, >= 1.11.2)
+      rack (>= 1.5.2, < 3)
+      railties (>= 4.0, < 5.2)
     activesupport (4.2.10)
       i18n (~> 0.7)
       minitest (~> 5.1)
@@ -43,6 +59,7 @@ GEM
       rake (>= 10.4, < 13.0)
     arel (6.0.4)
     ast (2.3.0)
+    attr_required (1.0.1)
     autoprefixer-rails (7.2.3)
       execjs
     awesome_print (1.6.1)
@@ -52,6 +69,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.1)
     base32 (0.3.2)
     bcrypt (3.1.11)
+    bindata (2.4.1)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     binman (5.1.0)
@@ -163,9 +181,15 @@ GEM
     hashie-forbidden_attributes (0.1.1)
       hashie (>= 3.0)
     hirb (0.7.3)
+    httpclient (2.8.3)
     i18n (0.8.0)
     ice_nine (0.11.2)
     json (2.1.0)
+    json-jwt (1.8.3)
+      activesupport
+      bindata
+      securecompare
+      url_safe_base64
     json-schema (2.5.1)
       addressable (~> 2.3.7)
     jwt (1.5.6)
@@ -236,6 +260,17 @@ GEM
       omniauth (~> 1.0)
       rack-openid (~> 1.3.1)
     opener (0.1.0)
+    openid_connect (1.1.3)
+      activemodel
+      attr_required (>= 1.0.0)
+      json (>= 1.4.3)
+      json-jwt (>= 1.5.0)
+      rack-oauth2 (>= 1.6.1)
+      swd (>= 1.0.0)
+      tzinfo
+      validate_email
+      validate_url
+      webfinger (>= 1.0.1)
     orm_adapter (0.5.0)
     paint (1.0.0)
     parallel (1.12.1)
@@ -269,6 +304,12 @@ GEM
     rack-cors (1.0.1)
     rack-mini-profiler (0.10.7)
       rack (>= 1.2.0)
+    rack-oauth2 (1.7.0)
+      activesupport (>= 2.3)
+      attr_required (>= 0.0.5)
+      httpclient (>= 2.4)
+      multi_json (>= 1.3.6)
+      rack (>= 1.1)
     rack-openid (1.3.1)
       rack (>= 1.1.0)
       ruby-openid (>= 2.1.8)
@@ -359,6 +400,7 @@ GEM
       uri_template (~> 0.5.0)
     search_cop (1.0.6)
       treetop
+    securecompare (1.0.0)
     shellany (0.0.1)
     shoulda (3.5.0)
       shoulda-context (~> 1.0, >= 1.0.1)
@@ -381,6 +423,10 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    swd (1.1.2)
+      activesupport (>= 3)
+      attr_required (>= 0.0.5)
+      httpclient (>= 2.4)
     temple (0.7.7)
     thor (0.19.4)
     thread_safe (0.3.6)
@@ -396,6 +442,13 @@ GEM
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.3.0)
     uri_template (0.5.3)
+    url_safe_base64 (0.2.2)
+    validate_email (0.1.6)
+      activemodel (>= 3.0)
+      mail (>= 2.2.5)
+    validate_url (1.0.2)
+      activemodel (>= 3.0.0)
+      addressable
     vcr (3.0.3)
     virtus (1.0.5)
       axiom-types (~> 0.1)
@@ -409,6 +462,9 @@ GEM
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)
       sprockets-rails (>= 2.0, < 4.0)
+    webfinger (1.1.0)
+      activesupport
+      httpclient (>= 2.4)
     webmock (2.3.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -431,6 +487,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_record_union
+  activerecord-session_store
   annotate
   awesome_print
   base32
@@ -476,6 +533,7 @@ DEPENDENCIES
   omniauth-gitlab
   omniauth-google-oauth2
   omniauth-openid
+  omniauth-openid-connect!
   pg (~> 0.20.0)
   poltergeist (~> 1.15.0)
   pry-rails

--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -23,12 +23,14 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   alias gitlab google_oauth2
   # Callback for Bitbucket.
   alias bitbucket google_oauth2
+  # Callback for Open ID.
+  alias openid_connect google_oauth2
 
   private
 
   # If user does not exist then ask for username and display_name.
   def check_user
-    data = request.env["omniauth.auth"]
+    data = request.env["omniauth.auth"].to_hash
     unless data
       redirect_to new_user_session_url
       return
@@ -38,7 +40,7 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       redirect_to new_user_session_url, alert: alert
       return
     end
-    @user = User.find_by(email: data.info["email"])
+    @user = User.find_by(email: data["info"]["email"])
     return if @user
     session["omniauth.auth"] = data.except(:extra)
     redirect_to users_oauth_url

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -49,6 +49,7 @@ class User < ActiveRecord::Base
                               github
                               gitlab
                               bitbucket
+                              openid_connect
                             ],
                             authentication_keys: [:username]]
 

--- a/app/views/devise/sessions/_social_login.html.slim
+++ b/app/views/devise/sessions/_social_login.html.slim
@@ -14,6 +14,12 @@
         i.fa.fa-openid
         '&nbsp;Open Id
 
+  - if APP_CONFIG.enabled? "oauth.openid_connect"
+    .col-xs-12.col-sm-6
+      = link_to user_openid_connect_omniauth_authorize_path, class: 'btn btn-primary btn-block btn-lg' do
+        i.fa.fa-openid
+        '&nbsp;OIDC
+
   - if APP_CONFIG.enabled? "oauth.github"
     .col-xs-12.col-sm-6
       = link_to user_github_omniauth_authorize_path, class: 'btn btn-primary btn-block btn-lg' do

--- a/config/config.yml
+++ b/config/config.yml
@@ -158,6 +158,48 @@ oauth:
       # Only members of team can sign in/up with Bitbucket. Need permission to read team membership.
       team: ""
 
+  # OpenID Connect authentication support. Need permission to read email.
+  # Callback url: <host>/users/auth/openid_connect/callback
+  openid_connect:
+    enabled: true
+    # Base url that the endpoints are located.
+    issuer: 'https://auth.muike.com/auth/realms/master'
+    scope: 'openid'
+    # Use code for Basic flow or 'token id_token' for implicit flow  or (default 'code')
+    response_type: 'code'
+    # Will utilize the .well-known configuration to find the endpoints
+    # <issuer>/.well-known/openid-configuration
+    discovery: true
+    # Client options below are used to create the URLs to connect to the OpenID Connect services.
+    # Typically these are the same as the issuer
+    client_options:
+      scheme: 'https'
+      host: 'auth.muike.com'
+      port: 443
+      identifier: 'portus'
+      secret: ''
+      redirect_uri: 'http://localhost:3000/users/auth/openid_connect/callback'
+      # If you discorvery is disabled you must specify the following options
+      # authorization_endpoint:
+      # token_endpoint:
+      # userinfo_endpoint:
+      # client_x509_signing_key:
+      # {
+      #      # /auth/<name> が認証開始のURLになる.
+
+      #    issuer:
+    #      scope: [:openid, :email, :profile, :address],
+    #      response_type: :code,
+  #        discovery: true,
+####          client_options: {
+  #          scheme: "https",
+#            host: "auth.muike.com",#
+#            port: 443,
+#            identifier: "portus",
+#            secret: "",
+#            redirect_uri: "http://localhost:3000/users/auth/openid_connect/callback",
+#          },
+#        }
 # Set first_user_admin to true if you want that the first user that signs up
 # to be an admin.
 #

--- a/config/initializers/devise/oauth.rb
+++ b/config/initializers/devise/oauth.rb
@@ -29,6 +29,17 @@ def open_id_fetch_options
   options
 end
 
+def openid_connect_fetch_options
+  {
+      name: :openid_connect,
+      issuer: APP_CONFIG["oauth"]["openid_connect"]['issuer'],
+      scope: APP_CONFIG["oauth"]["openid_connect"]['scope'],
+      response_type: APP_CONFIG["oauth"]["openid_connect"]['code'],
+      discovery: APP_CONFIG["oauth"]["openid_connect"]["discovery"],
+      client_options:  APP_CONFIG["oauth"]["openid_connect"]["client_options"]
+    }
+end
+
 def github_fetch_options
   { scope: "user,read:org" }
 end
@@ -55,7 +66,6 @@ def configure_backend!(config, backend, id = nil, secret = nil)
   return unless APP_CONFIG.enabled?("oauth.#{backend}")
 
   options = send("#{backend}_fetch_options")
-
   if id
     config.omniauth backend, id, secret, options
   else
@@ -68,6 +78,7 @@ def configure_oauth!(config)
   [
     { backend: :google_oauth2, id: "id", secret: "secret" },
     { backend: :open_id },
+    { backend: :openid_connect},
     { backend: :github, id: "client_id", secret: "client_secret" },
     { backend: :gitlab, id: "application_id", secret: "secret" },
     { backend: :bitbucket, id: "key", secret: "secret" }

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -2,4 +2,4 @@
 
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: "_portus_session"
+Rails.application.config.session_store :active_record_store, key: "_portus_session"

--- a/db/migrate/20180124232457_add_sessions_table.rb
+++ b/db/migrate/20180124232457_add_sessions_table.rb
@@ -1,0 +1,12 @@
+class AddSessionsTable < ActiveRecord::Migration
+  def change
+    create_table :sessions do |t|
+      t.string :session_id, :null => false
+      t.text :data
+      t.timestamps
+    end
+
+    add_index :sessions, :session_id, :unique => true
+    add_index :sessions, :updated_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180109114124) do
+ActiveRecord::Schema.define(version: 20180124232457) do
 
   create_table "activities", force: :cascade do |t|
     t.integer  "trackable_id",   limit: 4
@@ -97,6 +97,16 @@ ActiveRecord::Schema.define(version: 20180109114124) do
 
   add_index "repositories", ["name", "namespace_id"], name: "index_repositories_on_name_and_namespace_id", unique: true, using: :btree
   add_index "repositories", ["namespace_id"], name: "index_repositories_on_namespace_id", using: :btree
+
+  create_table "sessions", force: :cascade do |t|
+    t.string   "session_id", limit: 255,   null: false
+    t.text     "data",       limit: 65535
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "sessions", ["session_id"], name: "index_sessions_on_session_id", unique: true, using: :btree
+  add_index "sessions", ["updated_at"], name: "index_sessions_on_updated_at", using: :btree
 
   create_table "stars", force: :cascade do |t|
     t.integer  "user_id",       limit: 4

--- a/spec/controllers/auth/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/auth/omniauth_callbacks_controller_spec.rb
@@ -78,6 +78,24 @@ describe Auth::OmniauthCallbacksController do
     end
   end
 
+  describe "GET #openid_connect" do
+    before do
+      APP_CONFIG["oauth"] = { "openid_connect" => { } }
+      OmniAuth.config.add_mock(:openid_connect,
+                               provider: "openid_connect",
+                               uid:      "12345",
+                               info:     { email: "test@mail.net" })
+      request.env["omniauth.auth"] = OmniAuth.config.mock_auth[:open_id]
+    end
+
+    it "sign in and redirect to /" do
+      create :user, email: "test@mail.net"
+      get :openid_connect
+      expect(response).to redirect_to authenticated_root_url
+      expect(subject.current_user).not_to eq(nil)
+    end
+  end
+
   describe "GET #github" do
     before do
       APP_CONFIG["oauth"] = { "github" => {


### PR DESCRIPTION
Integrated with `https://github.com/hhorikawa/omniauth-openid-connect` to provide a simple OpenID Connect authorization. There was a few other bugs that I ran into.

when storing the Omniauth respose into the session there was mixed code. One was treating the object as a hash and another was treating it as a omniauth object. There was only one reference to the omniauth object so I just converted the object to an hash and then changed the one reference to the omniauth object to be a hash reference.

With the pull of the omniauth-openid-connect being from github the docker file used to create the development image needs git to also be installed.

Added social link for OpenID Connect. The verbiage for hte link was too long so I made it say ODIC on the social icon. I do think we need to revist how this is generated. With the addition of OpenID Connect and OpenID there maybe a need to specify several social icons with the same type. Both the social icons and the config will need to change to accomodate this. I opted to not include this change because it could break current installations when upgrading.

Session storage - I ran into a limitation where the information stored inside of the session was exceeding 4kb. This is because currently portus uses cookie based session storage which has a limitation of 4kb. unfortunatly openid requries 4.1kb for the tokens and certs. I switched to the other common session storage to be `active_record_store` which is a database driven session storage. This really should of been done sense the first implementation of omniauth as there is some critical information in that data that could be abused if stored in a cookie. I am also surprised that the 4kb limit hasnt been broken for other things in Portus.

Added simple spec for openid_connect. Since i am not sure how to run the tests locally I think it will fail when travis-ci runs it. 

Issues #1619