### PR TITLE
security: fetch the manifest more safely

### DIFF
--- a/lib/portus/background/security_scanning.rb
+++ b/lib/portus/background/security_scanning.rb
@@ -42,9 +42,11 @@ module Portus
           # progress.
           tag.update_vulnerabilities(scanned: Tag.statuses[:scan_working])
 
-          # Fetch vulnerabilities.
+          # Fetch vulnerabilities. If there was an error and nil was returned,
+          # simply skip this iteration.
           sec = ::Portus::Security.new(tag.repository.full_name, tag.name)
           vulns = sec.vulnerabilities
+          next unless vulns
 
           # And now update the tag with the vulnerabilities.
           dig = update_tag(tag, vulns)

--- a/lib/portus/http_helpers.rb
+++ b/lib/portus/http_helpers.rb
@@ -92,7 +92,7 @@ module Portus
         str += "\n"
       end
 
-      raise NotFoundError, str
+      raise ::Portus::Errors::NotFoundError, str
     end
 
     private

--- a/lib/portus/registry_client.rb
+++ b/lib/portus/registry_client.rb
@@ -52,8 +52,13 @@ module Portus
     #   - The manifest digest.
     #   - The manifest itself as a ruby hash.
     #
-    # It will raise either a ManifestNotFoundError or a RuntimeError if
-    # something goes wrong.
+    # Three different exceptions might be raised:
+    #
+    #   - ::Portus::RequestError: there was a request error with the registry
+    #     (e.g. a timeout).
+    #   - ::Portus::Errors::NotFoundError: the given manifest was not found.
+    #   - ::Portus::RegistryClient::ManifestError: there was an unknown problem
+    #     with the manifest.
     def manifest(repository, tag = "latest")
       res = safe_request("#{repository}/manifests/#{tag}", "get")
 


### PR DESCRIPTION
In order to fetch vulnerabilities, the security scanner first has to
gather the layers to be inspected. In our case, we fetch this
information from the image manifest as given by the Registry.

This commit adds some code so the fetching of this manifest is safer.
For example, it will not freak out if a timeout was reached when
requesting the manifest from the registry.

Fixes #1743

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>