### PR TITLE
security: don't crash on clair timeouts

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -218,7 +218,7 @@ registry:
   timeout:
     value: 2
 
-  #Set timeout in seconds for read response from registry.
+  # Set timeout in seconds for read response from registry.
   read_timeout:
     value: 120
 
@@ -282,6 +282,10 @@ security:
     # Port being used by Clair to report its status. Taking the default from
     # Clair.
     health_port: 6061
+
+    # Timeout for HTTP requests with Clair. Defaults to 900 seconds, which is
+    # the default for Clair too.
+    timeout: 900
 
   # zypper-docker can be run as a server with its `serve` command. This backend
   # fetches the information as given by zypper-docker. Note that this feature

--- a/lib/portus/http_helpers.rb
+++ b/lib/portus/http_helpers.rb
@@ -147,13 +147,22 @@ module Portus
       [auth_args["Bearer realm"], query_params]
     end
 
-    # Performs an HTTP request to the given URI and request object. It returns an
-    # HTTP response that has been sent from the registry.
-    def get_response_token(uri, req)
+    # Performs an HTTP request to the given URI and request object. You may
+    # optionally pass a read and open timeout, otherwise the ones provided in
+    # the `registry` config will be used. It returns an HTTP response that has
+    # been sent from the registry.
+    def get_response_token(uri, req, timeout = nil)
+      open, read = if timeout
+                     [timeout, timeout]
+                   else
+                     [APP_CONFIG["registry"]["timeout"]["value"],
+                      APP_CONFIG["registry"]["read_timeout"]["value"]]
+                   end
+
       options = {
         use_ssl:      uri.scheme == "https",
-        open_timeout: APP_CONFIG["registry"]["timeout"]["value"].to_i,
-        read_timeout: APP_CONFIG["registry"]["read_timeout"]["value"].to_i
+        open_timeout: open.to_i,
+        read_timeout: read.to_i
       }
 
       Net::HTTP.start(uri.hostname, uri.port, options) do |http|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -78,7 +78,8 @@ RSpec.configure do |config|
 
     APP_CONFIG["security"] = {
       "clair" => {
-        "server" => ""
+        "server"  => "",
+        "timeout" => 900
       }, "zypper" => {
         "server" => ""
       }, "dummy" => {


### PR DESCRIPTION
Moreover, I've also added a configuration option so the timeouts for the
registry and clair can be configured separately. This has been done
because the Clair timeout by default is 900 seconds, which might be a
bit too high for registries.

Fixes #1751

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>