### PR TITLE
Renamed from sync-strategy to strategy

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -302,4 +302,4 @@ background:
     #   - initial: like `on-start`, but it only runs if the database is
     #     empty. This is the default value since it's deemed to be the most
     #     common use-case.
-    sync-strategy: initial
+    strategy: initial

--- a/lib/portus/background/sync.rb
+++ b/lib/portus/background/sync.rb
@@ -19,7 +19,7 @@ module Portus
       def work?
         return false unless APP_CONFIG.enabled?("background.sync")
 
-        val = APP_CONFIG["background"]["sync"]["sync-strategy"]
+        val = APP_CONFIG["background"]["sync"]["strategy"]
         case val
         when "update-delete", "update"
           true
@@ -28,14 +28,14 @@ module Portus
         when "initial"
           !@executed && !Repository.any?
         else
-          Rails.logger.error "Unrecognized value '#{val}' for sync-strategy"
+          Rails.logger.error "Unrecognized value '#{val}' for strategy"
           false
         end
       end
 
       def enabled?
         if APP_CONFIG.enabled?("background.sync")
-          strategy = APP_CONFIG["background"]["sync"]["sync-strategy"]
+          strategy = APP_CONFIG["background"]["sync"]["strategy"]
           if strategy == "initial" && Repository.any?
             Rails.logger.info "`#{self}` was disabled because strategy is set to " \
                               "'initial' and the database is not empty"
@@ -69,7 +69,7 @@ module Portus
       # This task will be asked to be disable if the strategy was set to
       # "on-start" or "initial", and the first execution has already been done.
       def disable?
-        strategy = APP_CONFIG["background"]["sync"]["sync-strategy"]
+        strategy = APP_CONFIG["background"]["sync"]["strategy"]
         if strategy == "initial" || strategy == "on-start"
           @executed
         else
@@ -113,7 +113,7 @@ module Portus
 
       # Delete the given repositories unless the configuration does not allow it.
       def delete_maybe!(repositories)
-        return if APP_CONFIG["background"]["sync"]["sync-strategy"] == "update"
+        return if APP_CONFIG["background"]["sync"]["strategy"] == "update"
 
         portus = User.find_by(username: "portus")
         Tag.where(repository_id: repositories).find_each { |t| t.delete_by!(portus) }

--- a/spec/lib/portus/background/sync_spec.rb
+++ b/spec/lib/portus/background/sync_spec.rb
@@ -13,8 +13,8 @@ end
 describe ::Portus::Background::Sync do
   before do
     APP_CONFIG["background"]["sync"] = {
-      "enabled"       => true,
-      "sync-strategy" => "update-delete"
+      "enabled"  => true,
+      "strategy" => "update-delete"
     }
   end
 
@@ -31,22 +31,22 @@ describe ::Portus::Background::Sync do
     end
 
     it "returns false on an unrecognized value" do
-      APP_CONFIG["background"]["sync"]["sync-strategy"] = "Wubba Lubba Dub Dub"
+      APP_CONFIG["background"]["sync"]["strategy"] = "Wubba Lubba Dub Dub"
 
       expect(Rails.logger).to receive(:error).with("Unrecognized value " \
-                                                   "'Wubba Lubba Dub Dub' for sync-strategy")
+                                                   "'Wubba Lubba Dub Dub' for strategy")
       expect(subject.work?).to be_falsey
     end
 
     it "returns true if it's update or update-delete" do
-      APP_CONFIG["background"]["sync"]["sync-strategy"] = "update"
+      APP_CONFIG["background"]["sync"]["strategy"] = "update"
       expect(subject.work?).to be_truthy
-      APP_CONFIG["background"]["sync"]["sync-strategy"] = "update-delete"
+      APP_CONFIG["background"]["sync"]["strategy"] = "update-delete"
       expect(subject.work?).to be_truthy
     end
 
     it "returns the same value as @executed on 'on-start'" do
-      APP_CONFIG["background"]["sync"]["sync-strategy"] = "on-start"
+      APP_CONFIG["background"]["sync"]["strategy"] = "on-start"
       expect(subject.work?).to be_truthy
 
       create(:registry)
@@ -58,7 +58,7 @@ describe ::Portus::Background::Sync do
     end
 
     it "returns the same value as @executed on 'initial'" do
-      APP_CONFIG["background"]["sync"]["sync-strategy"] = "initial"
+      APP_CONFIG["background"]["sync"]["strategy"] = "initial"
       expect(subject.work?).to be_truthy
 
       create(:registry)
@@ -70,7 +70,7 @@ describe ::Portus::Background::Sync do
     end
 
     it "returns true if on 'initial' if there was no registry" do
-      APP_CONFIG["background"]["sync"]["sync-strategy"] = "initial"
+      APP_CONFIG["background"]["sync"]["strategy"] = "initial"
       expect(subject.work?).to be_truthy
       subject.execute!
       expect(subject.work?).to be_truthy
@@ -202,7 +202,7 @@ describe ::Portus::Background::Sync do
       end
 
       it "does not remove old repositories if we are using 'update'" do
-        APP_CONFIG["background"]["sync"]["sync-strategy"] = "update"
+        APP_CONFIG["background"]["sync"]["strategy"] = "update"
 
         allow_any_instance_of(::Portus::RegistryClient).to receive(:manifest).and_return(["", ""])
 
@@ -300,8 +300,8 @@ describe ::Portus::Background::Sync do
 
     it "returns false on initial if there are repositories" do
       APP_CONFIG["background"]["sync"] = {
-        "enabled"       => true,
-        "sync-strategy" => "initial"
+        "enabled"  => true,
+        "strategy" => "initial"
       }
 
       registry = create(:registry)
@@ -316,14 +316,14 @@ describe ::Portus::Background::Sync do
 
   describe "#disable?" do
     it "returns false on update or update-delete" do
-      APP_CONFIG["background"]["sync"]["sync-strategy"] = "update"
+      APP_CONFIG["background"]["sync"]["strategy"] = "update"
       expect(subject.disable?).to be_falsey
-      APP_CONFIG["background"]["sync"]["sync-strategy"] = "update-delete"
+      APP_CONFIG["background"]["sync"]["strategy"] = "update-delete"
       expect(subject.disable?).to be_falsey
     end
 
     it "returns whatever @executed contains on initial" do
-      APP_CONFIG["background"]["sync"]["sync-strategy"] = "initial"
+      APP_CONFIG["background"]["sync"]["strategy"] = "initial"
       expect(subject.disable?).to be_falsey
 
       create(:registry)
@@ -335,7 +335,7 @@ describe ::Portus::Background::Sync do
     end
 
     it "returns whatever @executed contains on on-start" do
-      APP_CONFIG["background"]["sync"]["sync-strategy"] = "on-start"
+      APP_CONFIG["background"]["sync"]["strategy"] = "on-start"
       expect(subject.disable?).to be_falsey
 
       create(:registry)
@@ -347,7 +347,7 @@ describe ::Portus::Background::Sync do
     end
 
     it "returns false if no registry was set" do
-      APP_CONFIG["background"]["sync"]["sync-strategy"] = "initial"
+      APP_CONFIG["background"]["sync"]["strategy"] = "initial"
       expect(subject.disable?).to be_falsey
       subject.execute!
       expect(subject.disable?).to be_falsey

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -85,7 +85,7 @@ RSpec.configure do |config|
     }
 
     APP_CONFIG["background"] = {
-      "sync" => { "enabled" => false, "sync-strategy" => "initial" }
+      "sync" => { "enabled" => false, "strategy" => "initial" }
     }
 
     Rails.cache.write("portus-checks", nil)


### PR DESCRIPTION
The `sync` part was redundant since it was already under the `sync`
option.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>