### PR TITLE
Make reply_to setting optional

### DIFF
--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -3,5 +3,5 @@
 # DeviseMailer is the mailer being used by Devise.
 class DeviseMailer < Devise::Mailer
   default from: "#{APP_CONFIG["email"]["name"]} <#{APP_CONFIG["email"]["from"]}>"
-  default reply_to: APP_CONFIG["email"]["reply_to"]
+  default reply_to: APP_CONFIG["email"]["reply_to"] if APP_CONFIG["email"]["reply_to"].present?
 end

--- a/config/config.yml
+++ b/config/config.yml
@@ -7,7 +7,9 @@
 email:
   from: "portus@example.com"
   name: "Portus"
-  reply_to: "no-reply@example.com"
+  # The reply_to field is empty, as the user has the possibility to enable
+  # it optionally by filling in the appropriate reply address.
+  reply_to: ""
 
   # If enabled, then SMTP will be used. Otherwise 'sendmail' will be used
   # (defaults to: /usr/sbin/sendmail -i -t).

--- a/config/initializers/mail.rb
+++ b/config/initializers/mail.rb
@@ -8,7 +8,7 @@ end
 
 unless Rails.env.test?
   check_email!("from")
-  check_email!("reply_to")
+  check_email!("reply_to") if APP_CONFIG["email"]["reply_to"].present?
 
   # If SMTP was set, then use it as the delivery method and configure it with the
   # given config.


### PR DESCRIPTION
Fixes #1693 .

Make sure that the email settings are not checked and therefore no error is raised, when "reply_to" is empty.