### PR TITLE
Increased the text storage for vulnerabilities

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -15,7 +15,7 @@
 #  marked          :boolean          default(FALSE)
 #  username        :string(255)
 #  scanned         :integer          default(0)
-#  vulnerabilities :text(65535)
+#  vulnerabilities :text(16777215)
 #
 # Indexes
 #

--- a/db/migrate/20180207145522_change_vulnerabilities_to_medium_text.rb
+++ b/db/migrate/20180207145522_change_vulnerabilities_to_medium_text.rb
@@ -1,0 +1,5 @@
+class ChangeVulnerabilitiesToMediumText < ActiveRecord::Migration
+  def change
+    change_column :tags, :vulnerabilities, :text, limit: 16.megabytes - 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180109114124) do
+ActiveRecord::Schema.define(version: 20180207145522) do
 
   create_table "activities", force: :cascade do |t|
     t.integer  "trackable_id",   limit: 4
@@ -109,17 +109,17 @@ ActiveRecord::Schema.define(version: 20180109114124) do
   add_index "stars", ["user_id"], name: "index_stars_on_user_id", using: :btree
 
   create_table "tags", force: :cascade do |t|
-    t.string   "name",            limit: 255,   default: "latest", null: false
-    t.integer  "repository_id",   limit: 4,                        null: false
-    t.datetime "created_at",                                       null: false
-    t.datetime "updated_at",                                       null: false
+    t.string   "name",            limit: 255,      default: "latest", null: false
+    t.integer  "repository_id",   limit: 4,                           null: false
+    t.datetime "created_at",                                          null: false
+    t.datetime "updated_at",                                          null: false
     t.integer  "user_id",         limit: 4
     t.string   "digest",          limit: 255
-    t.string   "image_id",        limit: 255,   default: ""
-    t.boolean  "marked",                        default: false
+    t.string   "image_id",        limit: 255,      default: ""
+    t.boolean  "marked",                           default: false
     t.string   "username",        limit: 255
-    t.integer  "scanned",         limit: 4,     default: 0
-    t.text     "vulnerabilities", limit: 65535
+    t.integer  "scanned",         limit: 4,        default: 0
+    t.text     "vulnerabilities", limit: 16777215
   end
 
   add_index "tags", ["repository_id"], name: "index_tags_on_repository_id", using: :btree

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -15,7 +15,7 @@
 #  marked          :boolean          default(FALSE)
 #  username        :string(255)
 #  scanned         :integer          default(0)
-#  vulnerabilities :text(65535)
+#  vulnerabilities :text(16777215)
 #
 # Indexes
 #

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -15,7 +15,7 @@
 #  marked          :boolean          default(FALSE)
 #  username        :string(255)
 #  scanned         :integer          default(0)
-#  vulnerabilities :text(65535)
+#  vulnerabilities :text(16777215)
 #
 # Indexes
 #


### PR DESCRIPTION
Some images like `node:8` had so many vulnerabilities that then the
stored JSON was huge. This is a temporary fix because we are about to
release 2.3 and this fix is needed. A more suitable approach is the one
mentioned in #1669.

Fixes #1657

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>