### PR TITLE
api: added endpoints for re-scheduling scanning

### DIFF
--- a/lib/api/root_api.rb
+++ b/lib/api/root_api.rb
@@ -11,6 +11,7 @@ require "api/v1/repositories"
 require "api/v1/tags"
 require "api/v1/teams"
 require "api/v1/users"
+require "api/v1/vulnerabilities"
 require "api/version"
 
 module API
@@ -55,6 +56,7 @@ module API
     mount ::API::V1::Tags
     mount ::API::V1::Teams
     mount ::API::V1::Users
+    mount ::API::V1::Vulnerabilities
     mount ::API::Version
 
     route :any, "*path" do

--- a/lib/api/v1/vulnerabilities.rb
+++ b/lib/api/v1/vulnerabilities.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module API
+  module V1
+    # Tags implements all the endpoints regarding tags that have not been
+    # addressed in other classes.
+    class Vulnerabilities < Grape::API
+      version "v1", using: :path
+
+      resource :vulnerabilities do
+        before do
+          authorization!(force_admin: true)
+        end
+
+        desc "Force re-schedule for all tags",
+             tags:    ["vulnerabilities"],
+             detail:  "Force the security scanner to go through all the tags" \
+                      " again, even if they have been marked as scanned",
+             failure: [
+               [401, "Authentication fails"],
+               [403, "Authorization fails"]
+             ]
+
+        post do
+          Tag.update_all(scanned: Tag.statuses[:scan_none])
+          status 202
+        end
+
+        route_param :id, type: Integer, requirements: { id: /.*/ } do
+          desc "Force re-schedule for the given tag",
+               tags:    ["vulnerabilities"],
+               detail:  "Force the security scanner to scan again a given tag," \
+                        "even if it was already marked as scanned",
+               failure: [
+                 [401, "Authentication fails"],
+                 [403, "Authorization fails"]
+               ]
+
+          post do
+            tag = Tag.find(params[:id])
+            tag.update_column(:scanned, Tag.statuses[:scan_none])
+            status 202
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/api/grape_api/v1/vulnerabilities_spec.rb
+++ b/spec/api/grape_api/v1/vulnerabilities_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe API::V1::Vulnerabilities, focus: true do
+  let!(:admin) { create(:admin) }
+  let!(:token) { create(:application_token, user: admin) }
+  let!(:public_namespace) do
+    create(:namespace,
+           visibility: Namespace.visibilities[:visibility_public],
+           team:       create(:team))
+  end
+  let!(:repository) { create(:repository, namespace: public_namespace) }
+  let!(:tag1)       { create(:tag, name: "tag1", repository: repository) }
+  let!(:tag2)       { create(:tag, name: "tag2", repository: repository) }
+
+  before do
+    @header = build_token_header(token)
+  end
+
+  context "POST /api/v1/vulnerabilities" do
+    it "forces the re-schedule for all tags" do
+      Tag.update_all(scanned: Tag.statuses[:scan_done])
+      post "/api/v1/vulnerabilities", nil, @header
+      expect(response).to have_http_status(:accepted)
+
+      expect(Tag.any? { |t| t.scanned != Tag.statuses[:scan_none] }).to be_falsey
+    end
+  end
+
+  context "POST /api/v1/vulnerabilities/:id" do
+    it "forces the re-schedule for a single tag" do
+      Tag.update_all(scanned: Tag.statuses[:scan_done])
+      post "/api/v1/vulnerabilities/#{tag1.id}", nil, @header
+      expect(response).to have_http_status(:accepted)
+
+      t = Tag.find_by(name: tag1.name)
+      expect(t.scanned).to eq(Tag.statuses[:scan_none])
+      t = Tag.find_by(name: tag2.name)
+      expect(t.scanned).to eq(Tag.statuses[:scan_done])
+    end
+  end
+end


### PR DESCRIPTION
This commit adds two new endpoints: `/vulnerabilities` and
`/vulnerabilities/:id`. Both these endpoints require admin privileges,
and they will simply toggle the `scanned` column of tags so the scanning
task can pick them up.

This commit does not deal with the UI part, it simply provides the
backend code. The frontend code can be delivered later on.

See #1658

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>