### PR TITLE
background: mark failed scans as re-schedulable

### DIFF
--- a/lib/portus/background/security_scanning.rb
+++ b/lib/portus/background/security_scanning.rb
@@ -42,6 +42,8 @@ module Portus
           dig = update_tag(tag, vulns)
           digests << dig if dig
         end
+
+        check_failed!
       end
 
       def to_s
@@ -76,6 +78,20 @@ module Portus
         end
 
         digest
+      end
+
+      # If not all tags where marked as done, then we have a problem (either
+      # Clair was temporarily unavailable, or we are hitting a bug). In that
+      # case, log the issue and mark the affected tags as not-scanned, so they
+      # can be picked up in following iterations.
+      def check_failed!
+        tags = Tag.where.not(scanned: Tag.statuses[:scan_done])
+        return if tags.empty?
+
+        Rails.logger.warn "Some tags were not marked as done. This may happen" \
+                          " either because the security scanner had a temporary problem, or" \
+                          " because there is a bug. They will be picked up in the next iteration."
+        tags.update_all(scanned: Tag.statuses[:scan_none])
       end
     end
   end

--- a/spec/lib/portus/background/security_scanning_spec.rb
+++ b/spec/lib/portus/background/security_scanning_spec.rb
@@ -111,6 +111,17 @@ describe ::Portus::Background::SecurityScanning do
       expect(Tag.all).to(be_all { |t| t.scanned == Tag.statuses[:scan_done] })
       expect(Tag.all).to(be_all { |t| t.vulnerabilities == ["something"] })
     end
+
+    it "marks tags as not scanned if it does not fetch vulnerabilities properly" do
+      create(:tag, name: "tag", repository: repository, digest: "1", author: admin)
+      allow_any_instance_of(::Portus::Security).to receive(:vulnerabilities) {}
+      allow_any_instance_of(Tag).to receive(:update_vulnerabilities) {}
+
+      subject.execute!
+
+      t = Tag.find_by(name: "tag")
+      expect(t.scanned).to eq(Tag.statuses[:scan_none])
+    end
   end
 
   describe "#to_s" do


### PR DESCRIPTION
After a security scanning iteration, some tags might not be in a
:scan_done state. This is possible in situtations like:

- Clair was unavailable for some time because of a hiccup.
- There's an actual bug on the security scanning.

In these cases, we will check in the end of the iteration whether all
tags have been marked as scan. If this is not the case, then we will log
a warning and mark the failed tags as :scan_none (so in the next
iteration they can be picked up and hopefully be scanned properly this
time).

See #1649

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>