### PR TITLE
packaging: do not install empty portusctl

### DIFF
--- a/packaging/suse/portus.spec.in
+++ b/packaging/suse/portus.spec.in
@@ -152,9 +152,6 @@ mkdir %{buildroot}/%{portusdir}/log
 rm -rf %{buildroot}/%{portusdir}/tmp
 mkdir %{buildroot}/%{portusdir}/tmp
 
-install -d %{buildroot}/%{_sbindir}
-cp packaging/suse/bin/portusctl %{buildroot}/%{_sbindir}/
-
 %fdupes %{buildroot}/%{portusdir}
 
 %files


### PR DESCRIPTION
This is a leftover in which the RPM package tried to copy a (now
non-existant) portusctl to /usr/sbin.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>
