### PR TITLE
spec: use another image for integration tests

### DIFF
--- a/bin/test-integration.sh
+++ b/bin/test-integration.sh
@@ -78,6 +78,11 @@ if [[ ! "$SKIP_ENV_TESTS" ]]; then
     fi
 fi
 
+# Integration tests will play with the following images
+export DEVEL_NAME="busybox"
+export DEVEL_IMAGE="$DEVEL_NAME:latest"
+docker pull $DEVEL_IMAGE
+
 # Run tests.
 tests=()
 if [[ -z "$TESTS" ]]; then

--- a/spec/integration/events.bats
+++ b/spec/integration/events.bats
@@ -10,8 +10,8 @@ function setup() {
     docker_run login -u admin -p 12341234 172.17.0.1:5000
     [ $status -eq 0 ]
 
-    docker_tag opensuse/portus:development 172.17.0.1:5000/portus:uniquetag
-    docker_run push 172.17.0.1:5000/portus:uniquetag
+    docker_tag $DEVEL_IMAGE 172.17.0.1:5000/test:uniquetag
+    docker_run push 172.17.0.1:5000/test:uniquetag
     [ $status -eq 0 ]
 
     helper_runner wait_event_done.rb uniquetag
@@ -28,8 +28,8 @@ function setup() {
     docker_run login -u admin -p 12341234 172.17.0.1:5000
     [ $status -eq 0 ]
 
-    docker_tag opensuse/portus:development 172.17.0.1:5000/portus:uniquetag
-    docker_run push 172.17.0.1:5000/portus:uniquetag
+    docker_tag $DEVEL_IMAGE 172.17.0.1:5000/test:uniquetag
+    docker_run push 172.17.0.1:5000/test:uniquetag
     [ $status -eq 0 ]
 
     helper_runner wait_event_done.rb uniquetag
@@ -39,7 +39,7 @@ function setup() {
     [[ "${lines[-1]}" =~ "1" ]]
 
     # And now let's delete this tag.
-    helper_runner delete.rb portus uniquetag
+    helper_runner delete.rb test uniquetag
     [ $status -eq 0 ]
 
     helper_runner wait_event_done.rb uniquetag pickfirst

--- a/spec/integration/push.bats
+++ b/spec/integration/push.bats
@@ -13,8 +13,8 @@ function setup() {
     docker_run login -u admin -p 12341234 172.17.0.1:5000
     [ $status -eq 0 ]
 
-    docker_tag opensuse/portus:development 172.17.0.1:5000/portus:development
-    docker_run push 172.17.0.1:5000/portus:development
+    docker_tag $DEVEL_IMAGE 172.17.0.1:5000/test:development
+    docker_run push 172.17.0.1:5000/test:development
 
     [ $status -eq 0 ]
     [[ "${lines[-1]}" =~ "development: digest: sha256:" ]]
@@ -24,9 +24,9 @@ function setup() {
     docker_run login -u admin -p 12341234 172.17.0.1:5000
     [ $status -eq 0 ]
 
-    docker_tag opensuse/portus:development 172.17.0.1:5000/portus:development
-    docker_tag opensuse/portus:development 172.17.0.1:5000/portus:development2
-    docker_run push 172.17.0.1:5000/portus
+    docker_tag $DEVEL_IMAGE 172.17.0.1:5000/test:development
+    docker_tag $DEVEL_IMAGE 172.17.0.1:5000/test:development2
+    docker_run push 172.17.0.1:5000/test
 
     [ $status -eq 0 ]
 }
@@ -35,8 +35,8 @@ function setup() {
     docker_run login -u user -p 12341234 172.17.0.1:5000
     [ $status -eq 0 ]
 
-    docker_tag opensuse/portus:development 172.17.0.1:5000/portus:development
-    docker_run push 172.17.0.1:5000/portus:development
+    docker_tag $DEVEL_IMAGE 172.17.0.1:5000/test:development
+    docker_run push 172.17.0.1:5000/test:development
 
     [ $status -eq 1 ]
     [[ "${lines[-1]}" =~ "authentication required" ]]
@@ -48,8 +48,8 @@ function setup() {
 
     docker_run login -u user -p 12341234 172.17.0.1:5000
 
-    docker_tag opensuse/portus:development 172.17.0.1:5000/portus:development
-    docker_run push 172.17.0.1:5000/portus:development
+    docker_tag $DEVEL_IMAGE 172.17.0.1:5000/test:development
+    docker_run push 172.17.0.1:5000/test:development
     [ $status -eq 1 ]
 }
 
@@ -62,11 +62,11 @@ function setup() {
 
     # Contributor can push and pull
 
-    docker_tag opensuse/portus:development 172.17.0.1:5000/namespace/portus:development
-    docker_run push 172.17.0.1:5000/namespace/portus:development
+    docker_tag $DEVEL_IMAGE 172.17.0.1:5000/namespace/test:development
+    docker_run push 172.17.0.1:5000/namespace/test:development
     [ $status -eq 0 ]
 
-    docker_run pull 172.17.0.1:5000/namespace/portus:development
+    docker_run pull 172.17.0.1:5000/namespace/test:development
     [ $status -eq 0 ]
 
     # Viewer can only push
@@ -74,9 +74,9 @@ function setup() {
     __logout
     docker_run login -u viewer -p 12341234 172.17.0.1:5000
 
-    docker_run push 172.17.0.1:5000/namespace/portus:development
+    docker_run push 172.17.0.1:5000/namespace/test:development
     [ $status -eq 1 ]
 
-    docker_run pull 172.17.0.1:5000/namespace/portus:development
+    docker_run pull 172.17.0.1:5000/namespace/test:development
     [ $status -eq 0 ]
 }


### PR DESCRIPTION
From now on we will rely on an image that is known to be always there,
regardless of the environment.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>