### PR TITLE
Stabilize the `sync` background task before the 2.3 release

### DIFF
--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -50,7 +50,7 @@ class RepositoriesController < ApplicationController
       logger.error "The following tags could not be removed: #{ts}."
       redirect_to repository_path(@repository), alert: "Could not remove all the tags", float: true
     else
-      @repository.delete_and_update!(current_user)
+      @repository.delete_by!(current_user)
       redirect_to namespace_path(@repository.namespace),
                   notice: "Repository removed with all its tags", float: true
     end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -23,7 +23,7 @@ class TagsController < ApplicationController
     repo = tag.repository
     if tag.delete_by_digest!(current_user)
       if repo.tags.empty?
-        repo.delete_and_update!(current_user)
+        repo.delete_by!(current_user)
         flash[:notice] = "Repository removed with all its tags"
       end
       head :ok

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -65,7 +65,7 @@ class Repository < ActiveRecord::Base
 
   # Updates the activities related to this repository and adds a new activity
   # regarding the removal of this.
-  def delete_and_update!(actor)
+  def delete_by!(actor)
     logger.tagged("catalog") { logger.info "Removed the image '#{name}'." }
 
     # Take care of current activities.
@@ -118,10 +118,10 @@ class Repository < ActiveRecord::Base
     # Destroy tags and the repository if it's empty now.
     user = User.find_from_event(event)
     repo.tags.where(digest: event["target"]["digest"], marked: false).map do |t|
-      t.delete_and_update!(user)
+      t.delete_by!(user)
     end
     repo = repo.reload
-    repo.delete_and_update!(user) if !repo.nil? && repo.tags.empty?
+    repo.delete_by!(user) if !repo.nil? && repo.tags.empty?
   end
 
   # Add the repository with the given `repo` name and the given `tag`. The
@@ -202,7 +202,7 @@ class Repository < ActiveRecord::Base
     create_tags client, repository, portus, repo["tags"] - tags
 
     # Finally remove the tags that are left and return the repo.
-    repository.tags.where(name: to_be_deleted_tags).find_each { |t| t.delete_and_update!(portus) }
+    repository.tags.where(name: to_be_deleted_tags).find_each { |t| t.delete_by!(portus) }
     repository.reload
   end
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -72,11 +72,11 @@ class Tag < ActiveRecord::Base
       return false
     end
 
-    Tag.where(digest: dig).map { |t| t.delete_and_update!(actor) }
+    Tag.where(digest: dig).map { |t| t.delete_by!(actor) }
   end
 
   # Delete this tag and update its activity.
-  def delete_and_update!(actor)
+  def delete_by!(actor)
     logger.tagged("catalog") { logger.info "Removed the tag '#{name}'." }
 
     # If the tag is no longer there, ignore this call and return early.

--- a/bin/background.rb
+++ b/bin/background.rb
@@ -51,9 +51,14 @@ slept = 0
 #
 
 loop do
-  they.each do |t|
+  they.each_with_index do |t, idx|
     next if slept % t.sleep_value != 0
     t.execute! if t.work?
+
+    if t.disable?
+      Rails.logger.info "Disabling '#{t}'. Reason: #{t.disable_message}."
+      they.delete_at(idx)
+    end
   end
 
   break if ARGV.first == "--one-shot"

--- a/config/config.yml
+++ b/config/config.yml
@@ -281,10 +281,25 @@ security:
 anonymous_browsing:
   enabled: true
 
-# Environment variables for ensuring the execution of the
-# background tasks 'registry' and 'sync'.
+# Configuration for the background tasks.
 background:
-  registry: 
+  # The registry integration: it processes the given registry events (e.g. a new
+  # tag was pushed). It's therefore highly *discouraged* to disable this task.
+  registry:
     enabled: true
-  sync: 
+
+  # Registry synchronization: it synchronizes all the contents from the registry
+  # into the database.
+  sync:
     enabled: true
+
+    # There are four accepted values:
+    #   - update-delete: it performs a full synchronization.
+    #   - update: it only adds missing tags, but it does not remove any contents
+    #     from the database.
+    #   - on-start: when starting Portus it runs an `update-delete` and then it
+    #     gets disabled (i.e. it will only run once).
+    #   - initial: like `on-start`, but it only runs if the database is
+    #     empty. This is the default value since it's deemed to be the most
+    #     common use-case.
+    sync-strategy: initial

--- a/lib/portus/background/README.md
+++ b/lib/portus/background/README.md
@@ -1,0 +1,23 @@
+## Background tasks
+
+This is the documentation for writing and maintaining background tasks. All the
+tasks defined in this directory should be picked up by the Rails runner:
+`bin/background.rb`. Make sure that when you write a new background task this
+has been added into the `they` array.
+
+### Interface
+
+The `bin/background.rb` expects the following methods to be implemented by a
+task:
+
+- `sleep_value`: simply return an integer which contains the time span in
+  seconds between executions. Note that the `sleep_value` of all tasks have to
+  be divisible by the one with the lowest value.
+- `work?`: returns true if the task can perform an execution, otherwise it
+  returns false.
+- `execute!`: performs an execution. This is the bulk of the background task.
+- `disable?`: returns true if the task can be entirely removed after some
+  time. This might be useful for tasks which need to perform at least one
+  execution and leave. If your task can be disabled in some situation, then you
+  should provide `disable_message`, which returns a string.
+- `to_s`: returns a string with a fancy name for your task.

--- a/lib/portus/background/registry.rb
+++ b/lib/portus/background/registry.rb
@@ -31,6 +31,10 @@ module Portus
         end
       end
 
+      def disable?
+        false
+      end
+
       def to_s
         "Registry events"
       end

--- a/lib/portus/background/registry.rb
+++ b/lib/portus/background/registry.rb
@@ -19,9 +19,10 @@ module Portus
 
       def enabled?
         val = APP_CONFIG.enabled?("background.registry")
-				Rails.logger.warn("Registry integration has been disabled. This is highly discouraged!") unless val
-				val
-			end
+        msg = "Registry integration has been disabled. This is highly discouraged!"
+        Rails.logger.warn(msg) unless val
+        val
+      end
 
       def execute!
         RegistryEvent.where(status: RegistryEvent.statuses[:fresh]).find_each do |e|

--- a/lib/portus/background/security_scanning.rb
+++ b/lib/portus/background/security_scanning.rb
@@ -21,6 +21,10 @@ module Portus
         ::Portus::Security.enabled?
       end
 
+      def disable?
+        false
+      end
+
       # execute! updates the vulnerabilities of all tags which have not been
       # scanned yet. Note that this is done digest-wise, so tags which have
       # already been scanned might be updated as a side-effect of a tag with the

--- a/lib/portus/background/sync.rb
+++ b/lib/portus/background/sync.rb
@@ -6,16 +6,31 @@ module Portus
   module Background
     # Sync synchronizes the contents from the registry into the DB.
     class Sync
+      def initialize
+        @executed = false
+      end
+
       # Returns how many seconds has to pass between each loop for this
       # synchronization to happen.
       def sleep_value
         20
       end
 
-      # Returns always true because this does not depend on some configuration
-      # options.
       def work?
-        true
+        return false unless APP_CONFIG.enabled?("background.sync")
+
+        val = APP_CONFIG["background"]["sync"]["sync-strategy"]
+        case val
+        when "update-delete", "update"
+          true
+        when "on-start"
+          !@executed
+        when "initial"
+          !@executed && !Repository.any?
+        else
+          Rails.logger.error "Unrecognized value '#{val}' for sync-strategy"
+          false
+        end
       end
 
       def enabled?
@@ -43,11 +58,27 @@ module Portus
           # Update the registry in a transaction, since we don't want to leave
           # the DB in an unknown state because of an update failure.
           ActiveRecord::Base.transaction { update_registry!(cat) }
+          @executed = true
         rescue EOFError, *::Portus::Errors::NET,
                ::Portus::Errors::NoBearerRealmException, ::Portus::Errors::AuthorizationError,
                ::Portus::Errors::NotFoundError, ::Portus::Errors::CredentialsMissingError => e
           Rails.logger.warn "Exception: #{e.message}"
         end
+      end
+
+      # This task will be asked to be disable if the strategy was set to
+      # "on-start" or "initial", and the first execution has already been done.
+      def disable?
+        strategy = APP_CONFIG["background"]["sync"]["sync-strategy"]
+        if strategy == "initial" || strategy == "on-start"
+          @executed
+        else
+          false
+        end
+      end
+
+      def disable_message
+        "task was ordered to execute once, and this has already been performed"
       end
 
       def to_s
@@ -74,12 +105,19 @@ module Portus
 
         # At this point, the remaining items in the "repos" array are repos that
         # exist in the DB but not in the catalog. Remove all of them.
-        portus = User.find_by(username: "portus")
-        Tag.where(repository_id: dangling_repos).find_each { |t| t.delete_and_update!(portus) }
-        Repository.where(id: dangling_repos).find_each { |r| r.delete_and_update!(portus) }
+        delete_maybe!(dangling_repos)
 
         # Check that no events have happened while doing all this.
         check_events!
+      end
+
+      # Delete the given repositories unless the configuration does not allow it.
+      def delete_maybe!(repositories)
+        return if APP_CONFIG["background"]["sync"]["sync-strategy"] == "update"
+
+        portus = User.find_by(username: "portus")
+        Tag.where(repository_id: repositories).find_each { |t| t.delete_and_update!(portus) }
+        Repository.where(id: repositories).find_each { |r| r.delete_and_update!(portus) }
       end
 
       # Raises an ActiveRecord::Rollback exception if there are registry events

--- a/lib/portus/background/sync.rb
+++ b/lib/portus/background/sync.rb
@@ -116,8 +116,8 @@ module Portus
         return if APP_CONFIG["background"]["sync"]["sync-strategy"] == "update"
 
         portus = User.find_by(username: "portus")
-        Tag.where(repository_id: repositories).find_each { |t| t.delete_and_update!(portus) }
-        Repository.where(id: repositories).find_each { |r| r.delete_and_update!(portus) }
+        Tag.where(repository_id: repositories).find_each { |t| t.delete_by!(portus) }
+        Repository.where(id: repositories).find_each { |r| r.delete_by!(portus) }
       end
 
       # Raises an ActiveRecord::Rollback exception if there are registry events

--- a/lib/portus/background/sync.rb
+++ b/lib/portus/background/sync.rb
@@ -19,10 +19,17 @@ module Portus
       end
 
       def enabled?
-        if APP_CONFIG("background.sync") == false
-          Rails.logger.warn("WARNING: Sync is disabled!")
+        if APP_CONFIG.enabled?("background.sync")
+          strategy = APP_CONFIG["background"]["sync"]["sync-strategy"]
+          if strategy == "initial" && Repository.any?
+            Rails.logger.info "`#{self}` was disabled because strategy is set to " \
+                              "'initial' and the database is not empty"
+            false
+          else
+            true
+          end
         else
-          APP_CONFIG("background.sync")
+          false
         end
       end
 

--- a/lib/portus/background/sync.rb
+++ b/lib/portus/background/sync.rb
@@ -77,6 +77,16 @@ module Portus
         portus = User.find_by(username: "portus")
         Tag.where(repository_id: dangling_repos).find_each { |t| t.delete_and_update!(portus) }
         Repository.where(id: dangling_repos).find_each { |r| r.delete_and_update!(portus) }
+
+        # Check that no events have happened while doing all this.
+        check_events!
+      end
+
+      # Raises an ActiveRecord::Rollback exception if there are registry events
+      # ready to be fetched.
+      def check_events!
+        return unless RegistryEvent.exists?(status: RegistryEvent.statuses[:fresh])
+        raise ActiveRecord::Rollback
       end
     end
   end

--- a/spec/api/grape_api/v1/vulnerabilities_spec.rb
+++ b/spec/api/grape_api/v1/vulnerabilities_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe API::V1::Vulnerabilities, focus: true do
+describe API::V1::Vulnerabilities do
   let!(:admin) { create(:admin) }
   let!(:token) { create(:application_token, user: admin) }
   let!(:public_namespace) do

--- a/spec/lib/portus/background/registry_spec.rb
+++ b/spec/lib/portus/background/registry_spec.rb
@@ -59,6 +59,18 @@ describe ::Portus::Background::Registry do
     end
   end
 
+  describe "#enabled?" do
+    it "returns true when enabled" do
+      APP_CONFIG["background"]["registry"] = { "enabled" => true }
+      expect(subject.enabled?).to be_truthy
+    end
+
+    it "returns false when not enabled" do
+      APP_CONFIG["background"]["registry"] = { "enabled" => false }
+      expect(subject.enabled?).to be_falsey
+    end
+  end
+
   describe "#to_s" do
     it "works" do
       expect(subject.to_s).to eq "Registry events"

--- a/spec/lib/portus/background/registry_spec.rb
+++ b/spec/lib/portus/background/registry_spec.rb
@@ -11,7 +11,7 @@ describe ::Portus::Background::Registry do
   end
 
   describe "#work?" do
-    it "always return true" do
+    it "always returns true" do
       expect(subject.work?).to be_truthy
     end
   end
@@ -68,6 +68,12 @@ describe ::Portus::Background::Registry do
     it "returns false when not enabled" do
       APP_CONFIG["background"]["registry"] = { "enabled" => false }
       expect(subject.enabled?).to be_falsey
+    end
+  end
+
+  describe "#disable?" do
+    it "always returns false" do
+      expect(subject.disable?).to be_falsey
     end
   end
 

--- a/spec/lib/portus/background/security_scanning_spec.rb
+++ b/spec/lib/portus/background/security_scanning_spec.rb
@@ -139,6 +139,12 @@ describe ::Portus::Background::SecurityScanning do
     end
   end
 
+  describe "#disable?" do
+    it "always returns false" do
+      expect(subject.disable?).to be_falsey
+    end
+  end
+
   describe "#to_s" do
     it "works" do
       expect(subject.to_s).to eq "Security scanning"

--- a/spec/lib/portus/background/security_scanning_spec.rb
+++ b/spec/lib/portus/background/security_scanning_spec.rb
@@ -124,6 +124,21 @@ describe ::Portus::Background::SecurityScanning do
     end
   end
 
+  describe "#enabled?" do
+    it "returns true when enabled" do
+      expect(subject.enabled?).to be_truthy
+    end
+
+    it "returns false when not enabled" do
+      APP_CONFIG["security"] = {
+        "clair"  => { "server" => "" },
+        "zypper" => { "server" => "" },
+        "dummy"  => { "server" => "" }
+      }
+      expect(subject.enabled?).to be_falsey
+    end
+  end
+
   describe "#to_s" do
     it "works" do
       expect(subject.to_s).to eq "Security scanning"

--- a/spec/lib/portus/background/sync_spec.rb
+++ b/spec/lib/portus/background/sync_spec.rb
@@ -189,6 +189,33 @@ describe ::Portus::Background::Sync do
     end
   end
 
+  describe "#enabled?" do
+    it "returns true when enabled" do
+      APP_CONFIG["background"]["sync"] = { "enabled" => true }
+      expect(subject.enabled?).to be_truthy
+    end
+
+    it "returns false when not enabled" do
+      APP_CONFIG["background"]["sync"] = { "enabled" => false }
+      expect(subject.enabled?).to be_falsey
+    end
+
+    it "returns false on initial if there are repositories" do
+      APP_CONFIG["background"]["sync"] = {
+        "enabled"       => true,
+        "sync-strategy" => "initial"
+      }
+
+      registry = create(:registry)
+      create(:user)
+      namespace = create(:namespace, registry: registry)
+      repo = create(:repository, name: "repo", namespace: namespace)
+      create(:tag, name: "tag", repository: repo)
+
+      expect(subject.enabled?).to be_falsey
+    end
+  end
+
   describe "#to_s" do
     it "works" do
       expect(subject.to_s).to eq "Registry synchronization"

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -684,7 +684,7 @@ describe Repository do
     end
   end
 
-  describe "#delete_and_update!" do
+  describe "#delete_by!" do
     let(:registry)        { create(:registry, hostname: "registry.test.lan") }
     let(:user)            { create(:user) }
     let(:repository_name) { "busybox" }
@@ -708,7 +708,7 @@ describe Repository do
 
       # And now delete and see what happens.
       expect do
-        repo.delete_and_update!(user)
+        repo.delete_by!(user)
       end.to change(PublicActivity::Activity, :count).by(1)
 
       # The original push activity has changed, so it's still trackable.

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -93,7 +93,7 @@ describe Tag do
       repository.create_activity(:push, owner: user, recipient: tag)
       repository.create_activity(:push, owner: user, recipient: tag2)
 
-      tag.delete_and_update!(user)
+      tag.delete_by!(user)
 
       activities = PublicActivity::Activity.order(:updated_at)
       expect(activities.count).to eq 3
@@ -155,7 +155,7 @@ describe Tag do
 
   # NOTE: lots of cases are being left out on purpose because they are already
   # tested in the previous `describe` block.
-  describe "#delete_and_update!" do
+  describe "#delete_by!" do
     let!(:tag) { create(:tag, name: "tag1", repository: repository, digest: "1") }
 
     before do
@@ -165,7 +165,7 @@ describe Tag do
     it "does nothing if the tag has already beed removed" do
       expect(Rails.logger).to receive(:info).with(/Removed the tag.../)
       expect(Rails.logger).to receive(:info).with(/Ignoring.../)
-      tag.delete_and_update!(user)
+      tag.delete_by!(user)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -84,6 +84,10 @@ RSpec.configure do |config|
       }
     }
 
+    APP_CONFIG["background"] = {
+      "sync" => { "enabled" => false, "sync-strategy" => "initial" }
+    }
+
     Rails.cache.write("portus-checks", nil)
   end
 


### PR DESCRIPTION
This PR includes three commits:

- The first commit cleans up the changes from #1679 (adding tests and rebasing).
- The second commit rolls back any changes from the iteration if in the end it notices registry events (i.e. a push/delete happened while this task was being run). The idea is that this task should not conflict with the `registry` one, which has a higher priority.
- The third commit adds a `sync-strategy` option, which depends on the changes from #1631. This way we allow people to tune this task further. Then, if enabled we will provide four more options, which range from a riskier approach (current behavior), to safer ones. The idea is that this task has given us quite some headaches, so we will default to the safest (and probably the most useful) behavior.