### PR TITLE
[packaging] add yarn.lock as Source2. yarn.lock is being used to

### DIFF
--- a/packaging/suse/portus.spec.in
+++ b/packaging/suse/portus.spec.in
@@ -30,6 +30,7 @@ Source0:        %{branch}.tar.gz
 # Generated with `yarn install` which produces a reproduceable `node_modules`
 # directory thanks to the yarn.lock file defined in the Portus repo.
 Source1:        node_modules.tar.gz
+Source2:        yarn.lock
 __PATCHSOURCES__
 
 Requires:       rubygem(%{rb_default_ruby_abi}:gem2rpm)


### PR DESCRIPTION
generate the spec file so it is important to keep this in the package
source

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>

### Summary

Provide a general description of the changes in your pull request. If this pull
request fixes a known issue, please tag it as well (e.g.: `Fixes #1`). Check the
`CONTRIBUTING.md` file for more information.

Thanks for contributing to Portus!
