### PR TITLE
Implement a environment variable in config.yml, so that only admins can push images.

### DIFF
--- a/app/policies/namespace_policy.rb
+++ b/app/policies/namespace_policy.rb
@@ -30,10 +30,14 @@ class NamespacePolicy
   def push?
     raise Pundit::NotAuthorizedError, "must be logged in" unless user
 
-    # Only owners and contributors have WRITE access
-    user.admin? ||
-      namespace.team.owners.exists?(user.id) ||
-      namespace.team.contributors.exists?(user.id)
+    if APP_CONFIG.enabled?("user_permission.push_images")
+      # Only owner and contributors have WRITE access
+      user.admin? ||
+        namespace.team.owners.exists?(user.id) ||
+        namespace.team.contributors.exists?(user.id)
+    else
+      user.admin?
+    end
   end
 
   def index?

--- a/config/config.yml
+++ b/config/config.yml
@@ -248,6 +248,11 @@ user_permission:
   manage_namespace:
     enabled: true
 
+  # Allow users to push images to namespaces, where they are owner/contributor of.
+  # If this is disabled, only admins can push images. This defaults to true.
+  push_images:
+    enabled: true
+
 # Security scanner support. Add the server location for each driver in order to
 # enable it. If no drivers have been enabled, then this feature is skipped
 # altogether. Enabling multiple drivers will simply aggregate the information

--- a/spec/controllers/namespaces_controller_spec.rb
+++ b/spec/controllers/namespaces_controller_spec.rb
@@ -276,6 +276,19 @@ describe NamespacesController, type: :controller do
         expect(response.status).to eq(401)
         expect(namespace.reload.team.id).to eq team.id
       end
+
+      context "when option user_permission.push_images" do
+        before do
+          APP_CONFIG["user_permission"]["push_images"]["enabled"] = false
+        end
+
+        it "raises an authorization error when trying to change to a non-existing team" do
+          sign_in owner
+          patch :update, id: namespace.id, namespace: { team: "unknown" }, format: :json
+          expect(response.status). to eq(401)
+          expect(namespace.reload.team.id).to eq team.id
+        end
+      end
     end
 
     it "does not allow to change the team to viewers" do

--- a/spec/features/namespaces_spec.rb
+++ b/spec/features/namespaces_spec.rb
@@ -311,6 +311,26 @@ describe "Namespaces support" do
       expect(page).to have_content("Pull Viewer")
     end
 
+    context "when user_permission.push_images is disabled" do
+      before do
+        APP_CONFIG["user_permission"]["push_images"]["enabled"] = false
+      end
+
+      it "shows the proper visual aid for each role" do
+        login_as user
+        visit namespace_path(namespace.id)
+        expect(page).to have_content("Push Pull Owner")
+
+        login_as user2, scope: :user
+        visit namespace_path(namespace.id)
+        expect(page).not_to have_content("Push Pull Contr.")
+
+        login_as user3, scope: :user
+        visit namespace_path(namespace.id)
+        expect(page).to have_content("Pull Viewer")
+      end
+    end
+
     it "An user sees dropdown for 'Show webhooks'", js: true do
       visit namespace_path(namespace.id)
 

--- a/spec/features/repositories_spec.rb
+++ b/spec/features/repositories_spec.rb
@@ -131,6 +131,32 @@ describe "Repositories support" do
       expect(info).not_to have_content("You are a contributor in this repository")
     end
 
+    context "when user_permission.push_images is disabled" do
+      before do
+        APP_CONFIG["user_permission"]["push_images"]["enabled"] = false
+      end
+
+      it "Visual  aid for each role is shown properly" do
+        login_as user
+        visit repository_path(repository)
+        info = page.find(".repository-information-icon")["data-content"]
+        expect(info).to have_content("You can push images")
+        expect(info).to have_content("You can pull images")
+        expect(info).to have_content("You are an owner of this repository")
+        expect(info).not_to have_content("You are a contributor in this repository")
+        expect(info).not_to have_content("You are a viewer in this repository")
+
+        login_as user2, scope: :user
+        visit repository_path(repository)
+        info = page.find(".repository-information-icon")["data-content"]
+        expect(info).not_to have_content("You can push images")
+        expect(info).to have_content("You can pull images")
+        expect(info).not_to have_content("You are an owner of this repository")
+        expect(info).to have_content("You are a contributor in this repository")
+        expect(info).not_to have_content("You are a viewer in this repository")
+      end
+    end
+
     it "A user can star a repository", js: true do
       visit repository_path(repository)
       expect(page).to have_css("#toggle_star")

--- a/spec/helpers/repositories_helper_spec.rb
+++ b/spec/helpers/repositories_helper_spec.rb
@@ -33,6 +33,18 @@ RSpec.describe RepositoriesHelper, type: :helper do
       expect(message).to include("You can push images")
     end
 
+    context "when the user push permission is disabled" do
+      before do
+        APP_CONFIG["user_permission"]["push_images"]["enabled"] = false
+      end
+
+      it "shows you can push images only for admins" do
+        sign_in owner
+        message = helper.render_repository_information(repo)
+        expect(message).not_to include("You can push images")
+      end
+    end
+
     it "shows you can pull images" do
       sign_in owner
       message = helper.render_repository_information(repo)

--- a/spec/policies/namespace_policy_spec.rb
+++ b/spec/policies/namespace_policy_spec.rb
@@ -118,6 +118,38 @@ describe NamespacePolicy do
         expect(subject).not_to permit(user, registry.global_namespace)
       end
     end
+
+    context "when user_permission.push_images is disabled" do
+      before do
+        APP_CONFIG["user_permission"]["push_images"]["enabled"] = false
+      end
+
+      it "disallows access to user with viewer role" do
+        expect(subject).not_to permit(viewer, namespace)
+      end
+
+      it "disallows access to user with owner role" do
+        expect(subject).not_to permit(owner, namespace)
+      end
+
+      it "disallows access to user who is not part of the team" do
+        expect(subject).not_to permit(user, namespace)
+      end
+
+      it "disallows access to user who is not part of the team" do
+        expect(subject).not_to permit(user, namespace)
+      end
+
+      it "disallows access to user who is not logged in" do
+        expect do
+          subject.new(nil, namespace).push?
+        end.to raise_error(Pundit::NotAuthorizedError, /must be logged in/)
+      end
+
+      it "allows access to admin" do
+        expect(subject).to permit(@admin, namespace)
+      end
+    end
   end
 
   permissions :all? do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -71,7 +71,9 @@ RSpec.configure do |config|
       # This allows non-admins to modify teams
       "manage_team"       => { "enabled" => true },
       # This allows non-admins to create teams
-      "create_team"       => { "enabled" => true }
+      "create_team"       => { "enabled" => true },
+      # This allows non-admins to push images
+      "push_images"       => { "enabled" => true }
     }
 
     APP_CONFIG["security"] = {


### PR DESCRIPTION
Implement a environment variable in config.yml, so that only admins can push images.

New version of #1689.

Signed-off-by: Fabian Baumanis <fabian.baumanis@suse.com>
