### PR TITLE
Rename swagger_doc into official naming openapi-spec.

### DIFF
--- a/config/initializers/swagger.rb
+++ b/config/initializers/swagger.rb
@@ -7,6 +7,6 @@ unless Rails.env.production?
            ":#{val.last}" if val.size == 2
          end
 
-  GrapeSwaggerRails.options.url     = "/api/swagger_doc.json"
+  GrapeSwaggerRails.options.url     = "/api/openapi-spec.json"
   GrapeSwaggerRails.options.app_url = "#{protocol}#{APP_CONFIG["machine_fqdn"]["value"]}#{port}"
 end

--- a/doc/REST-API.md
+++ b/doc/REST-API.md
@@ -16,7 +16,7 @@ If the authentication fails, then the HTTP status code 401 is returned. If autho
 
 ## OpenAPI Specification
 
-OpenAPI Specification (aka The Swagger Specification) can be fetched from the running Portus instance by visiting the URL `/api/swagger_doc` e.g.
-[localhost:3000/api/swagger_doc](http://localhost:3000/api/swagger_doc) or executing the rake command `rake oapi:fetch`
+OpenAPI Specification (aka The Swagger Specification) can be fetched from the running Portus instance by visiting the URL `/api/openapi-spec` e.g.
+[localhost:3000/api/openapi-spec](http://localhost:3000/api/openapi-spec) or executing the rake command `rake oapi:fetch`
 
 To display the results in a more human readable form you can use the [Swagger UI](http://petstore.swagger.io/) and import the above URL.


### PR DESCRIPTION
Rename swagger_doc into official naming openapi-spec.

closes #1652

However in feature releases we remove the swagger term in code at other location as well.  