### PR TITLE
docs: added documentation for the API

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,49 @@
+AllCops:
+  TargetRubyVersion: 2.5
+
+  DisplayCopNames: true
+  DisplayStyleGuide: false
+
+#
+# Layout
+#
+
+# This is a remnant of old SUSE-style alignment for hashes, The table format
+# looks more human readable.
+Layout/AlignHash:
+  EnforcedHashRocketStyle: table
+  EnforcedColonStyle: table
+
+#
+# Metrics
+#
+
+# The default is just too small.
+Metrics/AbcSize:
+  Max: 30
+
+# The default is just too small. A limit of 100 looks reasonable and many other
+# projects (including inside of SUSE) are also using this value.
+Metrics/LineLength:
+  Max: 100
+
+Metrics/MethodLength:
+  Max: 20
+
+#
+# Style
+#
+
+# This forces us to create a new object for no real reason.
+Style/MultipleComparison:
+  Enabled: false
+
+# This is a common SUSE configuration value: the performance difference between
+# single and double quotes is no longer there, and so it's better to be
+# consistent and force only double quotes.
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+# Same as Style/StringLiterals.
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: double_quotes

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,13 @@
-source 'https://rubygems.org'
+# frozen_string_literal: true
 
-gem 'github-pages'
-gem 'sass'
-gem 'therubyracer'
+source "https://rubygems.org"
+
+gem "github-pages"
+gem "sass"
+gem "therubyracer"
 
 group :test do
-  gem 'html-proofer'
-  gem 'rake'
-  gem 'rubocop'
+  gem "html-proofer"
+  gem "rake"
+  gem "rubocop"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,21 +1,23 @@
-abort('Please run this using `bundle exec rake`') unless ENV['BUNDLE_BIN_PATH']
-require 'html-proofer'
+# frozen_string_literal: true
 
-desc 'Test the website'
+abort("Please run this using `bundle exec rake`") unless ENV["BUNDLE_BIN_PATH"]
+require "html-proofer"
+
+desc "Test the website"
 task :test do
   options = {
-    check_sri: true,
-    check_html: true,
-    check_img_http: true,
+    check_sri:       true,
+    check_html:      true,
+    check_img_http:  true,
     check_opengraph: true,
-    typhoeus: {
+    typhoeus:        {
       timeout: 120
     },
-    cache: {
-      timeframe: '6w'
+    cache:           {
+      timeframe: "6w"
     }
   }
-  HTMLProofer.check_directory('./_site', options).run
+  HTMLProofer.check_directory("./_site", options).run
 end
 
 task default: [:test]

--- a/_data/api.yml
+++ b/_data/api.yml
@@ -1,0 +1,1154 @@
+---
+info:
+  title: Portus API
+  description: Portus CRUD API
+  contact:
+    name: Portus authors
+    email: portus-dev@googlegroups.com
+  version: 0.0.1
+swagger: '2.0'
+produces:
+- application/json
+securityDefinitions:
+  api_key:
+    type: apiKey
+    name: Portus-Auth
+    in: header
+security:
+- api_key: []
+host: 172.17.0.1:3000
+tags:
+- name: health
+  description: Operations about healths
+- name: namespaces
+  description: Operations about namespaces
+- name: registries
+  description: Operations about registries
+- name: repositories
+  description: Operations about repositories
+- name: tags
+  description: Operations about tags
+- name: teams
+  description: Operations about teams
+- name: users
+  description: Operations about users
+- name: version
+  description: Operations about versions
+paths:
+  "/api/v1/health":
+    get:
+      summary: Returns hash of metrics
+      description: Returns general metrics on the health of the system
+      produces:
+      - application/json
+      responses:
+        '200':
+          description: Returns hash of metrics
+          schema:
+            "$ref": "#/definitions/Health"
+        '503':
+          description: Some of the required services are unhealthy
+          schema:
+            "$ref": "#/definitions/Health"
+      tags:
+      - health
+      operationId: getApiV1Health
+  "/api/v1/namespaces":
+    get:
+      summary: Returns a list of namespaces
+      description: This will expose all accessible namespaces
+      produces:
+      - application/json
+      responses:
+        '200':
+          description: Returns a list of namespaces
+          schema:
+            type: array
+            items:
+              "$ref": "#/definitions/Namespaces"
+        '401':
+          description: Authentication fails
+        '403':
+          description: Authorization fails
+      tags:
+      - namespaces
+      operationId: getApiV1Namespaces
+    post:
+      summary: Create a namespace
+      description: Create a namespace
+      produces:
+      - application/json
+      consumes:
+      - application/json
+      parameters:
+      - in: formData
+        name: name
+        description: Namespace name
+        type: string
+        required: true
+      - in: formData
+        name: team
+        description: Team name
+        type: string
+        required: true
+      - in: formData
+        name: description
+        description: Team description
+        type: string
+        required: false
+      responses:
+        '201':
+          description: Create a namespace
+          schema:
+            "$ref": "#/definitions/Teams"
+        '401':
+          description: Authentication fails
+        '403':
+          description: Authorization fails
+      tags:
+      - namespaces
+      operationId: postApiV1Namespaces
+  "/api/v1/namespaces/validate":
+    get:
+      summary: Validates the given namespace
+      description: Validates the given namespace
+      produces:
+      - application/json
+      parameters:
+      - in: query
+        name: name
+        description: Name to be checked
+        type: string
+        required: true
+      responses:
+        '200':
+          description: Validates the given namespace
+          schema:
+            "$ref": "#/definitions/Status"
+        '401':
+          description: Authentication fails
+        '403':
+          description: Authorization fails
+      tags:
+      - namespaces
+      operationId: getApiV1NamespacesValidate
+  "/api/v1/namespaces/{id}/repositories":
+    get:
+      summary: Returns the list of the repositories for the given namespace
+      description: Returns the list of the repositories for the given namespace
+      produces:
+      - application/json
+      parameters:
+      - in: path
+        name: id
+        description: Namespace ID
+        type: integer
+        format: int32
+        required: true
+      responses:
+        '200':
+          description: Returns the list of the repositories for the given namespace
+          schema:
+            type: array
+            items:
+              "$ref": "#/definitions/Repositories"
+        '401':
+          description: Authentication fails
+        '403':
+          description: Authorization fails
+        '404':
+          description: Not found
+      tags:
+      - namespaces
+      operationId: getApiV1NamespacesIdRepositories
+  "/api/v1/namespaces/{id}":
+    get:
+      summary: Show namespaces by id
+      description: Show namespaces by id
+      produces:
+      - application/json
+      parameters:
+      - in: path
+        name: id
+        description: Namespace ID
+        type: integer
+        format: int32
+        required: true
+      responses:
+        '200':
+          description: Show namespaces by id
+          schema:
+            "$ref": "#/definitions/Namespaces"
+        '401':
+          description: Authentication fails
+        '403':
+          description: Authorization fails
+        '404':
+          description: Not found
+      tags:
+      - namespaces
+      operationId: getApiV1NamespacesId
+  "/api/v1/registries":
+    get:
+      summary: Returns a list of registries
+      description: This will expose all accessible registries
+      produces:
+      - application/json
+      responses:
+        '200':
+          description: Returns a list of registries
+          schema:
+            type: array
+            items:
+              "$ref": "#/definitions/Registries"
+        '401':
+          description: Authentication fails
+        '403':
+          description: Authorization fails
+      tags:
+      - registries
+      operationId: getApiV1Registries
+  "/api/v1/registries/validate":
+    get:
+      summary: Validates the given registry
+      description: Besides containing the usual Status object, it adds the reachable
+        validation to the `hostname` field in the `messages` hash. This validation
+        returns a string containing the error as given by the registry. If empty then
+        everything went well
+      produces:
+      - application/json
+      parameters:
+      - in: query
+        name: name
+        description: The name of the registry
+        type: string
+        required: false
+      - in: query
+        name: hostname
+        description: The hostname of the registry
+        type: string
+        required: false
+      - in: query
+        name: external_hostname
+        description: An external hostname of the registry, useful if behind a proxy
+          with a different FQDN
+        type: string
+        required: false
+      - in: query
+        name: use_ssl
+        description: Whether the registry uses SSL or not
+        type: boolean
+        required: false
+      - in: formData
+        name: only
+        description: Restrict which parameters are to be validated
+        type: array
+        items:
+          type: string
+        required: false
+      responses:
+        '200':
+          description: Validates the given registry
+          schema:
+            "$ref": "#/definitions/Status"
+        '401':
+          description: Authentication fails
+        '403':
+          description: Authorization fails
+      tags:
+      - registries
+      operationId: getApiV1RegistriesValidate
+  "/api/v1/repositories":
+    get:
+      summary: Returns list of repositories
+      description: This will expose all repositories
+      produces:
+      - application/json
+      responses:
+        '200':
+          description: Returns list of repositories
+          schema:
+            type: array
+            items:
+              "$ref": "#/definitions/Repositories"
+        '401':
+          description: Authentication fails
+        '403':
+          description: Authorization fails
+      tags:
+      - repositories
+      operationId: getApiV1Repositories
+  "/api/v1/repositories/{id}/tags":
+    get:
+      summary: Returns the list of the tags for the given repository
+      description: Returns the list of the tags for the given repository
+      produces:
+      - application/json
+      parameters:
+      - in: path
+        name: id
+        description: Repository ID
+        type: integer
+        format: int32
+        required: true
+      responses:
+        '200':
+          description: Returns the list of the tags for the given repository
+          schema:
+            type: array
+            items:
+              "$ref": "#/definitions/Tags"
+        '401':
+          description: Authentication fails
+        '403':
+          description: Authorization fails
+        '404':
+          description: Not found
+      tags:
+      - repositories
+      operationId: getApiV1RepositoriesIdTags
+  "/api/v1/repositories/{id}/tags/grouped":
+    get:
+      summary: Returns the list of the tags for the given repository groupped by digest
+      description: Returns the list of the tags for the given repository groupped
+        by digest
+      produces:
+      - application/json
+      parameters:
+      - in: path
+        name: id
+        description: Repository ID
+        type: integer
+        format: int32
+        required: true
+      responses:
+        '200':
+          description: Returns the list of the tags for the given repository groupped
+            by digest
+          schema:
+            type: array
+            items:
+              "$ref": "#/definitions/Tags"
+        '401':
+          description: Authentication fails
+        '403':
+          description: Authorization fails
+        '404':
+          description: Not found
+      tags:
+      - repositories
+      operationId: getApiV1RepositoriesIdTagsGrouped
+  "/api/v1/repositories/{id}/tags/{tag_id}":
+    get:
+      summary: Show tag by id
+      description: Show tag by id
+      produces:
+      - application/json
+      parameters:
+      - in: path
+        name: id
+        description: Repository ID
+        type: integer
+        format: int32
+        required: true
+      - in: path
+        name: tag_id
+        description: Tag ID
+        type: string
+        required: true
+      responses:
+        '200':
+          description: Show tag by id
+          schema:
+            "$ref": "#/definitions/Tags"
+        '401':
+          description: Authentication fails
+        '403':
+          description: Authorization fails
+        '404':
+          description: Not found
+      tags:
+      - repositories
+      operationId: getApiV1RepositoriesIdTagsTagId
+  "/api/v1/repositories/{id}":
+    get:
+      summary: Show repositories by id
+      description: Show repositories by id
+      produces:
+      - application/json
+      parameters:
+      - in: path
+        name: id
+        description: Repository ID
+        type: integer
+        format: int32
+        required: true
+      responses:
+        '200':
+          description: Show repositories by id
+          schema:
+            "$ref": "#/definitions/Repositories"
+        '401':
+          description: Authentication fails
+        '403':
+          description: Authorization fails
+        '404':
+          description: Not found
+      tags:
+      - repositories
+      operationId: getApiV1RepositoriesId
+  "/api/v1/tags":
+    get:
+      summary: Returns list of tags
+      description: This will expose all tags
+      produces:
+      - application/json
+      responses:
+        '200':
+          description: Returns list of tags
+          schema:
+            type: array
+            items:
+              "$ref": "#/definitions/Tags"
+        '401':
+          description: Authentication fails
+        '403':
+          description: Authorization fails
+      tags:
+      - tags
+      operationId: getApiV1Tags
+  "/api/v1/tags/{id}":
+    get:
+      summary: Show tag by id
+      description: Show tag by id
+      produces:
+      - application/json
+      parameters:
+      - in: path
+        name: id
+        description: Tag ID
+        type: integer
+        format: int32
+        required: true
+      responses:
+        '200':
+          description: Show tag by id
+          schema:
+            "$ref": "#/definitions/Tags"
+        '401':
+          description: Authentication fails
+        '403':
+          description: Authorization fails
+        '404':
+          description: Not found
+      tags:
+      - tags
+      operationId: getApiV1TagsId
+  "/api/v1/teams":
+    get:
+      summary: Returns list of teams
+      description: This will expose all teams
+      produces:
+      - application/json
+      responses:
+        '200':
+          description: Returns list of teams
+          schema:
+            type: array
+            items:
+              "$ref": "#/definitions/Teams"
+        '401':
+          description: Authentication fails
+        '403':
+          description: Authorization fails
+      tags:
+      - teams
+      operationId: getApiV1Teams
+    post:
+      summary: Create a team
+      description: Create a team
+      produces:
+      - application/json
+      consumes:
+      - application/json
+      parameters:
+      - in: formData
+        name: name
+        description: Team name
+        type: string
+        required: true
+      - in: formData
+        name: description
+        description: Team description
+        type: string
+        required: false
+      responses:
+        '201':
+          description: Create a team
+          schema:
+            "$ref": "#/definitions/Teams"
+        '401':
+          description: Authentication fails
+        '403':
+          description: Authorization fails
+      tags:
+      - teams
+      operationId: postApiV1Teams
+  "/api/v1/teams/{id}/namespaces":
+    get:
+      summary: Returns the list of namespaces for the given team
+      description: Returns the list of namespaces for the given team
+      produces:
+      - application/json
+      parameters:
+      - in: path
+        name: id
+        description: Repository ID
+        type: integer
+        format: int32
+        required: true
+      responses:
+        '200':
+          description: Returns the list of namespaces for the given team
+          schema:
+            type: array
+            items:
+              "$ref": "#/definitions/Namespaces"
+        '401':
+          description: Authentication fails
+        '403':
+          description: Authorization fails
+        '404':
+          description: Not found
+      tags:
+      - teams
+      operationId: getApiV1TeamsIdNamespaces
+  "/api/v1/teams/{id}/members":
+    get:
+      summary: Returns the list of team members
+      description: Returns the list of team members
+      produces:
+      - application/json
+      parameters:
+      - in: path
+        name: id
+        description: Repository ID
+        type: integer
+        format: int32
+        required: true
+      responses:
+        '200':
+          description: Returns the list of team members
+          schema:
+            type: array
+            items:
+              "$ref": "#/definitions/Users"
+        '401':
+          description: Authentication fails
+        '403':
+          description: Authorization fails
+        '404':
+          description: Not found
+      tags:
+      - teams
+      operationId: getApiV1TeamsIdMembers
+  "/api/v1/teams/{id}":
+    get:
+      summary: Show teams by id
+      description: Show teams by id
+      produces:
+      - application/json
+      parameters:
+      - in: path
+        name: id
+        description: Team ID
+        type: string
+        required: true
+      responses:
+        '200':
+          description: Show teams by id
+          schema:
+            "$ref": "#/definitions/Teams"
+        '401':
+          description: Authentication fails
+        '403':
+          description: Authorization fails
+        '404':
+          description: Not found
+      tags:
+      - teams
+      operationId: getApiV1TeamsId
+  "/api/v1/users/{id}/application_tokens":
+    get:
+      summary: Returns list of user's tokens
+      description: Returns list of user's tokens
+      produces:
+      - application/json
+      parameters:
+      - in: path
+        name: id
+        description: User ID
+        type: integer
+        format: int32
+        required: true
+      responses:
+        '200':
+          description: Returns list of user's tokens
+          schema:
+            type: array
+            items:
+              "$ref": "#/definitions/ApplicationTokens"
+        '401':
+          description: Authentication fails
+        '403':
+          description: Authorization fails
+        '404':
+          description: Not found
+      tags:
+      - users
+      operationId: getApiV1UsersIdApplicationTokens
+    post:
+      summary: Create user's token
+      description: Create user's token
+      produces:
+      - application/json
+      consumes:
+      - application/x-www-form-urlencoded
+      - application/json
+      parameters:
+      - in: formData
+        name: application
+        description: Application name
+        type: string
+        required: true
+      - in: path
+        name: id
+        description: User ID
+        type: integer
+        format: int32
+        required: true
+      responses:
+        '201':
+          description: Create user's token
+          schema:
+            "$ref": "#/definitions/ApplicationTokens"
+        '400':
+          description: Bad request
+          schema:
+            "$ref": "#/definitions/ApiErrors"
+        '401':
+          description: Authentication fails
+        '403':
+          description: Authorization fails
+      tags:
+      - users
+      operationId: postApiV1UsersIdApplicationTokens
+  "/api/v1/users/application_tokens/{id}":
+    delete:
+      summary: Delete application token
+      description: Delete application token
+      produces:
+      - application/json
+      parameters:
+      - in: path
+        name: id
+        description: Token id
+        type: string
+        required: true
+      responses:
+        '204':
+          description: Delete application token
+        '401':
+          description: Authentication fails
+        '403':
+          description: Authorization fails
+        '404':
+          description: Not found
+      tags:
+      - users
+      operationId: deleteApiV1UsersApplicationTokensId
+  "/api/v1/users":
+    post:
+      summary: Create new user
+      description: Create new user
+      produces:
+      - application/json
+      consumes:
+      - application/x-www-form-urlencoded
+      - application/json
+      parameters:
+      - in: formData
+        name: user[username]
+        description: User name
+        type: string
+        required: true
+      - in: formData
+        name: user[email]
+        description: E-mail
+        type: string
+        required: true
+      - in: formData
+        name: user[password]
+        description: Password
+        type: string
+        required: true
+      - in: formData
+        name: user[display_name]
+        description: Display name
+        type: string
+        required: false
+      responses:
+        '201':
+          description: Create new user
+          schema:
+            "$ref": "#/definitions/Users"
+        '400':
+          description: Bad request
+          schema:
+            "$ref": "#/definitions/ApiErrors"
+        '401':
+          description: Authentication fails
+        '403':
+          description: Authorization fails
+      tags:
+      - users
+      operationId: postApiV1Users
+    get:
+      summary: Returns list of users
+      description: This will expose all users
+      produces:
+      - application/json
+      responses:
+        '200':
+          description: Returns list of users
+          schema:
+            type: array
+            items:
+              "$ref": "#/definitions/Users"
+        '401':
+          description: Authentication fails
+        '403':
+          description: Authorization fails
+      tags:
+      - users
+      operationId: getApiV1Users
+  "/api/v1/users/{id}":
+    put:
+      summary: Update user
+      description: Update user
+      produces:
+      - application/json
+      consumes:
+      - application/x-www-form-urlencoded
+      - application/json
+      parameters:
+      - in: formData
+        name: user[username]
+        description: User name
+        type: string
+        required: false
+      - in: formData
+        name: user[email]
+        description: E-mail
+        type: string
+        required: false
+      - in: formData
+        name: user[password]
+        description: Password
+        type: string
+        required: false
+      - in: formData
+        name: user[display_name]
+        description: Display name
+        type: string
+        required: false
+      - in: path
+        name: id
+        description: User ID
+        type: integer
+        format: int32
+        required: true
+      responses:
+        '200':
+          description: Update user
+          schema:
+            "$ref": "#/definitions/Users"
+        '400':
+          description: Bad request
+          schema:
+            "$ref": "#/definitions/ApiErrors"
+        '401':
+          description: Authentication fails
+        '403':
+          description: Authorization fails
+        '404':
+          description: Not found
+      tags:
+      - users
+      operationId: putApiV1UsersId
+    delete:
+      summary: Delete user
+      description: Delete user
+      produces:
+      - application/json
+      parameters:
+      - in: path
+        name: id
+        description: User ID
+        type: integer
+        format: int32
+        required: true
+      responses:
+        '204':
+          description: Delete user
+        '401':
+          description: Authentication fails
+        '403':
+          description: Authorization fails
+        '404':
+          description: Not found
+      tags:
+      - users
+      operationId: deleteApiV1UsersId
+    get:
+      summary: Show user by id or email
+      description: Show user by id or email
+      produces:
+      - application/json
+      parameters:
+      - in: path
+        name: id
+        description: User ID or email
+        type: string
+        required: true
+      responses:
+        '200':
+          description: Show user by id or email
+          schema:
+            "$ref": "#/definitions/Users"
+        '401':
+          description: Authentication fails
+        '403':
+          description: Authorization fails
+        '404':
+          description: Not found
+      tags:
+      - users
+      operationId: getApiV1UsersId
+  "/api/v1/_ping":
+    get:
+      summary: Ping this API
+      description: Returns 200 as a status code
+      produces:
+      - application/json
+      responses:
+        '200':
+          description: Ping this API
+      tags:
+      - health
+      operationId: getApiV1Ping
+  "/api/version":
+    get:
+      summary: Fetch the version of Portus
+      description: Returns the version of Portus and the supported API versions
+      produces:
+      - application/json
+      responses:
+        '200':
+          description: Fetch the version of Portus
+          schema:
+            "$ref": "#/definitions/Version"
+      tags:
+      - version
+      operationId: getApiVersion
+definitions:
+  Health:
+    type: object
+    properties:
+      database:
+        "$ref": "#/definitions/HealthStatus"
+        description: Database health status
+      registry:
+        "$ref": "#/definitions/HealthStatus"
+        description: Registry health status
+      clair:
+        "$ref": "#/definitions/HealthStatus"
+        description: CoreOS Clair health status. Empty if Clair support has not been
+          enabled
+    description: Returns general metrics on the health of the system
+  HealthStatus:
+    type: object
+    properties:
+      msg:
+        type: string
+        description: Description message
+      success:
+        type: boolean
+        description: Whether health checking was successful or not for the component
+  Namespaces:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int32
+        description: Namespace ID
+      name:
+        type: string
+        description: Namespace name
+      created_at:
+        type: string
+        format: date-time
+      updated_at:
+        type: string
+        format: date-time
+      description:
+        type: string
+        description: The description of the namespace
+      team_name:
+        type: string
+      team_id:
+        type: integer
+        format: int32
+        description: The ID of the team containing this namespace
+      repositories_count:
+        type: integer
+        format: int32
+        description: The number of repositories that belong to this namespace
+      webhooks_count:
+        type: integer
+        format: int32
+        description: The number of webooks that belong to this namespace
+      visibility:
+        type: string
+        description: The visibility of namespaces by other people
+      global:
+        type: boolean
+        description: Whether this is the global namespace or not
+      permissions:
+        type: string
+        description: Different permissions for the current user
+    description: Returns the list of namespaces for the given team
+  Status:
+    type: object
+    properties:
+      messages:
+        type: object
+        description: Detailed hash with the fields
+      valid:
+        type: boolean
+        description: Whether the given resource is valid or not
+    description: Besides containing the usual Status object, it adds the reachable
+      validation to the `hostname` field in the `messages` hash. This validation returns
+      a string containing the error as given by the registry. If empty then everything
+      went well
+  Teams:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int32
+        description: Repository ID
+      name:
+        type: string
+        description: Repository name
+      created_at:
+        type: string
+        format: date-time
+      updated_at:
+        type: boolean
+        description: Whether the team is visible to the final user or not
+      hidden:
+        type: boolean
+        description: Whether the team is visible to the final user or not
+      role:
+        type: string
+        description: The role this of the current user within this team
+      users_count:
+        type: integer
+        format: int32
+        description: The number of enabled users that belong to this team
+      namespaces_count:
+        type: integer
+        format: int32
+        description: The number of namespaces that belong to this team
+    description: Show teams by id
+  Repositories:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int32
+        description: Repository ID
+      name:
+        type: string
+        description: Repository name
+      full_name:
+        type: string
+        description: Repository full name
+      created_at:
+        type: string
+        format: date-time
+      updated_at:
+        type: string
+        format: date-time
+      namespace:
+        type: string
+        description: The ID of the namespace containing this repository
+      registry_hostname:
+        type: integer
+        format: int32
+        description: The repository's registry hostname
+      stars:
+        type: integer
+        format: int32
+        description: The number of stars for this repository
+      tags_count:
+        type: integer
+        format: int32
+        description: The number of tags for this repository
+      tags:
+        type: array
+        items:
+          type: string
+        description: The repository's tags grouped by digest
+    description: Show repositories by id
+  Registries:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int32
+      name:
+        type: string
+        description: The name of the registry
+      hostname:
+        type: string
+        description: The hostname of the registry
+      external_hostname:
+        type: string
+        description: An external hostname of the registry, useful if behind a proxy
+          with a different FQDN
+      use_ssl:
+        type: boolean
+        description: Whether the registry uses SSL or not
+      created_at:
+        type: string
+        format: date-time
+      updated_at:
+        type: string
+        format: date-time
+    description: This will expose all accessible registries
+  Tags:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int32
+        description: Tag ID
+      name:
+        type: string
+        description: Tag name
+      author:
+        type: integer
+        format: int32
+        description: The ID of the user that pushed this tag
+      digest:
+        type: string
+        description: The digest of the tag
+      image_id:
+        type: string
+        description: The internal image ID
+      created_at:
+        type: string
+        format: date-time
+      updated_at:
+        type: string
+        format: date-time
+      scanned:
+        type: integer
+        format: int32
+        description: 'Whether vulnerabilities have been scanned or not. The values
+          available are: 0 (not scanned), 1 (work in progress) and 2 (scanning done).'
+      vulnerabilities:
+        type: array
+        items:
+          type: string
+        description: An array of vulnerabilities for this tag, or null if the feature
+          is not enabled
+    description: Show tag by id
+  Users:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int32
+        description: User ID
+      username:
+        type: string
+        description: User name
+      email:
+        type: string
+        description: E-mail
+      current_sign_in_at:
+        type: string
+        format: date-time
+      last_sign_in_at:
+        type: string
+        format: date-time
+      created_at:
+        type: string
+        format: date-time
+      updated_at:
+        type: string
+        format: date-time
+      admin:
+        type: boolean
+      enabled:
+        type: boolean
+      locked_at:
+        type: string
+        format: date-time
+      namespace_id:
+        type: integer
+        format: int32
+      display_name:
+        type: string
+        description: Display name
+    description: Show user by id or email
+  ApplicationTokens:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int32
+      application:
+        type: string
+      plain_token:
+        type: string
+    description: Create user's token
+  ApiErrors:
+    type: object
+    properties:
+      errors:
+        type: array
+        items:
+          "$ref": "#/definitions/Messages"
+    description: Update user
+  Messages:
+    type: object
+    properties:
+      message:
+        type: string
+  Version:
+    type: object
+    properties:
+      api-versions:
+        type: Array[String]
+        description: Versions of the API supported
+      git:
+        type: string
+        description: Git information
+      version:
+        type: string
+        description: Version of Portus
+    description: Returns the version of Portus and the supported API versions

--- a/_docs/API.md
+++ b/_docs/API.md
@@ -1,0 +1,64 @@
+---
+layout: swagger
+title: Portus REST API
+longtitle: Specification of the Portus REST API
+order: 5
+data: api
+---
+
+## Introduction
+
+We have been working on a REST API that can be used to operate Portus without
+needing to access the web UI, and we are already building some tooling like
+[openSUSE/portusctl](https://github.com/openSUSE/portusctl) which already takes
+advantage of this new API.
+
+Note though that we are doing organically. This means that we make no guarantees
+over the stability of this version of the API (once we've learned what we need
+from `v1`, we will make these guarantees on a [v2 version of the
+API](https://github.com/SUSE/Portus/issues/1500)).
+
+The specification listed below corresponds to the current state of the
+**master** branch, so the specification may vary from the v2.3 release. That
+being said, we are writing down the changes from the v2.3, so early users are
+not caught off guard. Besides this, take into account the following:
+
+- You have to set the `Content-Type` and the `Accept` headers to
+  `application/json` for every request.
+- Error messages are a bit chaotic (i.e. with different formats). We are
+  tracking this on [this issue](https://github.com/SUSE/Portus/issues/1437).
+
+## Authentication
+
+Authentication is done through [application
+tokens](/features/application_tokens.html). This way, you don't compromise your
+password, and you can revoke it whenever you think it's necessary.
+
+Once you have created this application token, you will have to pass the
+`PORTUS-AUTH` header for every HTTP request that you perform. This header
+follows this format: `<username>:<application token>`. So, if your user name is
+`user`, and the application token you have created has the value
+`T7Dfuz4fsy1UVxNUKyac`, then you have to set this header with the value:
+`user:T7Dfuz4fsy1UVxNUKyac`. You can try that this is working by performing the
+following HTTP request (where `https://172.17.0.1` points to a Portus instance):
+
+```
+$ curl -X GET --header 'Accept: application/json' --header 'Portus-Auth: user:T7Dfuz4fsy1UVxNUKyac' 'https://172.17.0.1/api/v1/users'
+```
+
+If everything went correctly, then you will get a JSON response with all the
+users from your Portus instance.
+
+Finally, [portusctl](https://github.com/openSUSE/portusctl) does this
+automatically for you if you provide the environment variables:
+`PORTUSCTL_API_SERVER`, `PORTUSCTL_API_TOKEN` and `PORTUSCTL_API_USER`. With
+this in mind, the following is equivalent to the previously used curl command:
+
+```
+$ export PORTUSCTL_API_USER="user"
+$ export PORTUSCTL_API_TOKEN="T7Dfuz4fsy1UVxNUKyac"
+$ export PORTUSCTL_API_SERVER="https://172.17.0.1"
+$ portusctl get users
+```
+
+## Endpoints

--- a/_includes/swagger-method.html
+++ b/_includes/swagger-method.html
@@ -1,0 +1,76 @@
+
+{% assign route   = include.r %}
+{% assign swagger = include.s %}
+
+<div class="swagger-paths">
+    {% for method in route[1] %}
+    <div class="swagger-method swagger-method-{{ method[0] }}">
+        <h4 id="spec-method-{{ method[0] | downcase }}{{ route[0] | replace: '/', '-' }}" class="swagger-method-title">
+            <span class="swagger-method-name">{{ method[0] | upcase }}</span>
+            <span class="swagger-method-route">{{ route[0] }}</span>
+        </h4>
+
+        <div class="swagger-method-details">
+          <p class="swagger-method-description">{{ method[1].description }}.</p>
+            {% if method[1].parameters %}
+            <div class="swagger-parameters">
+                <h4>Parameters</h4>
+
+                <ul>
+                  {% for parameter in method[1].parameters %}
+                    <li>
+                      <i>{{ parameter.name }}</i> ({{ parameter.type}}{% if parameter.required %}, <b>required</b>{% endif %}):
+                      {{ parameter.description }}.
+                      {% if parameter.in == "formData" %}
+                        This parameter is part of the data to be sent as a form.
+                      {% elsif parameter.in == "path" %}
+                        This parameter has to be included as part of the path.
+                      {% elsif parameter.in == "query" %}
+                        This parameter has to be set in the URL query.
+                      {% endif %}
+                    </li>
+                  {% endfor %}
+                </ul>
+            </div>
+            {% endif %}
+
+            {% if method[1].responses %}
+            <div class="swagger-response">
+                {% for response in method[1].responses %}
+                  {% assign aux = response[0] %}
+                  {% if aux == "200" or aux == "201" or aux == "202" %}
+                    {% if response[1].schema.first %}
+                      <h4>Response Class (status: {{ aux }})</h4>
+                      <p>
+                        {% if response[1].description != method[1].description %}{{ response[1].description }}.{% endif %}
+                        Format of the response:
+                      </p>
+                      {% highlight json %}{{ response | definition_extractor }}{% endhighlight %}
+                    {% endif %}
+                  {% endif %}
+                {% endfor %}
+
+                <h4>Response Messages</h4>
+
+                <table cellspacing="0" cellpadding="0">
+                {% for response in method[1].responses %}
+                  {% assign aux = response[0] %}
+                  {% if aux != "200" and aux != "201" and aux != "202" %}
+                  <tr>
+                    <td class="swagger-response-code">{{ response[0] }}</td>
+                    <td class="swagger-response-message">{{ response[1].description }}.</td>
+                  </tr>
+                  {% elsif response[1].schema.first == nil %}
+                  <tr>
+                    <td class="swagger-response-code">{{ response[0] }}</td>
+                    <td class="swagger-response-message">{{ response[1].description }}.</td>
+                  </tr>
+                  {% endif %}
+                {% endfor %}
+                </table>
+            </div>
+            {% endif %}
+        </div>
+    </div>
+    {% endfor %}
+</div>

--- a/_layouts/swagger.html
+++ b/_layouts/swagger.html
@@ -2,154 +2,21 @@
 layout: default
 ---
 
+<div class="alert alert-info">
+  Only available in <strong>2.3 or later</strong>.
+</div>
+
 <h1>{{ page.title }}</h1>
 
 {{ content }}
 
-{% if page.data %}
 {% assign swagger = site.data[page.data] %}
-{% else %}
-{% assign swagger = page %}
-{% endif %}
+{% assign paths   = swagger.paths | sort_by_tag %}
 
-{% for route in swagger.paths %}
-<div class="swagger-paths">
-    <h2 class="swagger-path">{{ route[0] }}</h>
-    {% for method in route[1] %}
-    <div class="swagger-method swagger-method-{{ method[0] }}">
-        <h3 class="swagger-method-title">
-            <a href="#" class="swagger-method-link">
-                <span class="swagger-method-name">{{ method[0] | upcase }}</span>
-                {{ method[1].summary }}
-            </a>
-        </h3>
-        <div class="swagger-method-details">
-            {% if method[1].parameters %}
-            <div class="swagger-parameters">
-                <h4>Parameters</h4>
-                <table class="swagger-parameters-table">
-                    <thead>
-                        <tr>
-                            <th>Name</th>
-                            <th>Located in</th>
-                            <th>Description</th>
-                            <th>Type</th>
-                        <tr>
-                    </thead>
-                    <tbody>
-                        {% for parameter in method[1].parameters %}
-                        <tr>
-                            <td>
-                                {% if parameter.required %}
-                                <span class="swagger-parameter-required">
-                                {% endif %}
-                                {{ parameter.name }}
-                                {% if parameter.required %}
-                                </span>
-                                {% endif %}
-                            </td>
-                            <td>{{ parameter.in }}</td>
-                            <td>{{ parameter.description }}</td>
-                            <td>
-                                {% if parameter.type %}
-                                {{ parameter.type | capitalize }}
-                                {% if parameter.items %}
-                                of {{ parameter.items.type | capitalize }}
-                                {% endif %}
-                                {% else %}
-                                String
-                                {% endif %}
-                            </td>
-                        </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
-            </div>
-            {% endif %}
-            {% if method[1].responses %}
-            <div class="swagger-response">
-                <h4>Responses</h4>
-                {% for response in method[1].responses %}
-                <h5>
-                    <span class="swagger-response-code">{{ response[0] }}</span>
-                    {{ response[1].description }}
-                </h5>
-                {% for content_type in swagger.produces %}
-                    {% if response[1].examples[content_type] %}
-                        {% assign example = response[1].examples[content_type] %}
-                        {% if content_type contains 'json' %}
-                            {% highlight json %}{{ example }}{% endhighlight %}
-                        {% elsif content_type contains 'xml' %}
-                            {% highlight xml %}{{ example }}{% endhighlight %}
-                        {% else %}
-                            {% highlight http %}{{ example }}{% endhighlight %}
-                        {% endif %}
-                    {% endif %}
-                {% endfor %}
-                {% endfor %}
-            </div>
-            {% endif %}
-        </div>
-    </div>
-    {% endfor %}
-</div>
+{% for tag in paths %}
+  <h3 id="spec-{{ tag[0] }}" class="swagger-tag">{{ tag[0] | capitalize }}</h3>
+
+  {% for method in tag[1] %}
+     {% include swagger-method.html r=method s=swagger %}
+  {% endfor %}
 {% endfor %}
-
-<script type="text/javascript">
-// Helpers
-
-var slice = Array.prototype.slice;
-
-function $(expr, parent) {
-    return typeof expr === "string" ? (parent || document).querySelector(expr) : expr || null;
-}
-
-function $$(expr, parent) {
-    return slice.call((parent || document).querySelectorAll(expr));
-}
-
-$.bind = function(element, o) {
-    if (element) {
-        for (var event in o) {
-            var callback = o[event];
-
-            event.split(/\s+/).forEach(function (event) {
-                element.addEventListener(event, callback);
-            });
-        }
-    }
-};
-
-$.toggleDetails = function (element) {
-    if (element.classList.contains('open')) {
-        element.classList.remove('open');
-    }
-    else {
-        element.classList.add('open');
-    }
-}
-
-// Initialization
-
-function init() {
-    $$('.swagger-method-title').forEach(function (title) {
-        $.bind(title, {
-            'click': function (e) {
-                var details = $('.swagger-method-details', title.parentNode)
-                $.toggleDetails(details);
-                e.preventDefault();
-            }
-        });
-    });
-}
-
-
-// DOM already loaded?
-if (document.readyState !== "loading") {
-    init();
-}
-else {
-    // Wait for it
-    document.addEventListener("DOMContentLoaded", init);
-}
-</script>

--- a/_plugins/definition_extractor.rb
+++ b/_plugins/definition_extractor.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "json"
+
+module Jekyll
+  # Extract the definition schema for the given response.
+  module DefinitionExtractor
+    # Extracts the response type definition from the input as JSON.
+    def definition_extractor(input)
+      res = extract_from_input(input.last)
+      JSON.pretty_generate(res)
+    end
+
+    protected
+
+    # Extracts the object to converted into JSON from the given input.
+    def extract_from_input(input)
+      ref, is_array = schema_ref(input)
+      return unless ref
+
+      res = {}
+      d = definition_from_ref(ref)
+      d.each { |k, v| res[k] = from_type(v) }
+      is_array ? [res] : res
+    end
+
+    # Returns the value to be set for the given type.
+    # rubocop:disable Metrics/CyclomaticComplexity
+    def from_type(val)
+      case val["type"]
+      when "integer"
+        0
+      when "string"
+        string_format(val)
+      when "boolean"
+        true
+      when "array"
+        ["#{val["items"]["type"]}s"]
+      when /Array\[(\w+)\]/
+        ["#{Regexp.last_match(1).downcase}s"]
+      when "object"
+        "<object>: #{val["description"]}"
+      else
+        # Check if this is a hash with some other entities inside of it.
+        extract_from_input("schema" => val) if val["$ref"]
+      end
+    end
+    # rubocop:enable Metrics/CyclomaticComplexity
+
+    # Returns a string representing the format of it.
+    def string_format(val)
+      val["format"] ? "<#{val["format"]}>" : "string"
+    end
+
+    # Returns the schema reference from the given input.
+    def schema_ref(input)
+      schema = input["schema"]
+      return unless schema
+
+      ref = schema["$ref"]
+      is_array = ref.nil?
+      ref ||= schema["items"]["$ref"]
+      return unless ref
+
+      [ref.split("/").last, is_array]
+    end
+
+    # Returns the property for the definition referenced by the given argument.
+    def definition_from_ref(ref)
+      definitions[ref]["properties"]
+    end
+
+    # Returns the definitions set by Swagger. This method depends on the
+    # `swagger_register.rb` plugin.
+    def definitions
+      # rubocop:disable Style/GlobalVars
+      o = $definitions
+      msg = "The $definitions variable has not been set"
+      raise StandardError, msg unless $definitions
+      # rubocop:enable Style/GlobalVars
+      o
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::DefinitionExtractor)

--- a/_plugins/sort_by_tag.rb
+++ b/_plugins/sort_by_tag.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Jekyll
+  # SortByTag returns the given paths sorted by tag.
+  module SortByTag
+    def sort_by_tag(input)
+      input.group_by { |_, v| v.first.last["tags"].first }
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::SortByTag)

--- a/_plugins/swagger_register.rb
+++ b/_plugins/swagger_register.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Register the API definitions, which is needed by the `definition_extractor.rb`
+# plugin.
+# rubocop:disable Style/GlobalVars
+Jekyll::Hooks.register :documents, :pre_render do |doc|
+  data = doc.site.data["api"]
+  $definitions = data["definitions"] if data && $definitions.nil?
+end
+# rubocop:enable Style/GlobalVars

--- a/stylesheets/partials/_layout.scss
+++ b/stylesheets/partials/_layout.scss
@@ -1,5 +1,9 @@
 @import "variables";
 
+body {
+    font-family: "Roboto", sans-serif;
+}
+
 .portus-topbar {
   height: 6rem;
   width: 100%;

--- a/stylesheets/partials/_swagger.scss
+++ b/stylesheets/partials/_swagger.scss
@@ -1,0 +1,18 @@
+#documentation {
+    .swagger-response table {
+        border-collapse: collapse;
+    }
+
+    .swagger-response td, th {
+        padding: 5px;
+        border: 0;
+    }
+
+    .swagger-response tr {
+        border: none !important;
+    }
+
+    .swagger-method-title {
+        font-size: 20px;
+    }
+}

--- a/stylesheets/portus.scss
+++ b/stylesheets/portus.scss
@@ -14,3 +14,4 @@
 @import "entry";
 @import "layout";
 @import "solarized-light";
+@import "swagger";


### PR DESCRIPTION
I've created some small Jekyll plugins to overcome some flaws from the liquid
markup language... The code for the API documentation was inspired by
https://github.com/jexhson/jekyll-swagger, but I ultimately changed it so much
that it does not resemble in any way that plugin.

Moreover, because of the creation of these plugins, rubocop was getting noisier,
so I adapted the configuration from the `master` branch into this one.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>