### PR TITLE
packaging: do not run bundle clean

### DIFF
--- a/packaging/suse/portus.spec.in
+++ b/packaging/suse/portus.spec.in
@@ -106,9 +106,6 @@ rm -r vendor/bundle/ruby/%{rb_ver}/*
 gem.ruby2.5 install --no-rdoc --no-ri --install-dir vendor/bundle/ruby/%{rb_ver}/ vendor/cache/bundler-*.gem
 bundle install --retry=3 --local --deployment --without test development assets
 
-# Clean unused gems
-bundle clean
-
 # Patch landing_page
 APPLICATION_CSS=$(find . -name application-*.css 2>/dev/null)
 cp $APPLICATION_CSS public/landing.css


### PR DESCRIPTION
It will only remove `bundler`, which we need...

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>