### PR TITLE
api: added the current type on some calls

### DIFF
--- a/lib/api/v1/repositories.rb
+++ b/lib/api/v1/repositories.rb
@@ -24,7 +24,7 @@ module API
              ]
 
         get do
-          present policy_scope(Repository), with: API::Entities::Repositories
+          present policy_scope(Repository), with: API::Entities::Repositories, type: current_type
         end
 
         route_param :id, type: String, requirements: { id: /.*/ } do
@@ -103,7 +103,7 @@ module API
           get do
             repo = Repository.find(params[:id])
             authorize repo, :show?
-            present repo, with: API::Entities::Repositories
+            present repo, with: API::Entities::Repositories, type: current_type
           end
         end
       end

--- a/lib/api/v1/teams.rb
+++ b/lib/api/v1/teams.rb
@@ -21,7 +21,7 @@ module API
              ]
 
         get do
-          present policy_scope(Team), with: API::Entities::Teams
+          present policy_scope(Team), with: API::Entities::Teams, type: current_type
         end
 
         desc "Create a team",
@@ -103,7 +103,7 @@ module API
           get do
             team = Team.find(params[:id])
             authorize team, :show?
-            present team, with: API::Entities::Teams
+            present team, with: API::Entities::Teams, type: current_type
           end
         end
       end


### PR DESCRIPTION
There were some calls to present which were missing the type context.
This should fix some oddities.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>