### PR TITLE
[Packaging] Review rubygem package

### DIFF
--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -78,9 +78,10 @@ pushd build/$packagename-$branch/
   # format (when in depth=0): "├─ NAME@VERSION". So, we have to replace @ by an
   # empty space, and this way we'll be able to awk it away.
   js_provides="# Provides extracted from the yarn.lock file."
-  for js in $(NODE_ENV=production yarn -s list --depth=0 | tr "@" " "); do
-    js_name=$(echo $js | awk '{ print $2 }')
-    js_version=$(echo $js | awk '{ print $3 }')
+  for js in $(NODE_ENV=production yarn -s list --depth=0 | cut -d" " -f2); do
+    js=$(echo $js | tr "@" " ")
+    js_name=$(echo $js | awk '{ print $1 }')
+    js_version=$(echo $js | awk '{ print $2 }')
     js_provides="$js_provides\nProvides: bundled(js($js_name)) = $js_version"
   done
 popd

--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -74,16 +74,6 @@ pushd build/$packagename-$branch/
       done
   fi
 
-  # Extract the JS dependencies. Yarn will list dependencies in the following
-  # format (when in depth=0): "├─ NAME@VERSION". So, we have to replace @ by an
-  # empty space, and this way we'll be able to awk it away.
-  js_provides="# Provides extracted from the yarn.lock file."
-  for js in $(NODE_ENV=production yarn -s list --depth=0 | cut -d" " -f2); do
-    js=$(echo $js | tr "@" " ")
-    js_name=$(echo $js | awk '{ print $1 }')
-    js_version=$(echo $js | awk '{ print $2 }')
-    js_provides="$js_provides\nProvides: bundled(js($js_name)) = $js_version"
-  done
 popd
 
 debug "Creating ${packagename}.spec based on ${packagename}.spec.in"

--- a/packaging/suse/portus.spec.in
+++ b/packaging/suse/portus.spec.in
@@ -19,10 +19,10 @@
 %define portusdir /srv/Portus
 
 %define fix_sheb() ( \
-  for i in $(grep '^#!/usr/bin/env ruby$' * -r | cut -d: -f1 | sort | uniq);do\
+  for i in $(grep '^#!/usr/bin/env ruby$' * -r | cut -d: -f1 | uniq);do\
     sed -e 's|^#!/usr/bin/env ruby$|#!/usr/bin/ruby.%{rb_suffix}|g' -i $i;\
   done;\
-  for i in $(grep '^#!/usr/bin/ruby$' * -r | cut -d: -f1 | sort | uniq);do\
+  for i in $(grep '^#!/usr/bin/ruby$' * -r | cut -d: -f1 | uniq);do\
      sed -e 's|^#!/usr/bin/ruby$|#!/usr/bin/ruby.ruby2.5|g' -i $i;\
   done;\
 )

--- a/packaging/suse/portus.spec.in
+++ b/packaging/suse/portus.spec.in
@@ -59,12 +59,10 @@ Obsoletes:      Portus < %{version}
 # This is the reason why we are obsoleting it
 Obsoletes:      Portus = 20151120162040
 
-# Javascript engine to build assets
+# Javascript engine to build assets. Note that yarn-packaging will automatically
+# create the provides for the JS libs
 BuildRequires:  nodejs6
 BuildRequires:  yarn
-
-# If we require yarn-packaging, this will auto create the provides
-# for the js libs
 BuildRequires:  yarn-packaging
 
 # Base ruby engine.

--- a/packaging/suse/portus.spec.in
+++ b/packaging/suse/portus.spec.in
@@ -18,6 +18,15 @@
 %define branch    __BRANCH__
 %define portusdir /srv/Portus
 
+%define fix_sheb() ( \
+  for i in $(grep '^#!/usr/bin/env ruby$' * -r | cut -d: -f1 | sort | uniq);do\
+    sed -e 's|^#!/usr/bin/env ruby$|#!/usr/bin/ruby.%{rb_suffix}|g' -i $i;\
+  done;\
+  for i in $(grep '^#!/usr/bin/ruby$' * -r | cut -d: -f1 | sort | uniq);do\
+     sed -e 's|^#!/usr/bin/ruby$|#!/usr/bin/ruby.ruby2.5|g' -i $i;\
+  done;\
+)
+
 Name:           portus
 Version:        __VERSION__
 Release:        0.0.1
@@ -33,10 +42,10 @@ Source1:        node_modules.tar.gz
 Source2:        yarn.lock
 __PATCHSOURCES__
 
-Requires:       rubygem(%{rb_default_ruby_abi}:gem2rpm)
+# Add gems as sources with the https://github.com/openSUSE/obs-service-bundle_gems
+
 Requires:       timezone
 Requires:       net-tools
-Requires:       portusctl
 %if 0%{?suse_version} >= 1210
 BuildRequires: systemd-rpm-macros
 %endif
@@ -58,11 +67,26 @@ BuildRequires:  yarn
 %define rb_build_abi      ruby:2.5.0
 %define rb_suffix         ruby2.5
 %define rb_ver            2.5.0
-BuildRequires:  %{rubydevel}
-BuildRequires:  %{rubygem gem2rpm}
 Requires:       config(%{rb_suffix}) >= %{rb_default_ruby_abi}
 
-__RUBYGEMS_BUILD_REQUIRES__
+BuildRequires: libcurl-devel
+Requires: libcurl4
+BuildRequires: libffi-devel
+%if 0%{?suse_version} <= 1320
+BuildRequires: libmysqlclient-devel < 10.1
+Requires: libmysqlclient18 < 10.1
+%else
+BuildRequires: libmysqlclient-devel
+Requires: libmysqlclient18
+%endif
+Recommends: mariadb
+BuildRequires: libxml2-devel libxslt-devel
+BuildRequires: postgresql-devel
+Requires: postgresql-devel
+
+Requires: %rb_default_ruby_suffix
+BuildRequires:  %rb_default_ruby_suffix %{rb_default_ruby_suffix}-rubygem-gem2rpm
+BuildRequires:  %{rb_suffix}-devel
 
 __NODEJS_BUILD_PROVIDES__
 
@@ -87,25 +111,38 @@ tar xzvf node_modules.tar.gz
 
 # Deal with Ruby gems.
 install -d vendor/cache
-cp %{_libdir}/ruby/gems/%{rb_ver}/cache/*.gem vendor/cache
+cp %{_sourcedir}/*.gem vendor/cache
 
 # Deploy gems for compiling the assets.
+export GEM_HOME=$PWD/vendor GEM_PATH=$PWD/vendor PATH=$PWD/vendor/bin:$PWD/bin:$PATH
+# Install bundler in the build system
+gem.%{rb_suffix} install --no-rdoc --no-ri vendor/cache/bundler-*.gem
+
+%fix_sheb
+
 bundle config build.nokogiri --use-system-libraries
 bundle install --retry=3 --local --deployment --without test development
-gem.ruby2.5 install --no-rdoc --no-ri --install-dir vendor/bundle/ruby/%{rb_ver}/ vendor/cache/bundler-*.gem
+gem.%{rb_suffix} install --no-rdoc --no-ri --install-dir vendor/bundle/ruby/%{rb_ver}/ vendor/cache/bundler-*.gem
+
+%fix_sheb
 
 # Compile assets
 PORTUS_SECRET_KEY_BASE="ap" PORTUS_KEY_PATH="ap" PORTUS_PASSWORD="ap" \
   INCLUDE_ASSETS_GROUP=yes RAILS_ENV=production NODE_ENV=production \
-  bundle exec rake portus:assets:compile
+  ./bin/bundle exec rake portus:assets:compile
 
 # Install the final gems (i.e. exclude the `assets` group from the final
 # bundle). Unfortunately, bundler does not have a way to remove gems from a
 # given group. So, we have to remove all of them, and then install the ones we
 # want...
 rm -r vendor/bundle/ruby/%{rb_ver}/*
-gem.ruby2.5 install --no-rdoc --no-ri --install-dir vendor/bundle/ruby/%{rb_ver}/ vendor/cache/bundler-*.gem
+gem.%{rb_suffix} install --no-rdoc --no-ri --install-dir vendor/bundle/ruby/%{rb_ver}/ vendor/cache/bundler-*.gem
+
+%fix_sheb
+
 bundle install --retry=3 --local --deployment --without test development assets
+
+%fix_sheb
 
 # Patch landing_page
 APPLICATION_CSS=$(find . -name application-*.css 2>/dev/null)
@@ -153,11 +190,20 @@ mkdir %{buildroot}/%{portusdir}/log
 rm -rf %{buildroot}/%{portusdir}/tmp
 mkdir %{buildroot}/%{portusdir}/tmp
 
+install -d %{buildroot}/%{_sbindir}
+cp packaging/suse/bin/portusctl %{buildroot}/%{_sbindir}/
+
+# Man pages
+install -d %{buildroot}%{_mandir}/man1
+install -p -m 644 packaging/suse/portusctl/man/man1/*.1 %{buildroot}%{_mandir}/man1
+
 %fdupes %{buildroot}/%{portusdir}
 
 %files
 %defattr(-,root,root)
 %{portusdir}
+%exclude %{portusdir}/lib/man_pages.rb
+%exclude %{portusdir}/lib/tasks/man.rake
 %exclude %{portusdir}/packaging/suse/.gitignore
 %exclude %{portusdir}/packaging/suse/package_and_push_to_obs.sh
 %exclude %{portusdir}/packaging/suse/portus.spec.in
@@ -176,5 +222,8 @@ mkdir %{buildroot}/%{portusdir}/tmp
 %{portusdir}/log/
 %{portusdir}/tmp/
 %{portusdir}/db/
+%{_sbindir}/portusctl
+%{_mandir}/man1/portusctl-*.1.gz
+%{_mandir}/man1/portusctl.1.gz
 
 %changelog

--- a/packaging/suse/portus.spec.in
+++ b/packaging/suse/portus.spec.in
@@ -46,6 +46,7 @@ __PATCHSOURCES__
 
 Requires:       timezone
 Requires:       net-tools
+Requires:       portusctl
 %if 0%{?suse_version} >= 1210
 BuildRequires: systemd-rpm-macros
 %endif
@@ -190,20 +191,11 @@ mkdir %{buildroot}/%{portusdir}/log
 rm -rf %{buildroot}/%{portusdir}/tmp
 mkdir %{buildroot}/%{portusdir}/tmp
 
-install -d %{buildroot}/%{_sbindir}
-cp packaging/suse/bin/portusctl %{buildroot}/%{_sbindir}/
-
-# Man pages
-install -d %{buildroot}%{_mandir}/man1
-install -p -m 644 packaging/suse/portusctl/man/man1/*.1 %{buildroot}%{_mandir}/man1
-
 %fdupes %{buildroot}/%{portusdir}
 
 %files
 %defattr(-,root,root)
 %{portusdir}
-%exclude %{portusdir}/lib/man_pages.rb
-%exclude %{portusdir}/lib/tasks/man.rake
 %exclude %{portusdir}/packaging/suse/.gitignore
 %exclude %{portusdir}/packaging/suse/package_and_push_to_obs.sh
 %exclude %{portusdir}/packaging/suse/portus.spec.in
@@ -222,8 +214,5 @@ install -p -m 644 packaging/suse/portusctl/man/man1/*.1 %{buildroot}%{_mandir}/m
 %{portusdir}/log/
 %{portusdir}/tmp/
 %{portusdir}/db/
-%{_sbindir}/portusctl
-%{_mandir}/man1/portusctl-*.1.gz
-%{_mandir}/man1/portusctl.1.gz
 
 %changelog

--- a/packaging/suse/portus.spec.in
+++ b/packaging/suse/portus.spec.in
@@ -42,7 +42,7 @@ Source1:        node_modules.tar.gz
 Source2:        yarn.lock
 __PATCHSOURCES__
 
-# Add gems as sources with the https://github.com/openSUSE/obs-service-bundle_gems
+# Add gems as sources with the https://github.com/openSUSE/obs-service-bundle_gems service
 
 Requires:       timezone
 Requires:       net-tools
@@ -82,7 +82,6 @@ Requires: libmysqlclient18 < 10.1
 BuildRequires: libmysqlclient-devel
 Requires: libmysqlclient18
 %endif
-Recommends: mariadb
 BuildRequires: libxml2-devel libxslt-devel
 BuildRequires: postgresql-devel
 Requires: postgresql-devel

--- a/packaging/suse/portus.spec.in
+++ b/packaging/suse/portus.spec.in
@@ -63,6 +63,10 @@ Obsoletes:      Portus = 20151120162040
 BuildRequires:  nodejs6
 BuildRequires:  yarn
 
+# If we require yarn-packaging, this will auto create the provides
+# for the js libs
+BuildRequires:  yarn-packaging
+
 # Base ruby engine.
 %define rb_build_versions ruby25
 %define rb_build_abi      ruby:2.5.0


### PR DESCRIPTION
Let's include the gems as sources instead of build requirements so
building this package does not require so many gem packages.

Build requiring rubygem packages is a "nightmare" when you try to build
portus in different repos:

* sometimes the rubygem RPMs are not there and need to be submited
* othertimes they are present but have a different version and that
 creates a conflict

Since the new macros in ruby-common are generating the

"Provides: bundled(rubygem(foo)) = version"

we don't need the BR to explicetely tell which rubygems are in, plus the
"provides" is much more explicit.

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>
