### PR TITLE
The OpenAPI should appear under openapi-spec and not swagger_doc

### DIFF
--- a/config/initializers/swagger.rb
+++ b/config/initializers/swagger.rb
@@ -7,6 +7,6 @@ unless Rails.env.production?
            ":#{val.last}" if val.size == 2
          end
 
-  GrapeSwaggerRails.options.url     = "/api/openapi-spec.json"
+  GrapeSwaggerRails.options.url     = "/api/openapi-spec"
   GrapeSwaggerRails.options.app_url = "#{protocol}#{APP_CONFIG["machine_fqdn"]["value"]}#{port}"
 end

--- a/lib/api/root_api.rb
+++ b/lib/api/root_api.rb
@@ -64,6 +64,7 @@ module API
     end
 
     add_swagger_documentation \
+      mount_path:           "/openapi-spec",
       security_definitions: {
         api_key: {
           type: "apiKey",


### PR DESCRIPTION
This is a fix for https://github.com/SUSE/Portus/pull/1656 The api wasn't still at the right place but the documentation was already updates. Now both the documentation and the the api are available under `/api/openapi-spec`