### PR TITLE
policies: added more fine-grained push policies

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -259,10 +259,15 @@ user_permission:
   manage_namespace:
     enabled: true
 
-  # Allow users to push images to namespaces, where they are owner/contributor of.
-  # If this is disabled, only admins can push images. This defaults to true.
+  # Define a push policy. There are three possible values:
+  #   1. allow-teams (default): leaves push policy at the team level: owners and
+  #      contributors can push. Portus administrators will also be able to push.
+  #   2. allow-personal: regular users can only push into their personal
+  #      namespaces. Owners and contributors cannot push into team owned
+  #      repositories: only Portus administrators will be able to push.
+  #   3. admin-only: only Portus administrators can push.
   push_images:
-    enabled: true
+    policy: allow-teams
 
 # Security scanner support. Add the server location for each driver in order to
 # enable it. If no drivers have been enabled, then this feature is skipped

--- a/spec/controllers/namespaces_controller_spec.rb
+++ b/spec/controllers/namespaces_controller_spec.rb
@@ -279,7 +279,7 @@ describe NamespacesController, type: :controller do
 
       context "when option user_permission.push_images" do
         before do
-          APP_CONFIG["user_permission"]["push_images"]["enabled"] = false
+          APP_CONFIG["user_permission"]["push_images"]["policy"] = "allow-personal"
         end
 
         it "raises an authorization error when trying to change to a non-existing team" do

--- a/spec/features/namespaces_spec.rb
+++ b/spec/features/namespaces_spec.rb
@@ -311,9 +311,9 @@ describe "Namespaces support" do
       expect(page).to have_content("Pull Viewer")
     end
 
-    context "when user_permission.push_images is disabled" do
+    context "when user_permission.push_images is restricted" do
       before do
-        APP_CONFIG["user_permission"]["push_images"]["enabled"] = false
+        APP_CONFIG["user_permission"]["push_images"]["policy"] = "allow-personal"
       end
 
       it "shows the proper visual aid for each role" do

--- a/spec/features/repositories_spec.rb
+++ b/spec/features/repositories_spec.rb
@@ -133,7 +133,7 @@ describe "Feature: Repositories" do
 
     context "when user_permission.push_images is disabled" do
       before do
-        APP_CONFIG["user_permission"]["push_images"]["enabled"] = false
+        APP_CONFIG["user_permission"]["push_images"]["policy"] = "allow-personal"
       end
 
       it "Visual  aid for each role is shown properly" do

--- a/spec/helpers/repositories_helper_spec.rb
+++ b/spec/helpers/repositories_helper_spec.rb
@@ -33,9 +33,9 @@ RSpec.describe RepositoriesHelper, type: :helper do
       expect(message).to include("You can push images")
     end
 
-    context "when the user push permission is disabled" do
+    context "when the user push permission is restrictred" do
       before do
-        APP_CONFIG["user_permission"]["push_images"]["enabled"] = false
+        APP_CONFIG["user_permission"]["push_images"]["policy"] = "allow-personal"
       end
 
       it "shows you can push images only for admins" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -73,7 +73,7 @@ RSpec.configure do |config|
       # This allows non-admins to create teams
       "create_team"       => { "enabled" => true },
       # This allows non-admins to push images
-      "push_images"       => { "enabled" => true }
+      "push_images"       => { "policy" => "allow-teams" }
     }
 
     APP_CONFIG["security"] = {


### PR DESCRIPTION
Before this commit, an administrator was able to disable push control
entirely for regular users. This commit adds a more fine-grained
solution:

1. allow-teams: as usual.
2. allow-personal: team access is restricted: regular users can only
   push into their personal namespaces.
3. admin-only: only admins can push.

This should hopefully tackle more work flows inside of Portus.

Fixes #1528
See #1137

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>