### PR TITLE
test: added git-validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,10 @@ before_install:
   - sudo apt-get install yarn
   - yarn install
 
+  # Intall Go, which is needed for git-validation
+  - eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=1.8 bash)"
+  - go get -u github.com/vbatts/git-validation
+
 before_script:
   - mysql -e 'create database portus_test;'
   - psql -c 'create database portus_test' -U postgres
@@ -57,6 +61,9 @@ script:
 
   # JavaScript style
   - yarn eslint
+
+  # Test commit messages
+  - bundle exec rake test:git
 
 env:
   global:

--- a/lib/tasks/test/git-validate.rake
+++ b/lib/tasks/test/git-validate.rake
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "English"
+
+# We will start reviewing commit from this one.
+FROM_SHA = "7164d92ed6602786d9519399a2ceb1bcc49facb8"
+
+# Performs the given command, and optionally spits the output as it comes.
+def spawn_cmd(cmd:, output: true)
+  status = 0
+
+  PTY.spawn(cmd) do |stdout, _, pid|
+    if output
+      # rubocop:disable Lint/HandleExceptions
+      begin
+        stdout.each { |line| print line }
+      rescue Errno::EIO
+        # End of output
+      end
+      # rubocop:enable Lint/HandleExceptions
+    end
+
+    Process.wait(pid)
+    status = $CHILD_STATUS.exitstatus
+  end
+  status
+end
+
+# Returns true if the `git-validation` command is available.
+def git_validation?
+  spawn_cmd(cmd: "which git-validation", output: false).zero?
+end
+
+namespace :test do
+  desc "Run git-validate on the source code"
+  task git: :environment do
+    unless git_validation?
+      puts "[TEST] The git-validate command could not be found"
+      exit 1
+    end
+
+    path = Rails.root
+    status = spawn_cmd(cmd: "cd #{path} && git-validation -q -range #{FROM_SHA}..HEAD")
+    exit status
+  end
+end


### PR DESCRIPTION
This tool allows us to validate git commit messages. Since
git-validation will reports tons of errors when checking the current git
history, I'm providing a range instead. This range spans from the
previous non-merge commit up to HEAD.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>
