### PR TITLE
Updated the documentation for contributors

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,40 @@
+### Description
+
+Check out the `CONTRIBUTING.md` file for some considerations before submitting a
+new issue.
+
+### Steps to reproduce
+
+1. First I did this...
+2. Then that...
+3. And this happened!
+
+- **Expected behavior**: I expected this to happen!
+- **Actual behavior**: But this happened...
+
+Providing logs of the moment when the issue has happened would also be
+useful. If you are in production, you might want to set the `PORTUS_LOG_LEVEL`
+to `debug` to get a more verbose log.
+
+### Deployment information
+
+**Deployment method**: how have you deployed Portus? Are you using one of the
+[examples](https://github.com/SUSE/Portus/tree/master/examples) as a base? If
+possible, could you paste your configuration? (don't forget to strip passwords
+or other sensitive data!)
+
+**Configuration**:
+
+You can get this information like this:
+
+- In bare metal execute: `bundle exec rake portus:info`.
+- In a container:
+  - Using the development `docker-compose.yml` file: `docker exec -it <container-id> bundle exec rake portus:info`.
+  - Using the [production image](https://hub.docker.com/r/opensuse/portus/): `docker exec -it <container-id> portusctl exec rake portus:info`.
+
+```yml
+CONFIG HERE
+```
+
+**Portus version**: with commit if possible. You can get this info too with the
+above commands.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+### Summary
+
+Provide a general description of the changes in your pull request. If this pull
+request fixes a known issue, please tag it as well (e.g.: `Fixes #1`). Check the
+`CONTRIBUTING.md` file for more information.
+
+Thanks for contributing to Portus!

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,30 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 90
+
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - blocked
+  - breaking change
+  - discussing
+  - junior job
+  - feature
+  - enhancement
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: true
+
+# Label to use when marking an issue as stale
+staleLabel: stale
+
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  Thanks for all your contributions!
+
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs.
+
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,31 +16,6 @@ Moreover, check whether it has already been reported
 - Add a comment only if you can provide helpful information that has not been
   provided in the discussion yet.
 
-If you want to report a **new issue**, please try to follow the following
-points if your issue is about Portus behaving in an unexpected manner:
-
-- Tell us the setup you're using. It can be as simple as:
-  - The docker-compose setup.
-  - The vagrant setup.
-  - The NGinx setup as described [here](http://port.us.org/docs/setups/3_nginx_bare_metal.html).
-  That being said, if you are using a custom setup explain to us how all the
-  pieces are glued together (you don't have to be too verbose, just specify the
-  most important stuff like configurations, etc.).
-- Paste the output of `rake portus:info` (or `portusctl rake portus:info` if
-  you are using the RPM).
-- If relevant, provide the related logs. If you are using the provided RPM,
-  this is as simple as just calling `portusctl logs`. Otherwise, provide the
-  contents of your `log/$environment.log` file, and the contents of the logs of
-  Apache/NGinx/etc. You don't have to provide *all* the contents, only the
-  relevant lines.
-- If possible, try to reproduce the same issue with logging set to `:debug`. You
-  can set this by modifying `config/environment/production.rb` (or whatever
-  environment you are in) and setting `config.log_level` to `:debug`. This will
-  give us more detailed logs. Another way to set this in production is by
-  setting the `PORTUS_LOG_LEVEL` environment variable to `debug`. Remember to
-  restart Portus when doing this.  And remember to set that value to `:info`
-  back again once you're done, otherwise your logs will grow quite rapidly!
-
 ## Check for assigned people
 
 We are using Github Issues for submitting known issues (e.g. bugs, features,
@@ -85,14 +60,6 @@ that all these changes have a comment explaining the reasoning behind it.
 
 Finally, note that `rubocop` is called on Travis-CI. This means that your Pull
 Request will not be merged until `rubocop` approves your changes.
-
-## Update the Changelog
-
-We keep a changelog in the `CHANGELOG.md` file. This is useful to understand
-what has changed between each version. When you implement a new feature, or a
-fix for an issue, please also update the `CHANGELOG.md` file accordingly. We
-don't follow a strict style for the changelog, just try to be consistent with
-the rest of the file.
 
 ## Sign your work
 


### PR DESCRIPTION
This PR includes two commits:

- The first one adds Github templates for issues and PR. This should not only help contributors, but also us since we'll hopefully get more detailed issues and PRs.
- The second commit adds [stale](https://github.com/probot/stale), which it's being used in some repos like Rails, Atom, etc. It marks *old* issues as stale, and it even closes them if there is no further activity. This should help us to detect old issues. Note that it will ignore some labels and issues which are already triaged in our projects.