### PR TITLE
api: added a bootstrap endpoint

### DIFF
--- a/bin/ci.sh
+++ b/bin/ci.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -ex
 
 ##
 # Auxiliar functions
@@ -57,7 +57,7 @@ bundle exec rake test:git
 
 # Style and security checks
 bundle exec rubocop -V
-bundle exec rubocop -F
+bundle exec rubocop --extra-details --display-style-guide --display-cop-names
 
 # Compile assets
 bundle exec rake portus:assets:compile

--- a/config/config.yml
+++ b/config/config.yml
@@ -163,12 +163,18 @@ oauth:
       # Only members of team can sign in/up with Bitbucket. Need permission to read team membership.
       team: ""
 
-# Set first_user_admin to true if you want that the first user that signs up
-# to be an admin.
+# When enabled (default value), the first users to be created on the UI will be
+# a Portus admin. If you disable this, then, in order to set the admin user, you
+# will need to run: rake portus:make_admin[USERNAME].
 #
-# Set to false otherwise. Then you will need to run
-#   rake portus:make_admin[USERNAME]
-# in order to set the admin user
+# Moreover, if you set this option to false, then the POST
+# /api/v1/users/bootstrap endpoint will be disabled (since it will try to create
+# the first user as an administrator).
+#
+# Thus, only set this option to false if you are really sure that you have
+# direct access to your Portus instance and it can be reached by other people on
+# your network. Otherwise, leave the default value and create your first admin
+# user right away (either through the API or the UI).
 first_user_admin:
   enabled: true
 

--- a/lib/api/helpers/application_tokens.rb
+++ b/lib/api/helpers/application_tokens.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module API
+  module Helpers
+    # Helpers regarding the management of authentication tokens. This module
+    # mostly contains methods that are shared across different paths.
+    module ApplicationTokens
+      # Create an application token for the given user with the given
+      # ID. The `params` parameter contains the parameters to be passed to the
+      # `ApplicationToken.create_token` method as `params`.
+      #
+      # This method already sends the proper HTTP response and code.
+      def create_application_token!(user, id, params)
+        if user.valid?
+          application_token, plain_token = ApplicationToken.create_token(
+            current_user: user,
+            user_id:      id,
+            params:       params
+          )
+
+          if application_token.errors.empty?
+            status 201
+            { plain_token: plain_token }
+          else
+            bad_request!(application_token.errors)
+          end
+        else
+          bad_request!(user.errors)
+        end
+      end
+    end
+  end
+end

--- a/lib/api/helpers/errors.rb
+++ b/lib/api/helpers/errors.rb
@@ -1,0 +1,58 @@
+
+# frozen_string_literal: true
+
+require "portus/auth_from_token"
+
+module API
+  module Helpers
+    # Errors implements helper methods for API error responses.
+    module Errors
+      def api_error!(code:, messages:)
+        obj = messages.is_a?(String) ? [messages] : messages
+        error!(obj, code)
+      end
+
+      # Sends a `400 Bad Request` error with a possible message as the response
+      # body.
+      def bad_request!(msg = "Bad Request")
+        api_error!(code: 400, messages: msg)
+      end
+
+      # Sends a `401 Unauthorized` error with a possible message as the response
+      # body.
+      def unauthorized!(msg = "Unauthorized")
+        api_error!(code: 401, messages: msg)
+      end
+
+      # Sends a `403 Forbidden` error with a possible message as the response
+      # body.
+      def forbidden!(msg = "Forbidden")
+        api_error!(code: 403, messages: msg)
+      end
+
+      # Sends a `404 Not found` error with a possible message as the response
+      # body.
+      def not_found!(msg = "Not found")
+        api_error!(code: 404, messages: msg)
+      end
+
+      # Sends a `405 Method Not Allowed` error with a possible message as the
+      # response body.
+      def method_not_allowed!(msg = "Method Not Allowed")
+        api_error!(code: 405, messages: msg)
+      end
+
+      # Sends a `422 Unprocessable Entity` error with a possible message as the
+      # response body.
+      def unprocessable_entity!(msg = "Unprocessable Entity")
+        api_error!(code: 422, messages: msg)
+      end
+
+      # Sends a `405 Internal Server Error` error with a possible message as the
+      # response body.
+      def internal_server_error!(msg = "Internal Server Error")
+        api_error!(code: 500, messages: msg)
+      end
+    end
+  end
+end

--- a/lib/api/helpers/namespaces.rb
+++ b/lib/api/helpers/namespaces.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module API
+  module Helpers
+    # Helpers for namespaces
+    module Namespaces
+      # Returns an aggregate of the accessible namespaces for the current user.
+      def accessible_namespaces
+        special = Namespace.special_for(current_user).order(created_at: :asc)
+        normal  = policy_scope(Namespace).order(created_at: :asc)
+        special + normal
+      end
+    end
+  end
+end

--- a/lib/api/v1/namespaces.rb
+++ b/lib/api/v1/namespaces.rb
@@ -76,7 +76,7 @@ module API
                     current_user: current_user,
                     type:         current_type
           else
-            error!({ "errors" => namespace.errors.full_messages }, 422, header)
+            unprocessable_entity!(namespace.errors.full_messages)
           end
         end
 

--- a/lib/api/v1/repositories.rb
+++ b/lib/api/v1/repositories.rb
@@ -121,7 +121,7 @@ module API
             destroy_service = ::Repositories::DestroyService.new(current_user)
             destroyed = destroy_service.execute(repository)
 
-            error!({ "errors" => destroy_service.error }, 422, header) unless destroyed
+            error!(destroy_service.error, 422, header) unless destroyed
           end
         end
       end

--- a/lib/api/v1/teams.rb
+++ b/lib/api/v1/teams.rb
@@ -48,7 +48,7 @@ module API
                     current_user: current_user,
                     type:         current_type
           else
-            error!({ "errors" => team.errors.full_messages }, 422, header)
+            unprocessable_entity!(team.errors.full_messages)
           end
         end
 

--- a/lib/api/v1/users.rb
+++ b/lib/api/v1/users.rb
@@ -1,209 +1,242 @@
 # frozen_string_literal: true
 
+require "api/helpers/application_tokens"
+
 module API
   module V1
     # Users implements all the endpoints regarding users and application tokens.
     class Users < Grape::API
       version "v1", using: :path
 
-      resource :users do
-        before do
-          authorization!(force_admin: true)
-        end
+      helpers ::API::Helpers::ApplicationTokens
 
-        route_param :id, type: Integer do
+      resource :users do
+        namespace do
+          before do
+            authorization!(force_admin: true)
+          end
+
+          route_param :id, type: Integer do
+            resource :application_tokens do
+              # List application tokens beloged to user with given :id.
+              desc "Returns list of user's tokens",
+                   params:   API::Entities::Users.documentation.slice(:id),
+                   is_array: true,
+                   entity:   API::Entities::ApplicationTokens,
+                   failure:  [
+                     [401, "Authentication fails"],
+                     [403, "Authorization fails"],
+                     [404, "Not found"]
+                   ]
+
+              get do
+                user = User.find params[:id]
+                present user.application_tokens,
+                        with: API::Entities::ApplicationTokens
+              end
+
+              # Create application token for user with given :id.
+              desc "Create user's token",
+                   params:   API::Entities::Users.documentation.slice(:id),
+                   success:  { code: 200 },
+                   entity:   API::Entities::ApplicationTokens,
+                   failure:  [
+                     [400, "Bad request", API::Entities::ApiErrors],
+                     [401, "Authentication fails"],
+                     [403, "Authorization fails"]
+                   ],
+                   consumes: ["application/x-www-form-urlencoded", "application/json"]
+
+              params do
+                requires :application, documentation: { desc: "Application name" }
+              end
+
+              post do
+                create_application_token!(@user, params[:id], declared(params.slice(:application)))
+              end
+            end
+          end
+
           resource :application_tokens do
-            # List application tokens beloged to user with given :id.
-            desc "Returns list of user's tokens",
-                 params:   API::Entities::Users.documentation.slice(:id),
-                 is_array: true,
-                 entity:   API::Entities::ApplicationTokens,
-                 failure:  [
+            desc "Delete application token",
+                 failure: [
                    [401, "Authentication fails"],
                    [403, "Authorization fails"],
                    [404, "Not found"]
                  ]
 
-            get do
-              user = User.find params[:id]
-              present user.application_tokens,
-                      with: API::Entities::ApplicationTokens
-            end
-
-            # Create application token for user with given :id.
-            desc "Create user's token",
-                 params:   API::Entities::Users.documentation.slice(:id),
-                 success:  { code: 200 },
-                 entity:   API::Entities::ApplicationTokens,
-                 failure:  [
-                   [400, "Bad request", API::Entities::ApiErrors],
-                   [401, "Authentication fails"],
-                   [403, "Authorization fails"]
-                 ],
-                 consumes: ["application/x-www-form-urlencoded", "application/json"]
-
             params do
-              requires :application, documentation: { desc: "Application name" }
+              requires :id, documentation: { desc: "Token id" }
             end
 
-            post do
-              application_token, plain_token = ApplicationToken.create_token(
-                current_user: @user,
-                user_id:      params[:id],
-                params:       declared(params.slice(:application))
-              )
-
-              if application_token.errors.empty?
-                status 200
-                { plain_token: plain_token }
-              else
-                status 400
-                { errors: application_token.errors }
-              end
+            delete ":id" do
+              token = ApplicationToken.find(params[:id])
+              token.create_activity! :destroy, @user
+              token.destroy
+              status 204
             end
           end
-        end
 
-        resource :application_tokens do
-          desc "Delete application token",
+          desc "Create new user",
+               failure:  [
+                 [400, "Bad request", API::Entities::ApiErrors],
+                 [401, "Authentication fails"],
+                 [403, "Authorization fails"]
+               ],
+               entity:   API::Entities::Users,
+               consumes: ["application/x-www-form-urlencoded", "application/json"]
+
+          params do
+            requires :user, type: Hash do
+              requires :all,
+                       only:  %i[username email],
+                       using: API::Entities::Users.documentation.slice(:username, :email)
+              requires :password, type: String, documentation: { desc: "Password" }
+              optional :all,
+                       only:  [:display_name],
+                       using: API::Entities::Users.documentation.slice(:display_name)
+            end
+          end
+
+          post do
+            user = User.create declared(params)[:user]
+            if user.valid?
+              present user, with: API::Entities::Users
+            else
+              bad_request!(user.errors)
+            end
+          end
+
+          # Update user with given :id.
+          desc "Update user",
+               params:   API::Entities::Users.documentation.slice(:id),
+               failure:  [
+                 [400, "Bad request", API::Entities::ApiErrors],
+                 [401, "Authentication fails"],
+                 [403, "Authorization fails"],
+                 [404, "Not found"]
+               ],
+               entity:   API::Entities::Users,
+               consumes: ["application/x-www-form-urlencoded", "application/json"]
+
+          params do
+            requires :user, type: Hash do
+              optional :all,
+                       only:  %i[username email],
+                       using: API::Entities::Users.documentation.slice(:username, :email)
+              optional :password, type: String, desc: "Password"
+              optional :all,
+                       only:  [:display_name],
+                       using: API::Entities::Users.documentation.slice(:display_name)
+            end
+          end
+
+          put ":id" do
+            attrs = declared(params, include_missing: false)[:user]
+            user = User.update(params[:id], attrs)
+            if user.valid?
+              present user, with: API::Entities::Users
+            else
+              status 400
+              { errors: user.errors }
+            end
+          end
+
+          # Delete user with given :id.
+          desc "Delete user",
+               params:  API::Entities::Users.documentation.slice(:id),
                failure: [
                  [401, "Authentication fails"],
                  [403, "Authorization fails"],
                  [404, "Not found"]
                ]
-
-          params do
-            requires :id, documentation: { desc: "Token id" }
-          end
 
           delete ":id" do
-            token = ApplicationToken.find(params[:id])
-            token.create_activity! :destroy, @user
-            token.destroy
+            user = User.find(params[:id])
+            user.update_activities! @user
+            user.destroy
             status 204
           end
-        end
 
-        desc "Create new user",
-             failure:  [
-               [400, "Bad request", API::Entities::ApiErrors],
-               [401, "Authentication fails"],
-               [403, "Authorization fails"]
-             ],
-             entity:   API::Entities::Users,
-             consumes: ["application/x-www-form-urlencoded", "application/json"]
-
-        params do
-          requires :user, type: Hash do
-            requires :all,
-                     only:  %i[username email],
-                     using: API::Entities::Users.documentation.slice(:username, :email)
-            requires :password, type: String, documentation: { desc: "Password" }
-            optional :all,
-                     only:  [:display_name],
-                     using: API::Entities::Users.documentation.slice(:display_name)
-          end
-        end
-
-        post do
-          user = User.create declared(params)[:user]
-          if user.valid?
-            present user, with: API::Entities::Users
-          else
-            status 400
-            { errors: user.errors }
-          end
-        end
-
-        # Update user with given :id.
-        desc "Update user",
-             params:   API::Entities::Users.documentation.slice(:id),
-             failure:  [
-               [400, "Bad request", API::Entities::ApiErrors],
-               [401, "Authentication fails"],
-               [403, "Authorization fails"],
-               [404, "Not found"]
-             ],
-             entity:   API::Entities::Users,
-             consumes: ["application/x-www-form-urlencoded", "application/json"]
-
-        params do
-          requires :user, type: Hash do
-            optional :all,
-                     only:  %i[username email],
-                     using: API::Entities::Users.documentation.slice(:username, :email)
-            optional :password, type: String, desc: "Password"
-            optional :all,
-                     only:  [:display_name],
-                     using: API::Entities::Users.documentation.slice(:display_name)
-          end
-        end
-
-        put ":id" do
-          attrs = declared(params, include_missing: false)[:user]
-          user = User.update(params[:id], attrs)
-          if user.valid?
-            present user, with: API::Entities::Users
-          else
-            status 400
-            { errors: user.errors }
-          end
-        end
-
-        # Delete user with given :id.
-        desc "Delete user",
-             params:  API::Entities::Users.documentation.slice(:id),
-             failure: [
-               [401, "Authentication fails"],
-               [403, "Authorization fails"],
-               [404, "Not found"]
-             ]
-
-        delete ":id" do
-          user = User.find(params[:id])
-          user.update_activities! @user
-          user.destroy
-          status 204
-        end
-
-        desc "Returns list of users",
-             tags:     ["users"],
-             detail:   "This will expose all users",
-             is_array: true,
-             entity:   API::Entities::Users,
-             failure:  [
-               [401, "Authentication fails"],
-               [403, "Authorization fails"]
-             ]
-
-        get do
-          users = User.all
-          present users, with: API::Entities::Users
-        end
-
-        route_param :id, type: String, requirements: { id: /.*/ } do
-          # Find user by id or email and return.
-          desc "Show user by id or email",
-               entity:  API::Entities::Users,
-               failure: [
+          desc "Returns list of users",
+               tags:     ["users"],
+               detail:   "This will expose all users",
+               is_array: true,
+               entity:   API::Entities::Users,
+               failure:  [
                  [401, "Authentication fails"],
-                 [403, "Authorization fails"],
-                 [404, "Not found"]
+                 [403, "Authorization fails"]
                ]
 
-          params do
-            requires :id, type: String, documentation: { desc: "User ID or email" }
+          get do
+            users = User.all
+            present users, with: API::Entities::Users
           end
 
-          get do
-            user = begin
-              User.find params[:id]
-            rescue ActiveRecord::RecordNotFound
-              nil
+          route_param :id, type: String, requirements: { id: /.*/ } do
+            # Find user by id or email and return.
+            desc "Show user by id or email",
+                 entity:  API::Entities::Users,
+                 failure: [
+                   [401, "Authentication fails"],
+                   [403, "Authorization fails"],
+                   [404, "Not found"]
+                 ]
+
+            params do
+              requires :id, type: String, documentation: { desc: "User ID or email" }
             end
-            user ||= User.find_by(email: params[:id])
-            raise ActiveRecord::RecordNotFound unless user
-            present user, with: API::Entities::Users
+
+            get do
+              user = begin
+                       User.find params[:id]
+                     rescue ActiveRecord::RecordNotFound
+                       nil
+                     end
+              user ||= User.find_by(email: params[:id])
+              raise ActiveRecord::RecordNotFound unless user
+              present user, with: API::Entities::Users
+            end
+          end
+        end
+
+        namespace do
+          desc "Create the first admin user",
+               failure:  [[400, "Bad request", API::Entities::ApiErrors]],
+               detail:   "Use this method to create the first admin user. The" \
+                         " response will include an application token so you can use this user" \
+                         " right away. This method should be used when bootstrapping a Portus" \
+                         " instance by using the REST API. Last but not least, it will" \
+                         " respond with a 405 if the `first_user_admin` configuration value" \
+                         " has been disabled",
+               tags:     ["users"],
+               entity:   API::Entities::ApplicationTokens,
+               consumes: ["application/x-www-form-urlencoded", "application/json"]
+
+          params do
+            requires :user, type: Hash do
+              requires :all,
+                       only:  %i[username email],
+                       using: API::Entities::Users.documentation.slice(:username, :email)
+              requires :password, type: String, documentation: { desc: "Password" }
+              optional :all,
+                       only:  [:display_name],
+                       using: API::Entities::Users.documentation.slice(:display_name)
+            end
+          end
+
+          post "/bootstrap" do
+            if !APP_CONFIG.enabled?("first_user_admin")
+              method_not_allowed!("this instance has disabled this endpoint")
+            elsif User.not_portus.any?
+              bad_request!("you can only use this when there are no users on the system")
+            else
+              ps = declared(params)[:user]
+              ps[:admin] = true
+
+              user = User.create ps
+              create_application_token!(user, user.id, application: "bootstrap")
+            end
           end
         end
       end


### PR DESCRIPTION
This new endpoint lives inside of the user namespace and its main goal is to
allow people to create the first admin user from the API. This endpoint is only
allowed if the `first_user_admin` option has not been disabled. Another
restriction is that there shouldn't be a user already created. Last but not
least, this method can be called without being authenticated.

In the ideal case, you would call this method when you just started your Portus
instance. Then, you will get the first user created
(same arguments as `POST /api/v1/users`) and it will also get an application
token assigned to it. The reponse will be the `plain_token` from the application
token. Thus, the whole point of this method is to follow this workflow:

1. Portus instance deployed.
2. Admin uses this bootstrap endpoint to create the admin user and get an
   application token.
3. With this application token the admin starts to administrate the
   instance (e.g. register the registry on Portus) entirely from the API.
4. Admin makes the Portus instance available inside of the organization and
   starts structuring it inside of Portus.

Finally, this commit also started to make error responses more uniform. This was
firstly done to DRY some of the code created by this feature. It probably needs
more work (see #1437).

See #1412

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>