### PR TITLE
api: use 422 when applicable

### DIFF
--- a/app/middleware/catch_json_parse_errors.rb
+++ b/app/middleware/catch_json_parse_errors.rb
@@ -14,7 +14,7 @@ class CatchJsonParseErrors
     error_output = "There was a problem in the JSON you submitted: #{error}"
     [
       400, { "Content-Type" => "application/json" },
-      [{ status: 400, error: error_output }.to_json]
+      [{ message: error_output }.to_json]
     ]
   end
 end

--- a/app/services/registries/create_service.rb
+++ b/app/services/registries/create_service.rb
@@ -28,7 +28,7 @@ module Registries
     def check_uniqueness!
       return unless Registry.any?
       @valid = false
-      @messages[:uniqueness] = "You can only create one registry"
+      @messages[:uniqueness] = ["You can only create one registry"]
     end
   end
 end

--- a/app/services/registries/update_service.rb
+++ b/app/services/registries/update_service.rb
@@ -10,7 +10,7 @@ module Registries
 
       check!
       if @valid
-        @messages.merge(@registry.errors.messages) unless @registry.save
+        @messages.merge(@registry.errors) unless @registry.save
       end
 
       @registry
@@ -28,7 +28,7 @@ module Registries
     def check_hostname!
       return if !Repository.any? || params[:hostname].blank?
       @valid = false
-      @messages[:hostname] = "Registry is not empty, cannot change hostname"
+      @messages[:hostname] = ["Registry is not empty, cannot change hostname"]
     end
   end
 end

--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -7,8 +7,16 @@ module API
     # General entities
 
     class ApiErrors < Grape::Entity
-      expose :errors, documentation: {
-        type: "API::Entities::Messages", is_array: true
+      expose :message, documentation: {
+        type: String,
+        desc: "Error message"
+      }
+    end
+
+    class FullApiErrors < Grape::Entity
+      expose :message, documentation: {
+        type: Hash,
+        desc: "Detailed hash with the fields"
       }
     end
 

--- a/lib/api/helpers/application_tokens.rb
+++ b/lib/api/helpers/application_tokens.rb
@@ -22,10 +22,10 @@ module API
             status 201
             { plain_token: plain_token }
           else
-            bad_request!(application_token.errors)
+            unprocessable_entity!(application_token.errors)
           end
         else
-          bad_request!(user.errors)
+          unprocessable_entity!(user.errors)
         end
       end
     end

--- a/lib/api/helpers/errors.rb
+++ b/lib/api/helpers/errors.rb
@@ -7,51 +7,46 @@ module API
   module Helpers
     # Errors implements helper methods for API error responses.
     module Errors
-      def api_error!(code:, messages:)
-        obj = messages.is_a?(String) ? [messages] : messages
-        error!(obj, code)
-      end
-
       # Sends a `400 Bad Request` error with a possible message as the response
       # body.
       def bad_request!(msg = "Bad Request")
-        api_error!(code: 400, messages: msg)
+        error!(msg, 400)
       end
 
       # Sends a `401 Unauthorized` error with a possible message as the response
       # body.
       def unauthorized!(msg = "Unauthorized")
-        api_error!(code: 401, messages: msg)
+        error!(msg, 401)
       end
 
       # Sends a `403 Forbidden` error with a possible message as the response
       # body.
       def forbidden!(msg = "Forbidden")
-        api_error!(code: 403, messages: msg)
+        error!(msg, 403)
       end
 
       # Sends a `404 Not found` error with a possible message as the response
       # body.
       def not_found!(msg = "Not found")
-        api_error!(code: 404, messages: msg)
+        error!(msg, 404)
       end
 
       # Sends a `405 Method Not Allowed` error with a possible message as the
       # response body.
       def method_not_allowed!(msg = "Method Not Allowed")
-        api_error!(code: 405, messages: msg)
+        error!(msg, 405)
       end
 
       # Sends a `422 Unprocessable Entity` error with a possible message as the
       # response body.
       def unprocessable_entity!(msg = "Unprocessable Entity")
-        api_error!(code: 422, messages: msg)
+        error!(msg, 422)
       end
 
       # Sends a `405 Internal Server Error` error with a possible message as the
       # response body.
       def internal_server_error!(msg = "Internal Server Error")
-        api_error!(code: 500, messages: msg)
+        error!(msg, 500)
       end
     end
   end

--- a/lib/api/root_api.rb
+++ b/lib/api/root_api.rb
@@ -49,7 +49,7 @@ module API
     # We are using the same formatter for any error that might be raised. The
     # _ignored parameter include (in order): backtrace, options, env and
     # original_exception.
-    error_formatter :json, ->(message, *_ignored) { { errors: message }.to_json }
+    error_formatter :json, ->(message, *_ignored) { { message: message }.to_json }
 
     helpers Pundit
     helpers ::API::Helpers

--- a/lib/api/v1/namespaces.rb
+++ b/lib/api/v1/namespaces.rb
@@ -54,8 +54,10 @@ module API
              entity:   API::Entities::Teams,
              consumes: ["application/x-www-form-urlencoded", "application/json"],
              failure:  [
+               [400, "Bad request", API::Entities::ApiErrors],
                [401, "Authentication fails"],
-               [403, "Authorization fails"]
+               [403, "Authorization fails"],
+               [422, "Unprocessable Entity", API::Entities::FullApiErrors]
              ]
 
         params do
@@ -76,7 +78,7 @@ module API
                     current_user: current_user,
                     type:         current_type
           else
-            unprocessable_entity!(namespace.errors.full_messages)
+            unprocessable_entity!(namespace.errors)
           end
         end
 

--- a/lib/api/v1/registries.rb
+++ b/lib/api/v1/registries.rb
@@ -34,7 +34,8 @@ module API
              failure:  [
                [400, "Bad request", API::Entities::ApiErrors],
                [401, "Authentication fails"],
-               [403, "Authorization fails"]
+               [403, "Authorization fails"],
+               [422, "Unprocessable Entity", API::Entities::FullApiErrors]
              ]
 
         params do
@@ -57,8 +58,7 @@ module API
           if svc.valid?
             present obj, with: API::Entities::Registries
           else
-            status 400
-            { errors: svc.messages }
+            unprocessable_entity!(svc.messages)
           end
         end
 
@@ -68,7 +68,8 @@ module API
                [400, "Bad request", API::Entities::ApiErrors],
                [401, "Authentication fails"],
                [403, "Authorization fails"],
-               [404, "Not found"]
+               [404, "Not found"],
+               [422, "Unprocessable Entity", API::Entities::FullApiErrors]
              ],
              entity:   API::Entities::Registries,
              consumes: ["application/x-www-form-urlencoded", "application/json"]
@@ -91,8 +92,7 @@ module API
           if svc.valid?
             present obj, with: API::Entities::Registries
           else
-            status 400
-            { errors: svc.messages }
+            unprocessable_entity!(svc.messages)
           end
         end
 

--- a/lib/api/v1/teams.rb
+++ b/lib/api/v1/teams.rb
@@ -28,8 +28,10 @@ module API
              entity:   API::Entities::Teams,
              consumes: ["application/x-www-form-urlencoded", "application/json"],
              failure:  [
+               [400, "Bad request", API::Entities::ApiErrors],
                [401, "Authentication fails"],
-               [403, "Authorization fails"]
+               [403, "Authorization fails"],
+               [422, "Unprocessable Entity", API::Entities::FullApiErrors]
              ]
 
         params do
@@ -48,7 +50,7 @@ module API
                     current_user: current_user,
                     type:         current_type
           else
-            unprocessable_entity!(team.errors.full_messages)
+            unprocessable_entity!(team.errors)
           end
         end
 

--- a/lib/api/v1/users.rb
+++ b/lib/api/v1/users.rb
@@ -43,7 +43,8 @@ module API
                    failure:  [
                      [400, "Bad request", API::Entities::ApiErrors],
                      [401, "Authentication fails"],
-                     [403, "Authorization fails"]
+                     [403, "Authorization fails"],
+                     [422, "Unprocessable Entity", API::Entities::FullApiErrors]
                    ],
                    consumes: ["application/x-www-form-urlencoded", "application/json"]
 
@@ -81,7 +82,8 @@ module API
                failure:  [
                  [400, "Bad request", API::Entities::ApiErrors],
                  [401, "Authentication fails"],
-                 [403, "Authorization fails"]
+                 [403, "Authorization fails"],
+                 [422, "Unprocessable Entity", API::Entities::FullApiErrors]
                ],
                entity:   API::Entities::Users,
                consumes: ["application/x-www-form-urlencoded", "application/json"]
@@ -103,7 +105,7 @@ module API
             if user.valid?
               present user, with: API::Entities::Users
             else
-              bad_request!(user.errors)
+              unprocessable_entity!(user.errors)
             end
           end
 
@@ -114,7 +116,8 @@ module API
                  [400, "Bad request", API::Entities::ApiErrors],
                  [401, "Authentication fails"],
                  [403, "Authorization fails"],
-                 [404, "Not found"]
+                 [404, "Not found"],
+                 [422, "Unprocessable Entity", API::Entities::FullApiErrors]
                ],
                entity:   API::Entities::Users,
                consumes: ["application/x-www-form-urlencoded", "application/json"]
@@ -137,8 +140,7 @@ module API
             if user.valid?
               present user, with: API::Entities::Users
             else
-              status 400
-              { errors: user.errors }
+              unprocessable_entity!(user.errors)
             end
           end
 

--- a/spec/api/grape_api/v1/namespaces_spec.rb
+++ b/spec/api/grape_api/v1/namespaces_spec.rb
@@ -193,12 +193,24 @@ describe API::V1::Namespaces do
       expect(response).to have_http_status(:bad_request)
     end
 
+    it "returns a 400 for malformed JSON" do
+      @admin_header = @admin_header.merge(
+        "CONTENT_TYPE" => "application/json",
+        "ACCEPT"       => "application/json"
+      )
+      post "/api/v1/namespaces", "{", @admin_header
+      expect(response).to have_http_status(:bad_request)
+
+      resp = JSON.parse(response.body)
+      expect(resp["message"]).to match(/There was a problem in the JSON you submitted/)
+    end
+
     it "returns 422 if invalid values" do
       post "/api/v1/namespaces", { name: "", team: team.name }, @admin_header
 
       parsed = JSON.parse(response.body)
       expect(response).to have_http_status(:unprocessable_entity)
-      expect(parsed["errors"]).to include("Name can't be blank")
+      expect(parsed["message"]["name"].first).to include("can't be blank")
     end
 
     it "returns 404 if team is hidden" do

--- a/spec/api/grape_api/v1/repositories_spec.rb
+++ b/spec/api/grape_api/v1/repositories_spec.rb
@@ -132,7 +132,7 @@ describe API::V1::Repositories do
       create(:tag, name: "taggg", repository: repository, digest: "1", author: admin)
       delete "/api/v1/repositories/#{repository.id}", nil, @header
       body = JSON.parse(response.body)
-      expect(body["errors"]).to include("could not remove taggg tag")
+      expect(body["message"]).to include("could not remove taggg tag")
       expect(response).to have_http_status(:unprocessable_entity)
     end
 

--- a/spec/api/grape_api/v1/teams_spec.rb
+++ b/spec/api/grape_api/v1/teams_spec.rb
@@ -121,12 +121,24 @@ describe API::V1::Teams do
       expect(response).to have_http_status(:bad_request)
     end
 
+    it "returns a 400 for malformed JSON" do
+      @header = @header.merge(
+        "CONTENT_TYPE" => "application/json",
+        "ACCEPT"       => "application/json"
+      )
+      post "/api/v1/teams", "{", @header
+      expect(response).to have_http_status(:bad_request)
+
+      resp = JSON.parse(response.body)
+      expect(resp["message"]).to match(/There was a problem in the JSON you submitted/)
+    end
+
     it "returns 422 if invalid values" do
       post "/api/v1/teams", { name: "" }, @header
 
       parsed = JSON.parse(response.body)
       expect(response).to have_http_status(:unprocessable_entity)
-      expect(parsed["errors"]).to include("Name can't be blank")
+      expect(parsed["message"]["name"].first).to include("can't be blank")
     end
 
     it "returns 403 if non-admins try to create a Team" do


### PR DESCRIPTION
We were using 400 instead of 422 in quite some places. This commit
addresses this trend.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>
