### PR TITLE
[packaging] add "js()" to the bundled javascript libs

### DIFF
--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -129,7 +129,7 @@ pushd build/$packagename-$branch/
   for js in $(NODE_ENV=production yarn -s list --depth=0 | tr "@" " "); do
     js_name=$(echo $js | awk '{ print $2 }')
     js_version=$(echo $js | awk '{ print $3 }')
-    js_provides="$js_provides\nProvides: bundled($js_name) = $js_version"
+    js_provides="$js_provides\nProvides: bundled(js($js_name)) = $js_version"
   done
 popd
 


### PR DESCRIPTION
example:

Provides: bundled(js(foo)) = version

instead of

Provides: bundled(foo) = version

to make it explicit foo is a javascript lib

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>