### PR TITLE
Added a table for vulnerabilities

### DIFF
--- a/app/assets/javascripts/modules/repositories/services/vulnerabilities-parser.js
+++ b/app/assets/javascripts/modules/repositories/services/vulnerabilities-parser.js
@@ -15,7 +15,7 @@ const parse = function (vulnerabilities) {
       }
 
       vulnerabilities[backend].forEach((vul) => {
-        severities[vul.Severity] += 1;
+        severities[vul.severity] += 1;
         total += 1;
       });
     });

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -6,6 +6,7 @@ class TagsController < ApplicationController
     authorize @tag
 
     @names = Tag.where(digest: @tag.digest).sort.map(&:name)
-    @vulnerabilities = @tag.fetch_vulnerabilities
+    vulns = @tag.fetch_vulnerabilities
+    @vulnerabilities = vulns ? vulns.group_by(&:scanner) : nil
   end
 end

--- a/app/models/scan_result.rb
+++ b/app/models/scan_result.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: scan_results
+#
+#  id               :integer          not null, primary key
+#  tag_id           :integer
+#  vulnerability_id :integer
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#
+
+# Relationship linking tags and vulnerabilities: a scan result involves
+# vulnerabilities for tags.
+class ScanResult < ActiveRecord::Base
+  belongs_to :tag
+  belongs_to :vulnerability
+
+  # Synchronize what we have in the database for the given tag with the given
+  # vulnerabilities. This may add/delete/update objects on the database as
+  # needed. This will also affect tags with the same digest as the given one.
+  def self.squash_data!(tag:, vulnerabilities:)
+    return unless vulnerabilities
+
+    if tag.digest.blank?
+      ScanResult.add_vulnerabilities!(tag: tag, vulnerabilities: vulnerabilities)
+    else
+      Tag.where(digest: tag.digest).find_each do |t|
+        ScanResult.add_vulnerabilities!(tag: t, vulnerabilities: vulnerabilities)
+      end
+    end
+  end
+
+  # Synchronize only the given tag with the given vulnerabilities. This may
+  # add/delete/update objects on the database as needed.
+  #
+  # Similar to `squash_data!`, but this one only affects the given tag, not the
+  # ones matching a given digest. Do *not* use this method directly: use
+  # `squash_data!` instead.
+  def self.add_vulnerabilities!(tag:, vulnerabilities:)
+    ScanResult.destroy_all(tag: tag)
+
+    vulnerabilities.each do |scanner, results|
+      results.each do |v|
+        break if v.blank?
+
+        vo = Vulnerability.find_or_create_by!(name: v["Name"])
+        vo.add_extra_values!(obj: v, sc: scanner)
+        ScanResult.create(tag: tag, vulnerability: vo)
+      end
+    end
+  end
+end

--- a/app/models/vulnerability.rb
+++ b/app/models/vulnerability.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: vulnerabilities
+#
+#  id         :integer          not null, primary key
+#  name       :string(255)      not null
+#  scanner    :string(255)      default(""), not null
+#  severity   :string(255)      default(""), not null
+#  link       :string(255)      default(""), not null
+#  fixed_by   :string(255)      default(""), not null
+#  metadata   :text(65535)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_vulnerabilities_on_name  (name) UNIQUE
+#
+
+# Vulnerability represents a vulnerability as detected by any of our sources.
+class Vulnerability < ActiveRecord::Base
+  has_many :scan_results, dependent: :destroy
+  has_many :tags, -> { uniq }, through: :scan_results
+
+  validates :name, uniqueness: true
+
+  # Add some fields into this vulnerability object given an `obj` with the
+  # `sc` scanner response.
+  def add_extra_values!(obj:, sc:)
+    attrs = fetch_attributes(obj: obj, sc: sc)
+    update(attrs) unless attrs.empty?
+  end
+
+  # With the given objects, fetch the attributes to be updated for this object.
+  def fetch_attributes(obj:, sc:)
+    attrs = {}
+    attrs[:fixed_by] = obj["FixedBy"] if obj["FixedBy"].present?
+    attrs[:link]     = obj["Link"] if obj["Link"].present?
+    attrs[:metadata] = obj["Metadata"] if obj["Metadata"].present?
+    attrs[:scanner]  = sc if scanner.blank?
+    attrs[:severity] = obj["Severity"] if obj["Severity"].present?
+    attrs
+  end
+end

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -14,7 +14,7 @@
 #  enabled        :boolean          default(FALSE)
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
-#  name           :string(255)
+#  name           :string(255)      not null
 #
 # Indexes
 #

--- a/app/views/tags/show.html.slim
+++ b/app/views/tags/show.html.slim
@@ -21,9 +21,9 @@
           ul
             - vulns.each do |v|
               li
-                a href="#{v['Link']}"
-                  = v["Name"]
-                |  (severity: #{v["Severity"]})
+                a href="#{v.link}"
+                  = v.name
+                |  (severity: #{v.severity})
 
       - else
         p No vulnerabilities found

--- a/db/migrate/20180409142550_create_vulnerabilities.rb
+++ b/db/migrate/20180409142550_create_vulnerabilities.rb
@@ -1,0 +1,16 @@
+class CreateVulnerabilities < ActiveRecord::Migration
+  def change
+    create_table :vulnerabilities do |t|
+      t.string :name, null: false
+      t.string :scanner, null: false, default: ""
+
+      t.string :severity, null: false, default: ""
+      t.string :link, null: false, default: ""
+      t.string :fixed_by, null: false, default: ""
+      t.text :metadata
+      t.timestamps null: false
+    end
+
+    add_index :vulnerabilities, :name, unique: true
+  end
+end

--- a/db/migrate/20180409143945_create_scan_results.rb
+++ b/db/migrate/20180409143945_create_scan_results.rb
@@ -1,0 +1,10 @@
+class CreateScanResults < ActiveRecord::Migration
+  def change
+    create_table :scan_results do |t|
+      t.integer :tag_id
+      t.integer :vulnerability_id
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20180411102022_remove_vulnerabilities_from_tag.rb
+++ b/db/migrate/20180411102022_remove_vulnerabilities_from_tag.rb
@@ -1,0 +1,5 @@
+class RemoveVulnerabilitiesFromTag < ActiveRecord::Migration
+  def change
+    remove_column :tags, :vulnerabilities, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180207145522) do
+ActiveRecord::Schema.define(version: 20180411102022) do
 
   create_table "activities", force: :cascade do |t|
     t.integer  "trackable_id",   limit: 4
@@ -98,6 +98,13 @@ ActiveRecord::Schema.define(version: 20180207145522) do
   add_index "repositories", ["name", "namespace_id"], name: "index_repositories_on_name_and_namespace_id", unique: true, using: :btree
   add_index "repositories", ["namespace_id"], name: "index_repositories_on_namespace_id", using: :btree
 
+  create_table "scan_results", force: :cascade do |t|
+    t.integer  "tag_id",           limit: 4
+    t.integer  "vulnerability_id", limit: 4
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+  end
+
   create_table "stars", force: :cascade do |t|
     t.integer  "user_id",       limit: 4
     t.integer  "repository_id", limit: 4
@@ -109,17 +116,16 @@ ActiveRecord::Schema.define(version: 20180207145522) do
   add_index "stars", ["user_id"], name: "index_stars_on_user_id", using: :btree
 
   create_table "tags", force: :cascade do |t|
-    t.string   "name",            limit: 255,      default: "latest", null: false
-    t.integer  "repository_id",   limit: 4,                           null: false
-    t.datetime "created_at",                                          null: false
-    t.datetime "updated_at",                                          null: false
-    t.integer  "user_id",         limit: 4
-    t.string   "digest",          limit: 255
-    t.string   "image_id",        limit: 255,      default: ""
-    t.boolean  "marked",                           default: false
-    t.string   "username",        limit: 255
-    t.integer  "scanned",         limit: 4,        default: 0
-    t.text     "vulnerabilities", limit: 16777215
+    t.string   "name",          limit: 255, default: "latest", null: false
+    t.integer  "repository_id", limit: 4,                      null: false
+    t.datetime "created_at",                                   null: false
+    t.datetime "updated_at",                                   null: false
+    t.integer  "user_id",       limit: 4
+    t.string   "digest",        limit: 255
+    t.string   "image_id",      limit: 255, default: ""
+    t.boolean  "marked",                    default: false
+    t.string   "username",      limit: 255
+    t.integer  "scanned",       limit: 4,   default: 0
   end
 
   add_index "tags", ["repository_id"], name: "index_tags_on_repository_id", using: :btree
@@ -177,6 +183,19 @@ ActiveRecord::Schema.define(version: 20180207145522) do
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   add_index "users", ["username"], name: "index_users_on_username", unique: true, using: :btree
 
+  create_table "vulnerabilities", force: :cascade do |t|
+    t.string   "name",       limit: 255,                null: false
+    t.string   "scanner",    limit: 255,   default: "", null: false
+    t.string   "severity",   limit: 255,   default: "", null: false
+    t.string   "link",       limit: 255,   default: "", null: false
+    t.string   "fixed_by",   limit: 255,   default: "", null: false
+    t.text     "metadata",   limit: 65535
+    t.datetime "created_at",                            null: false
+    t.datetime "updated_at",                            null: false
+  end
+
+  add_index "vulnerabilities", ["name"], name: "index_vulnerabilities_on_name", unique: true, using: :btree
+
   create_table "webhook_deliveries", force: :cascade do |t|
     t.integer  "webhook_id",      limit: 4
     t.string   "uuid",            limit: 255
@@ -213,7 +232,7 @@ ActiveRecord::Schema.define(version: 20180207145522) do
     t.boolean  "enabled",                    default: false
     t.datetime "created_at",                                 null: false
     t.datetime "updated_at",                                 null: false
-    t.string   "name",           limit: 255
+    t.string   "name",           limit: 255,                 null: false
   end
 
   add_index "webhooks", ["namespace_id"], name: "index_webhooks_on_namespace_id", using: :btree

--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -101,9 +101,11 @@ module API
               "0 (not scanned), 1 (work in progress) and 2 (scanning done)."
       }
       expose :vulnerabilities, documentation: {
-        is_array: true,
-        desc:     "An array of vulnerabilities for this tag, or null if the feature is not enabled"
-      }
+        desc: "A hash of vulnerabilities for this tag, or null if the feature is not enabled"
+      } do |t|
+        vulns = t.fetch_vulnerabilities
+        vulns&.group_by(&:scanner)
+      end
     end
 
     class Repositories < Grape::Entity

--- a/lib/portus/security_backends/clair.rb
+++ b/lib/portus/security_backends/clair.rb
@@ -55,8 +55,7 @@ module Portus
             next if name.blank? || known.include?(name)
 
             known << v["Name"]
-            # Skipping some fields that we don't use and can be very long...
-            res << v.except("Metadata", "Description")
+            res << v
           end
         end
         res.sort_by { |el| el["Name"] }

--- a/spec/controllers/webhooks_controller_spec.rb
+++ b/spec/controllers/webhooks_controller_spec.rb
@@ -14,7 +14,7 @@
 #  enabled        :boolean          default(FALSE)
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
-#  name           :string(255)
+#  name           :string(255)      not null
 #
 # Indexes
 #
@@ -166,6 +166,7 @@ RSpec.describe WebhooksController, type: :controller do
     render_views
     let(:valid_attributes) do
       {
+        name:      "webhook",
         namespace: namespace.id,
         url:       "example.org"
       }
@@ -420,7 +421,7 @@ RSpec.describe WebhooksController, type: :controller do
 
     it "tracks webhook creation" do
       post_params = {
-        webhook:      { url: "example.org" },
+        webhook:      { url: "example.org", name: "webhook" },
         namespace_id: namespace,
         format:       :js
       }

--- a/spec/factories/scan_result.rb
+++ b/spec/factories/scan_result.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryGirl.define do
+  factory :scan_result do
+    tag
+    vulnerability
+  end
+end

--- a/spec/factories/vulnerability.rb
+++ b/spec/factories/vulnerability.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryGirl.define do
+  factory :vulnerability do
+    sequence(:name) { |n| "vulnerability#{n}" }
+    severity "High"
+    sequence(:link) { |n| "http://a.link#{n}" }
+  end
+end

--- a/spec/factories/webhooks.rb
+++ b/spec/factories/webhooks.rb
@@ -14,7 +14,7 @@
 #  enabled        :boolean          default(FALSE)
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
-#  name           :string(255)
+#  name           :string(255)      not null
 #
 # Indexes
 #

--- a/spec/features/repositories_spec.rb
+++ b/spec/features/repositories_spec.rb
@@ -157,6 +157,26 @@ describe "Feature: Repositories" do
       end
     end
 
+    context "vulnerabilities" do
+      let!(:tag) do
+        create(:tag, name: "tag0", repository: repository, scanned: Tag.statuses[:scan_done])
+      end
+      let!(:vulnerability)  { create(:vulnerability, name: "CVE-1234", scanner: "clair") }
+      let!(:vulnerability1) { create(:vulnerability, name: "CVE-5678", scanner: "dummy") }
+      let!(:scan_result)    { create(:scan_result, tag: tag, vulnerability: vulnerability) }
+      let!(:scan_result1)   { create(:scan_result, tag: tag, vulnerability: vulnerability1) }
+
+      before do
+        APP_CONFIG["security"]["dummy"]["server"] = "yeah"
+      end
+
+      it "reports vulnerabilities", js: true do
+        visit repository_path(repository)
+        wait_for_ajax
+        expect(page).to have_content("2 vulnerabilities")
+      end
+    end
+
     it "A user can star a repository", js: true do
       visit repository_path(repository)
       expect(page).to have_css("#toggle_star")

--- a/spec/features/tags_spec.rb
+++ b/spec/features/tags_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Feature: Tags" do
+  let!(:registry) { create(:registry, hostname: "registry.test.lan") }
+  let!(:user) { create(:admin) }
+  let!(:team) { create(:team, owners: [user], contributors: [], viewers: []) }
+  let!(:namespace) { create(:namespace, team: team, name: "user") }
+  let!(:repository) { create(:repository, namespace: namespace, name: "busybox") }
+  let!(:tag) do
+    create(:tag, name: "tag0", repository: repository, scanned: Tag.statuses[:scan_done])
+  end
+  let!(:vulnerability)  { create(:vulnerability, name: "CVE-1234", scanner: "clair") }
+  let!(:vulnerability1) { create(:vulnerability, name: "CVE-5678", scanner: "dummy") }
+  let!(:scan_result)    { create(:scan_result, tag: tag, vulnerability: vulnerability) }
+  let!(:scan_result1)   { create(:scan_result, tag: tag, vulnerability: vulnerability1) }
+
+  before do
+    login_as user, scope: :user
+    APP_CONFIG["security"]["dummy"]["server"] = "yeah"
+  end
+
+  it "reports vulnerabilities", js: true do
+    visit tag_path(tag)
+
+    ["dummy", "clair", "CVE-1234", "CVE-5678", "High"].each do |i|
+      expect(page).to have_content(i)
+    end
+  end
+end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -4,18 +4,17 @@
 #
 # Table name: tags
 #
-#  id              :integer          not null, primary key
-#  name            :string(255)      default("latest"), not null
-#  repository_id   :integer          not null
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  user_id         :integer
-#  digest          :string(255)
-#  image_id        :string(255)      default("")
-#  marked          :boolean          default(FALSE)
-#  username        :string(255)
-#  scanned         :integer          default(0)
-#  vulnerabilities :text(16777215)
+#  id            :integer          not null, primary key
+#  name          :string(255)      default("latest"), not null
+#  repository_id :integer          not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  user_id       :integer
+#  digest        :string(255)
+#  image_id      :string(255)      default("")
+#  marked        :boolean          default(FALSE)
+#  username      :string(255)
+#  scanned       :integer          default(0)
 #
 # Indexes
 #
@@ -207,17 +206,14 @@ describe Tag do
   end
 
   describe "#fetch_vulnerabilities" do
-    let!(:tag) do
-      create(:tag, name: "tag", user_id: user.id, repository: repository,
-             digest: "1", vulnerabilities: "something")
-    end
+    let!(:tag) { create(:tag, name: "tag", user_id: user.id, repository: repository, digest: "1") }
+    let!(:vulnerability) { create(:vulnerability, name: "CVE-1234", scanner: "clair") }
+    let!(:scan_result)   { create(:scan_result, tag: tag, vulnerability: vulnerability) }
 
     it "returns nil if security scanning is not enabled" do
       # Checking that even if scanning is done and there are vulnerabilities, it
       # returns nil because security scanning is disabled.
-      tag.update_columns(scanned:         described_class.statuses[:scan_done],
-                         vulnerabilities: "something")
-
+      tag.update_columns(scanned: described_class.statuses[:scan_done])
       expect(tag.fetch_vulnerabilities).to be_nil
     end
 
@@ -234,9 +230,8 @@ describe Tag do
 
     it "returns the vulnerabilities when scan is over" do
       enable_security_vulns_module!
-      tag.update_columns(scanned:         described_class.statuses[:scan_done],
-                         vulnerabilities: "something")
-      expect(tag.fetch_vulnerabilities).to eq "something"
+      tag.update_columns(scanned: described_class.statuses[:scan_done])
+      expect(tag.fetch_vulnerabilities).to eq [vulnerability]
     end
   end
 end

--- a/spec/models/webhook_spec.rb
+++ b/spec/models/webhook_spec.rb
@@ -14,7 +14,7 @@
 #  enabled        :boolean          default(FALSE)
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
-#  name           :string(255)
+#  name           :string(255)      not null
 #
 # Indexes
 #

--- a/spec/vcr_cassettes/background/clair.yml
+++ b/spec/vcr_cassettes/background/clair.yml
@@ -164,7 +164,7 @@ http_interactions:
   recorded_at: Thu, 30 Nov 2017 15:41:58 GMT
 - request:
     method: post
-    uri: http://localhost:6060/v1/layers
+    uri: http://my.clair:6060/v1/layers
     body:
       encoding: UTF-8
       string: '{"Layer":{"Name":"sha256:28c417e954d8f9d2439d5b9c7ea3dcb2fd31690bf2d79b94333d889ea26689d2","NamespaceName":"","Path":"https://my.registry:5000/v2/repo/blobs/sha256:28c417e954d8f9d2439d5b9c7ea3dcb2fd31690bf2d79b94333d889ea26689d2","Headers":{"Authorization":"Bearer
@@ -199,7 +199,7 @@ http_interactions:
   recorded_at: Thu, 30 Nov 2017 15:41:58 GMT
 - request:
     method: post
-    uri: http://localhost:6060/v1/layers
+    uri: http://my.clair:6060/v1/layers
     body:
       encoding: UTF-8
       string: '{"Layer":{"Name":"sha256:faa8a552d0bddb391293b470084c91e7790c0d70fa17b69627a32729de105562","NamespaceName":"","Path":"https://my.registry:5000/v2/repo/blobs/sha256:faa8a552d0bddb391293b470084c91e7790c0d70fa17b69627a32729de105562","Headers":{"Authorization":"Bearer
@@ -234,7 +234,7 @@ http_interactions:
   recorded_at: Thu, 30 Nov 2017 15:41:58 GMT
 - request:
     method: post
-    uri: http://localhost:6060/v1/layers
+    uri: http://my.clair:6060/v1/layers
     body:
       encoding: UTF-8
       string: '{"Layer":{"Name":"sha256:acdc6057f492499eac1f4bcabe30e712d6fdf46c3b161be91294e6d3acc90004","NamespaceName":"","Path":"https://my.registry:5000/v2/repo/blobs/sha256:acdc6057f492499eac1f4bcabe30e712d6fdf46c3b161be91294e6d3acc90004","Headers":{"Authorization":"Bearer
@@ -269,7 +269,7 @@ http_interactions:
   recorded_at: Thu, 30 Nov 2017 15:41:58 GMT
 - request:
     method: post
-    uri: http://localhost:6060/v1/layers
+    uri: http://my.clair:6060/v1/layers
     body:
       encoding: UTF-8
       string: '{"Layer":{"Name":"sha256:6bda536f8dd6d360178e4e3871301bb9ed706eb2ed439be52d068aa3dec2fd00","NamespaceName":"","Path":"https://my.registry:5000/v2/repo/blobs/sha256:6bda536f8dd6d360178e4e3871301bb9ed706eb2ed439be52d068aa3dec2fd00","Headers":{"Authorization":"Bearer
@@ -304,7 +304,7 @@ http_interactions:
   recorded_at: Thu, 30 Nov 2017 15:41:58 GMT
 - request:
     method: get
-    uri: http://localhost:6060/v1/layers/sha256:6bda536f8dd6d360178e4e3871301bb9ed706eb2ed439be52d068aa3dec2fd00?features=false&vulnerabilities=true
+    uri: http://my.clair:6060/v1/layers/sha256:6bda536f8dd6d360178e4e3871301bb9ed706eb2ed439be52d068aa3dec2fd00?features=false&vulnerabilities=true
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/background/node.yml
+++ b/spec/vcr_cassettes/background/node.yml
@@ -1,0 +1,2786 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://my.registry:5000/v2/node/manifests/8
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/vnd.docker.distribution.manifest.v2+json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Docker-Distribution-Api-Version:
+      - registry/2.0
+      Www-Authenticate:
+      - Bearer realm="https://my.registry:3000/v2/token",service="my.registry:5000",scope="repository:node:pull"
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Thu, 12 Apr 2018 10:34:10 GMT
+      Content-Length:
+      - '147'
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"code":"UNAUTHORIZED","message":"authentication required","detail":[{"Type":"repository","Class":"","Name":"node","Action":"pull"}]}]}
+
+'
+    http_version:
+  recorded_at: Thu, 12 Apr 2018 10:34:10 GMT
+- request:
+    method: get
+    uri: https://my.registry:3000/v2/token?account=portus&scope=repository:node:pull&service=my.registry:5000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic cG9ydHVzOnBvcnR1czEyMzQ=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Accept-Encoding
+      Etag:
+      - W/"4c18e610065a3eef582b57bbe55da4ad"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Set-Cookie:
+      - _portus_session=K293Y1Z2bVlNSFNTWmtYTS9EdTYyMGlaaEJWckRLTmQ1ZjdSSFNhZDAzWXRtNEIvNkRFejBrS3VRWlNVTjMyLy9Rdzh1M0Y4OEw4M0RTQVVKRkkvMXc9PS0tbTJLcmlUZENBalhmK1FtbnkxWmlIZz09--e2e06865f2d8ad25e2d6c929d6ba7bb42816b990;
+        path=/; HttpOnly
+      X-Request-Id:
+      - 5bdb916b-ec8b-4401-aed5-cf751b55c78e
+      X-Runtime:
+      - '0.253752'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlBUV1Q6Rk5KRTo3VFc3OlVMSTc6RFpRQTpKSkpJOlJESlE6Mk03NjpIRDZHOlpSU0M6VlBJRjpPNUJVIn0.eyJpc3MiOiIxNzIuMTcuMC4xIiwic3ViIjoicG9ydHVzIiwiYXVkIjoiMTcyLjE3LjAuMTo1MDAwIiwiaWF0IjoxNTIzNTI5MjUxLCJuYmYiOjE1MjM1MjkyNDYsImV4cCI6MTUyMzUyOTU1MSwianRpIjoiZ242TE5wdjhwRURSMXVmWWNVRWN6d3oxenpoUzRFUWZYVTlweEtDQ1JKIiwiYWNjZXNzIjpbeyJ0eXBlIjoicmVwb3NpdG9yeSIsIm5hbWUiOiJub2RlIiwiYWN0aW9ucyI6WyJwdWxsIl19XX0.gggqCnQAIOzAnvMzc8aU8Odrp-6hmsemzOxiDbozzn4KB25ekszpgqLOr7Xvv95hbM7gpdQ65g0ywQ4mXZh_xKOThofmXIvUgEhrfqqoXLzL0NbA-Ch0Ueirm98t1sIW0T6QSAS4T2GjgzpX97o88DnyrCHWlfbdS7vxSP9MC_utIQK9asC5dgePfOuMijI2xsEJ6is0Zbng04NPkfIJPxDwAMsnpnDWLiGP70j4do1TfpDF0Dewr6cdArfyn4QARd30XKSa61xqJoW_1WbOYamCGnG8kZZ7qrToMvJKReZRSSgUnJXV7NGiktC21owjQZEwXaw32IX9_sQTXGdx1L-d8o7VzNZVfbcFWoqScv_KIwx2K8Bz2Uc-aBVyLlbnaZQZHWP_bxwYitvK0UzVD6wguFkTlqIhdMmo9KytGQQAp4CEnTu0UPOkWKvmLB6du0H66JoLBnx1WBt_4uJZ7w0suG0FFsD1BeeruTlkMdPB_4X2exqZZGkIIKAchPpPXPE24MGhuOXQI7RK7NtmPwO3PkbGv0CTcWKKIwQSxQ4tv80qdhX8t5Xuj1JLzNSwvafKTo_KZkYK-PBsh5ZIjy3VDvnv9VCTr1ZFp-MEbI-2wB3yyF02VRoiwG1WmqSpkz-E52T3y3ZBQlzHjmwWEj0Lg2PHV0LpVA-83avm3rk","expires_in":300,"issued_at":"2018-04-12T10:34:11+00:00"}'
+    http_version:
+  recorded_at: Thu, 12 Apr 2018 10:34:11 GMT
+- request:
+    method: get
+    uri: https://my.registry:5000/v2/node/manifests/8
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/vnd.docker.distribution.manifest.v2+json
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlBUV1Q6Rk5KRTo3VFc3OlVMSTc6RFpRQTpKSkpJOlJESlE6Mk03NjpIRDZHOlpSU0M6VlBJRjpPNUJVIn0.eyJpc3MiOiIxNzIuMTcuMC4xIiwic3ViIjoicG9ydHVzIiwiYXVkIjoiMTcyLjE3LjAuMTo1MDAwIiwiaWF0IjoxNTIzNTI5MjUxLCJuYmYiOjE1MjM1MjkyNDYsImV4cCI6MTUyMzUyOTU1MSwianRpIjoiZ242TE5wdjhwRURSMXVmWWNVRWN6d3oxenpoUzRFUWZYVTlweEtDQ1JKIiwiYWNjZXNzIjpbeyJ0eXBlIjoicmVwb3NpdG9yeSIsIm5hbWUiOiJub2RlIiwiYWN0aW9ucyI6WyJwdWxsIl19XX0.gggqCnQAIOzAnvMzc8aU8Odrp-6hmsemzOxiDbozzn4KB25ekszpgqLOr7Xvv95hbM7gpdQ65g0ywQ4mXZh_xKOThofmXIvUgEhrfqqoXLzL0NbA-Ch0Ueirm98t1sIW0T6QSAS4T2GjgzpX97o88DnyrCHWlfbdS7vxSP9MC_utIQK9asC5dgePfOuMijI2xsEJ6is0Zbng04NPkfIJPxDwAMsnpnDWLiGP70j4do1TfpDF0Dewr6cdArfyn4QARd30XKSa61xqJoW_1WbOYamCGnG8kZZ7qrToMvJKReZRSSgUnJXV7NGiktC21owjQZEwXaw32IX9_sQTXGdx1L-d8o7VzNZVfbcFWoqScv_KIwx2K8Bz2Uc-aBVyLlbnaZQZHWP_bxwYitvK0UzVD6wguFkTlqIhdMmo9KytGQQAp4CEnTu0UPOkWKvmLB6du0H66JoLBnx1WBt_4uJZ7w0suG0FFsD1BeeruTlkMdPB_4X2exqZZGkIIKAchPpPXPE24MGhuOXQI7RK7NtmPwO3PkbGv0CTcWKKIwQSxQ4tv80qdhX8t5Xuj1JLzNSwvafKTo_KZkYK-PBsh5ZIjy3VDvnv9VCTr1ZFp-MEbI-2wB3yyF02VRoiwG1WmqSpkz-E52T3y3ZBQlzHjmwWEj0Lg2PHV0LpVA-83avm3rk
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '2007'
+      Content-Type:
+      - application/vnd.docker.distribution.manifest.v2+json
+      Docker-Content-Digest:
+      - sha256:021c1dba94d141972a13f62194fea0f8ef2a081cd9c03fd3f70a529886a8af11
+      Docker-Distribution-Api-Version:
+      - registry/2.0
+      Etag:
+      - '"sha256:021c1dba94d141972a13f62194fea0f8ef2a081cd9c03fd3f70a529886a8af11"'
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Thu, 12 Apr 2018 10:34:11 GMT
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+           "schemaVersion": 2,
+           "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+           "config": {
+              "mediaType": "application/vnd.docker.container.image.v1+json",
+              "size": 7088,
+              "digest": "sha256:b87c2ad8344dd1c1fdfd09060a99ff5dbac4a1fe1a079ad871dfa228fc628e1c"
+           },
+           "layers": [
+              {
+                 "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+                 "size": 52599697,
+                 "digest": "sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"
+              },
+              {
+                 "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+                 "size": 19266203,
+                 "digest": "sha256:7b491c575b06601bb07a2d88bfc3ace6c6005edc1b4d8da3ba6e37e04e9592d6"
+              },
+              {
+                 "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+                 "size": 43253338,
+                 "digest": "sha256:b313b08bab3b8bbcf0de4171a2a80a01e67fab094f272819b76a58705d21ab28"
+              },
+              {
+                 "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+                 "size": 134968174,
+                 "digest": "sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"
+              },
+              {
+                 "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+                 "size": 4424,
+                 "digest": "sha256:da59faba155ba522f726da405914802862317b14c957fa22d9f2fe3e1b45fccb"
+              },
+              {
+                 "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+                 "size": 117628,
+                 "digest": "sha256:7f84ea62c1fd111da5519283a2ed50cb93bbe1023dd1d2c2aeda13b105ba97d0"
+              },
+              {
+                 "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+                 "size": 18508716,
+                 "digest": "sha256:0ae80f895f0292b5bb9871cf83ef266835aa590d755b4dd0839a3cb74c9d509f"
+              },
+              {
+                 "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+                 "size": 1010359,
+                 "digest": "sha256:2f11c95c9552c41316c9c6943b1160f098c5a9700bb5fc6ae57dfba7ef10dffc"
+              }
+           ]
+        }
+    http_version:
+  recorded_at: Thu, 12 Apr 2018 10:34:11 GMT
+- request:
+    method: post
+    uri: http://my.clair:6060/v1/layers
+    body:
+      encoding: UTF-8
+      string: '{"Layer":{"Name":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa","NamespaceName":"","Path":"https://my.registry:5000/v2/node/blobs/sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa","Headers":{"Authorization":"Bearer
+        eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlBUV1Q6Rk5KRTo3VFc3OlVMSTc6RFpRQTpKSkpJOlJESlE6Mk03NjpIRDZHOlpSU0M6VlBJRjpPNUJVIn0.eyJpc3MiOiIxNzIuMTcuMC4xIiwic3ViIjoicG9ydHVzIiwiYXVkIjoiMTcyLjE3LjAuMTo1MDAwIiwiaWF0IjoxNTIzNTI5MjUxLCJuYmYiOjE1MjM1MjkyNDYsImV4cCI6MTUyMzUyOTU1MSwianRpIjoiZ242TE5wdjhwRURSMXVmWWNVRWN6d3oxenpoUzRFUWZYVTlweEtDQ1JKIiwiYWNjZXNzIjpbeyJ0eXBlIjoicmVwb3NpdG9yeSIsIm5hbWUiOiJub2RlIiwiYWN0aW9ucyI6WyJwdWxsIl19XX0.gggqCnQAIOzAnvMzc8aU8Odrp-6hmsemzOxiDbozzn4KB25ekszpgqLOr7Xvv95hbM7gpdQ65g0ywQ4mXZh_xKOThofmXIvUgEhrfqqoXLzL0NbA-Ch0Ueirm98t1sIW0T6QSAS4T2GjgzpX97o88DnyrCHWlfbdS7vxSP9MC_utIQK9asC5dgePfOuMijI2xsEJ6is0Zbng04NPkfIJPxDwAMsnpnDWLiGP70j4do1TfpDF0Dewr6cdArfyn4QARd30XKSa61xqJoW_1WbOYamCGnG8kZZ7qrToMvJKReZRSSgUnJXV7NGiktC21owjQZEwXaw32IX9_sQTXGdx1L-d8o7VzNZVfbcFWoqScv_KIwx2K8Bz2Uc-aBVyLlbnaZQZHWP_bxwYitvK0UzVD6wguFkTlqIhdMmo9KytGQQAp4CEnTu0UPOkWKvmLB6du0H66JoLBnx1WBt_4uJZ7w0suG0FFsD1BeeruTlkMdPB_4X2exqZZGkIIKAchPpPXPE24MGhuOXQI7RK7NtmPwO3PkbGv0CTcWKKIwQSxQ4tv80qdhX8t5Xuj1JLzNSwvafKTo_KZkYK-PBsh5ZIjy3VDvnv9VCTr1ZFp-MEbI-2wB3yyF02VRoiwG1WmqSpkz-E52T3y3ZBQlzHjmwWEj0Lg2PHV0LpVA-83avm3rk"},"ParentName":"","Format":"Docker","IndexedByVersion":0,"Features":[]}}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Server:
+      - clair
+      Date:
+      - Thu, 12 Apr 2018 10:34:11 GMT
+      Content-Length:
+      - '1065'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"Layer":{"Name":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa","Path":"https://my.registry:5000/v2/node/blobs/sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa","Headers":{"Authorization":"Bearer
+        eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlBUV1Q6Rk5KRTo3VFc3OlVMSTc6RFpRQTpKSkpJOlJESlE6Mk03NjpIRDZHOlpSU0M6VlBJRjpPNUJVIn0.eyJpc3MiOiIxNzIuMTcuMC4xIiwic3ViIjoicG9ydHVzIiwiYXVkIjoiMTcyLjE3LjAuMTo1MDAwIiwiaWF0IjoxNTIzNTI5MjUxLCJuYmYiOjE1MjM1MjkyNDYsImV4cCI6MTUyMzUyOTU1MSwianRpIjoiZ242TE5wdjhwRURSMXVmWWNVRWN6d3oxenpoUzRFUWZYVTlweEtDQ1JKIiwiYWNjZXNzIjpbeyJ0eXBlIjoicmVwb3NpdG9yeSIsIm5hbWUiOiJub2RlIiwiYWN0aW9ucyI6WyJwdWxsIl19XX0.gggqCnQAIOzAnvMzc8aU8Odrp-6hmsemzOxiDbozzn4KB25ekszpgqLOr7Xvv95hbM7gpdQ65g0ywQ4mXZh_xKOThofmXIvUgEhrfqqoXLzL0NbA-Ch0Ueirm98t1sIW0T6QSAS4T2GjgzpX97o88DnyrCHWlfbdS7vxSP9MC_utIQK9asC5dgePfOuMijI2xsEJ6is0Zbng04NPkfIJPxDwAMsnpnDWLiGP70j4do1TfpDF0Dewr6cdArfyn4QARd30XKSa61xqJoW_1WbOYamCGnG8kZZ7qrToMvJKReZRSSgUnJXV7NGiktC21owjQZEwXaw32IX9_sQTXGdx1L-d8o7VzNZVfbcFWoqScv_KIwx2K8Bz2Uc-aBVyLlbnaZQZHWP_bxwYitvK0UzVD6wguFkTlqIhdMmo9KytGQQAp4CEnTu0UPOkWKvmLB6du0H66JoLBnx1WBt_4uJZ7w0suG0FFsD1BeeruTlkMdPB_4X2exqZZGkIIKAchPpPXPE24MGhuOXQI7RK7NtmPwO3PkbGv0CTcWKKIwQSxQ4tv80qdhX8t5Xuj1JLzNSwvafKTo_KZkYK-PBsh5ZIjy3VDvnv9VCTr1ZFp-MEbI-2wB3yyF02VRoiwG1WmqSpkz-E52T3y3ZBQlzHjmwWEj0Lg2PHV0LpVA-83avm3rk"},"Format":"Docker","IndexedByVersion":3}}
+
+'
+    http_version:
+  recorded_at: Thu, 12 Apr 2018 10:34:11 GMT
+- request:
+    method: post
+    uri: http://my.clair:6060/v1/layers
+    body:
+      encoding: UTF-8
+      string: '{"Layer":{"Name":"sha256:7b491c575b06601bb07a2d88bfc3ace6c6005edc1b4d8da3ba6e37e04e9592d6","NamespaceName":"","Path":"https://my.registry:5000/v2/node/blobs/sha256:7b491c575b06601bb07a2d88bfc3ace6c6005edc1b4d8da3ba6e37e04e9592d6","Headers":{"Authorization":"Bearer
+        eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlBUV1Q6Rk5KRTo3VFc3OlVMSTc6RFpRQTpKSkpJOlJESlE6Mk03NjpIRDZHOlpSU0M6VlBJRjpPNUJVIn0.eyJpc3MiOiIxNzIuMTcuMC4xIiwic3ViIjoicG9ydHVzIiwiYXVkIjoiMTcyLjE3LjAuMTo1MDAwIiwiaWF0IjoxNTIzNTI5MjUxLCJuYmYiOjE1MjM1MjkyNDYsImV4cCI6MTUyMzUyOTU1MSwianRpIjoiZ242TE5wdjhwRURSMXVmWWNVRWN6d3oxenpoUzRFUWZYVTlweEtDQ1JKIiwiYWNjZXNzIjpbeyJ0eXBlIjoicmVwb3NpdG9yeSIsIm5hbWUiOiJub2RlIiwiYWN0aW9ucyI6WyJwdWxsIl19XX0.gggqCnQAIOzAnvMzc8aU8Odrp-6hmsemzOxiDbozzn4KB25ekszpgqLOr7Xvv95hbM7gpdQ65g0ywQ4mXZh_xKOThofmXIvUgEhrfqqoXLzL0NbA-Ch0Ueirm98t1sIW0T6QSAS4T2GjgzpX97o88DnyrCHWlfbdS7vxSP9MC_utIQK9asC5dgePfOuMijI2xsEJ6is0Zbng04NPkfIJPxDwAMsnpnDWLiGP70j4do1TfpDF0Dewr6cdArfyn4QARd30XKSa61xqJoW_1WbOYamCGnG8kZZ7qrToMvJKReZRSSgUnJXV7NGiktC21owjQZEwXaw32IX9_sQTXGdx1L-d8o7VzNZVfbcFWoqScv_KIwx2K8Bz2Uc-aBVyLlbnaZQZHWP_bxwYitvK0UzVD6wguFkTlqIhdMmo9KytGQQAp4CEnTu0UPOkWKvmLB6du0H66JoLBnx1WBt_4uJZ7w0suG0FFsD1BeeruTlkMdPB_4X2exqZZGkIIKAchPpPXPE24MGhuOXQI7RK7NtmPwO3PkbGv0CTcWKKIwQSxQ4tv80qdhX8t5Xuj1JLzNSwvafKTo_KZkYK-PBsh5ZIjy3VDvnv9VCTr1ZFp-MEbI-2wB3yyF02VRoiwG1WmqSpkz-E52T3y3ZBQlzHjmwWEj0Lg2PHV0LpVA-83avm3rk"},"ParentName":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa","Format":"Docker","IndexedByVersion":0,"Features":[]}}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Server:
+      - clair
+      Date:
+      - Thu, 12 Apr 2018 10:34:11 GMT
+      Content-Length:
+      - '1123'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"Layer":{"Name":"sha256:7b491c575b06601bb07a2d88bfc3ace6c6005edc1b4d8da3ba6e37e04e9592d6","Path":"https://my.registry:5000/v2/node/blobs/sha256:7b491c575b06601bb07a2d88bfc3ace6c6005edc1b4d8da3ba6e37e04e9592d6","Headers":{"Authorization":"Bearer
+        eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlBUV1Q6Rk5KRTo3VFc3OlVMSTc6RFpRQTpKSkpJOlJESlE6Mk03NjpIRDZHOlpSU0M6VlBJRjpPNUJVIn0.eyJpc3MiOiIxNzIuMTcuMC4xIiwic3ViIjoicG9ydHVzIiwiYXVkIjoiMTcyLjE3LjAuMTo1MDAwIiwiaWF0IjoxNTIzNTI5MjUxLCJuYmYiOjE1MjM1MjkyNDYsImV4cCI6MTUyMzUyOTU1MSwianRpIjoiZ242TE5wdjhwRURSMXVmWWNVRWN6d3oxenpoUzRFUWZYVTlweEtDQ1JKIiwiYWNjZXNzIjpbeyJ0eXBlIjoicmVwb3NpdG9yeSIsIm5hbWUiOiJub2RlIiwiYWN0aW9ucyI6WyJwdWxsIl19XX0.gggqCnQAIOzAnvMzc8aU8Odrp-6hmsemzOxiDbozzn4KB25ekszpgqLOr7Xvv95hbM7gpdQ65g0ywQ4mXZh_xKOThofmXIvUgEhrfqqoXLzL0NbA-Ch0Ueirm98t1sIW0T6QSAS4T2GjgzpX97o88DnyrCHWlfbdS7vxSP9MC_utIQK9asC5dgePfOuMijI2xsEJ6is0Zbng04NPkfIJPxDwAMsnpnDWLiGP70j4do1TfpDF0Dewr6cdArfyn4QARd30XKSa61xqJoW_1WbOYamCGnG8kZZ7qrToMvJKReZRSSgUnJXV7NGiktC21owjQZEwXaw32IX9_sQTXGdx1L-d8o7VzNZVfbcFWoqScv_KIwx2K8Bz2Uc-aBVyLlbnaZQZHWP_bxwYitvK0UzVD6wguFkTlqIhdMmo9KytGQQAp4CEnTu0UPOkWKvmLB6du0H66JoLBnx1WBt_4uJZ7w0suG0FFsD1BeeruTlkMdPB_4X2exqZZGkIIKAchPpPXPE24MGhuOXQI7RK7NtmPwO3PkbGv0CTcWKKIwQSxQ4tv80qdhX8t5Xuj1JLzNSwvafKTo_KZkYK-PBsh5ZIjy3VDvnv9VCTr1ZFp-MEbI-2wB3yyF02VRoiwG1WmqSpkz-E52T3y3ZBQlzHjmwWEj0Lg2PHV0LpVA-83avm3rk"},"ParentName":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa","Format":"Docker","IndexedByVersion":3}}
+
+'
+    http_version:
+  recorded_at: Thu, 12 Apr 2018 10:34:11 GMT
+- request:
+    method: post
+    uri: http://my.clair:6060/v1/layers
+    body:
+      encoding: UTF-8
+      string: '{"Layer":{"Name":"sha256:b313b08bab3b8bbcf0de4171a2a80a01e67fab094f272819b76a58705d21ab28","NamespaceName":"","Path":"https://my.registry:5000/v2/node/blobs/sha256:b313b08bab3b8bbcf0de4171a2a80a01e67fab094f272819b76a58705d21ab28","Headers":{"Authorization":"Bearer
+        eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlBUV1Q6Rk5KRTo3VFc3OlVMSTc6RFpRQTpKSkpJOlJESlE6Mk03NjpIRDZHOlpSU0M6VlBJRjpPNUJVIn0.eyJpc3MiOiIxNzIuMTcuMC4xIiwic3ViIjoicG9ydHVzIiwiYXVkIjoiMTcyLjE3LjAuMTo1MDAwIiwiaWF0IjoxNTIzNTI5MjUxLCJuYmYiOjE1MjM1MjkyNDYsImV4cCI6MTUyMzUyOTU1MSwianRpIjoiZ242TE5wdjhwRURSMXVmWWNVRWN6d3oxenpoUzRFUWZYVTlweEtDQ1JKIiwiYWNjZXNzIjpbeyJ0eXBlIjoicmVwb3NpdG9yeSIsIm5hbWUiOiJub2RlIiwiYWN0aW9ucyI6WyJwdWxsIl19XX0.gggqCnQAIOzAnvMzc8aU8Odrp-6hmsemzOxiDbozzn4KB25ekszpgqLOr7Xvv95hbM7gpdQ65g0ywQ4mXZh_xKOThofmXIvUgEhrfqqoXLzL0NbA-Ch0Ueirm98t1sIW0T6QSAS4T2GjgzpX97o88DnyrCHWlfbdS7vxSP9MC_utIQK9asC5dgePfOuMijI2xsEJ6is0Zbng04NPkfIJPxDwAMsnpnDWLiGP70j4do1TfpDF0Dewr6cdArfyn4QARd30XKSa61xqJoW_1WbOYamCGnG8kZZ7qrToMvJKReZRSSgUnJXV7NGiktC21owjQZEwXaw32IX9_sQTXGdx1L-d8o7VzNZVfbcFWoqScv_KIwx2K8Bz2Uc-aBVyLlbnaZQZHWP_bxwYitvK0UzVD6wguFkTlqIhdMmo9KytGQQAp4CEnTu0UPOkWKvmLB6du0H66JoLBnx1WBt_4uJZ7w0suG0FFsD1BeeruTlkMdPB_4X2exqZZGkIIKAchPpPXPE24MGhuOXQI7RK7NtmPwO3PkbGv0CTcWKKIwQSxQ4tv80qdhX8t5Xuj1JLzNSwvafKTo_KZkYK-PBsh5ZIjy3VDvnv9VCTr1ZFp-MEbI-2wB3yyF02VRoiwG1WmqSpkz-E52T3y3ZBQlzHjmwWEj0Lg2PHV0LpVA-83avm3rk"},"ParentName":"sha256:7b491c575b06601bb07a2d88bfc3ace6c6005edc1b4d8da3ba6e37e04e9592d6","Format":"Docker","IndexedByVersion":0,"Features":[]}}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Server:
+      - clair
+      Date:
+      - Thu, 12 Apr 2018 10:34:11 GMT
+      Content-Length:
+      - '1123'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"Layer":{"Name":"sha256:b313b08bab3b8bbcf0de4171a2a80a01e67fab094f272819b76a58705d21ab28","Path":"https://my.registry:5000/v2/node/blobs/sha256:b313b08bab3b8bbcf0de4171a2a80a01e67fab094f272819b76a58705d21ab28","Headers":{"Authorization":"Bearer
+        eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlBUV1Q6Rk5KRTo3VFc3OlVMSTc6RFpRQTpKSkpJOlJESlE6Mk03NjpIRDZHOlpSU0M6VlBJRjpPNUJVIn0.eyJpc3MiOiIxNzIuMTcuMC4xIiwic3ViIjoicG9ydHVzIiwiYXVkIjoiMTcyLjE3LjAuMTo1MDAwIiwiaWF0IjoxNTIzNTI5MjUxLCJuYmYiOjE1MjM1MjkyNDYsImV4cCI6MTUyMzUyOTU1MSwianRpIjoiZ242TE5wdjhwRURSMXVmWWNVRWN6d3oxenpoUzRFUWZYVTlweEtDQ1JKIiwiYWNjZXNzIjpbeyJ0eXBlIjoicmVwb3NpdG9yeSIsIm5hbWUiOiJub2RlIiwiYWN0aW9ucyI6WyJwdWxsIl19XX0.gggqCnQAIOzAnvMzc8aU8Odrp-6hmsemzOxiDbozzn4KB25ekszpgqLOr7Xvv95hbM7gpdQ65g0ywQ4mXZh_xKOThofmXIvUgEhrfqqoXLzL0NbA-Ch0Ueirm98t1sIW0T6QSAS4T2GjgzpX97o88DnyrCHWlfbdS7vxSP9MC_utIQK9asC5dgePfOuMijI2xsEJ6is0Zbng04NPkfIJPxDwAMsnpnDWLiGP70j4do1TfpDF0Dewr6cdArfyn4QARd30XKSa61xqJoW_1WbOYamCGnG8kZZ7qrToMvJKReZRSSgUnJXV7NGiktC21owjQZEwXaw32IX9_sQTXGdx1L-d8o7VzNZVfbcFWoqScv_KIwx2K8Bz2Uc-aBVyLlbnaZQZHWP_bxwYitvK0UzVD6wguFkTlqIhdMmo9KytGQQAp4CEnTu0UPOkWKvmLB6du0H66JoLBnx1WBt_4uJZ7w0suG0FFsD1BeeruTlkMdPB_4X2exqZZGkIIKAchPpPXPE24MGhuOXQI7RK7NtmPwO3PkbGv0CTcWKKIwQSxQ4tv80qdhX8t5Xuj1JLzNSwvafKTo_KZkYK-PBsh5ZIjy3VDvnv9VCTr1ZFp-MEbI-2wB3yyF02VRoiwG1WmqSpkz-E52T3y3ZBQlzHjmwWEj0Lg2PHV0LpVA-83avm3rk"},"ParentName":"sha256:7b491c575b06601bb07a2d88bfc3ace6c6005edc1b4d8da3ba6e37e04e9592d6","Format":"Docker","IndexedByVersion":3}}
+
+'
+    http_version:
+  recorded_at: Thu, 12 Apr 2018 10:34:11 GMT
+- request:
+    method: post
+    uri: http://my.clair:6060/v1/layers
+    body:
+      encoding: UTF-8
+      string: '{"Layer":{"Name":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5","NamespaceName":"","Path":"https://my.registry:5000/v2/node/blobs/sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5","Headers":{"Authorization":"Bearer
+        eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlBUV1Q6Rk5KRTo3VFc3OlVMSTc6RFpRQTpKSkpJOlJESlE6Mk03NjpIRDZHOlpSU0M6VlBJRjpPNUJVIn0.eyJpc3MiOiIxNzIuMTcuMC4xIiwic3ViIjoicG9ydHVzIiwiYXVkIjoiMTcyLjE3LjAuMTo1MDAwIiwiaWF0IjoxNTIzNTI5MjUxLCJuYmYiOjE1MjM1MjkyNDYsImV4cCI6MTUyMzUyOTU1MSwianRpIjoiZ242TE5wdjhwRURSMXVmWWNVRWN6d3oxenpoUzRFUWZYVTlweEtDQ1JKIiwiYWNjZXNzIjpbeyJ0eXBlIjoicmVwb3NpdG9yeSIsIm5hbWUiOiJub2RlIiwiYWN0aW9ucyI6WyJwdWxsIl19XX0.gggqCnQAIOzAnvMzc8aU8Odrp-6hmsemzOxiDbozzn4KB25ekszpgqLOr7Xvv95hbM7gpdQ65g0ywQ4mXZh_xKOThofmXIvUgEhrfqqoXLzL0NbA-Ch0Ueirm98t1sIW0T6QSAS4T2GjgzpX97o88DnyrCHWlfbdS7vxSP9MC_utIQK9asC5dgePfOuMijI2xsEJ6is0Zbng04NPkfIJPxDwAMsnpnDWLiGP70j4do1TfpDF0Dewr6cdArfyn4QARd30XKSa61xqJoW_1WbOYamCGnG8kZZ7qrToMvJKReZRSSgUnJXV7NGiktC21owjQZEwXaw32IX9_sQTXGdx1L-d8o7VzNZVfbcFWoqScv_KIwx2K8Bz2Uc-aBVyLlbnaZQZHWP_bxwYitvK0UzVD6wguFkTlqIhdMmo9KytGQQAp4CEnTu0UPOkWKvmLB6du0H66JoLBnx1WBt_4uJZ7w0suG0FFsD1BeeruTlkMdPB_4X2exqZZGkIIKAchPpPXPE24MGhuOXQI7RK7NtmPwO3PkbGv0CTcWKKIwQSxQ4tv80qdhX8t5Xuj1JLzNSwvafKTo_KZkYK-PBsh5ZIjy3VDvnv9VCTr1ZFp-MEbI-2wB3yyF02VRoiwG1WmqSpkz-E52T3y3ZBQlzHjmwWEj0Lg2PHV0LpVA-83avm3rk"},"ParentName":"sha256:b313b08bab3b8bbcf0de4171a2a80a01e67fab094f272819b76a58705d21ab28","Format":"Docker","IndexedByVersion":0,"Features":[]}}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Server:
+      - clair
+      Date:
+      - Thu, 12 Apr 2018 10:34:11 GMT
+      Content-Length:
+      - '1122'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"Layer":{"Name":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5","Path":"https://my.registry:5000/v2/node/blobs/sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5","Headers":{"Authorization":"Bearer
+        eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlBUV1Q6Rk5KRTo3VFc3OlVMSTc6RFpRQTpKSkpJOlJESlE6Mk03NjpIRDZHOlpSU0M6VlBJRjpPNUJVIn0.eyJpc3MiOiIxNzIuMTcuMC4xIiwic3ViIjoicG9ydHVzIiwiYXVkIjoiMTcyLjE3LjAuMTo1MDAwIiwiaWF0IjoxNTIzNTI5MjUxLCJuYmYiOjE1MjM1MjkyNDYsImV4cCI6MTUyMzUyOTU1MSwianRpIjoiZ242TE5wdjhwRURSMXVmWWNVRWN6d3oxenpoUzRFUWZYVTlweEtDQ1JKIiwiYWNjZXNzIjpbeyJ0eXBlIjoicmVwb3NpdG9yeSIsIm5hbWUiOiJub2RlIiwiYWN0aW9ucyI6WyJwdWxsIl19XX0.gggqCnQAIOzAnvMzc8aU8Odrp-6hmsemzOxiDbozzn4KB25ekszpgqLOr7Xvv95hbM7gpdQ65g0ywQ4mXZh_xKOThofmXIvUgEhrfqqoXLzL0NbA-Ch0Ueirm98t1sIW0T6QSAS4T2GjgzpX97o88DnyrCHWlfbdS7vxSP9MC_utIQK9asC5dgePfOuMijI2xsEJ6is0Zbng04NPkfIJPxDwAMsnpnDWLiGP70j4do1TfpDF0Dewr6cdArfyn4QARd30XKSa61xqJoW_1WbOYamCGnG8kZZ7qrToMvJKReZRSSgUnJXV7NGiktC21owjQZEwXaw32IX9_sQTXGdx1L-d8o7VzNZVfbcFWoqScv_KIwx2K8Bz2Uc-aBVyLlbnaZQZHWP_bxwYitvK0UzVD6wguFkTlqIhdMmo9KytGQQAp4CEnTu0UPOkWKvmLB6du0H66JoLBnx1WBt_4uJZ7w0suG0FFsD1BeeruTlkMdPB_4X2exqZZGkIIKAchPpPXPE24MGhuOXQI7RK7NtmPwO3PkbGv0CTcWKKIwQSxQ4tv80qdhX8t5Xuj1JLzNSwvafKTo_KZkYK-PBsh5ZIjy3VDvnv9VCTr1ZFp-MEbI-2wB3yyF02VRoiwG1WmqSpkz-E52T3y3ZBQlzHjmwWEj0Lg2PHV0LpVA-83avm3rk"},"ParentName":"sha256:b313b08bab3b8bbcf0de4171a2a80a01e67fab094f272819b76a58705d21ab28","Format":"Docker","IndexedByVersion":3}}
+
+'
+    http_version:
+  recorded_at: Thu, 12 Apr 2018 10:34:11 GMT
+- request:
+    method: post
+    uri: http://my.clair:6060/v1/layers
+    body:
+      encoding: UTF-8
+      string: '{"Layer":{"Name":"sha256:da59faba155ba522f726da405914802862317b14c957fa22d9f2fe3e1b45fccb","NamespaceName":"","Path":"https://my.registry:5000/v2/node/blobs/sha256:da59faba155ba522f726da405914802862317b14c957fa22d9f2fe3e1b45fccb","Headers":{"Authorization":"Bearer
+        eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlBUV1Q6Rk5KRTo3VFc3OlVMSTc6RFpRQTpKSkpJOlJESlE6Mk03NjpIRDZHOlpSU0M6VlBJRjpPNUJVIn0.eyJpc3MiOiIxNzIuMTcuMC4xIiwic3ViIjoicG9ydHVzIiwiYXVkIjoiMTcyLjE3LjAuMTo1MDAwIiwiaWF0IjoxNTIzNTI5MjUxLCJuYmYiOjE1MjM1MjkyNDYsImV4cCI6MTUyMzUyOTU1MSwianRpIjoiZ242TE5wdjhwRURSMXVmWWNVRWN6d3oxenpoUzRFUWZYVTlweEtDQ1JKIiwiYWNjZXNzIjpbeyJ0eXBlIjoicmVwb3NpdG9yeSIsIm5hbWUiOiJub2RlIiwiYWN0aW9ucyI6WyJwdWxsIl19XX0.gggqCnQAIOzAnvMzc8aU8Odrp-6hmsemzOxiDbozzn4KB25ekszpgqLOr7Xvv95hbM7gpdQ65g0ywQ4mXZh_xKOThofmXIvUgEhrfqqoXLzL0NbA-Ch0Ueirm98t1sIW0T6QSAS4T2GjgzpX97o88DnyrCHWlfbdS7vxSP9MC_utIQK9asC5dgePfOuMijI2xsEJ6is0Zbng04NPkfIJPxDwAMsnpnDWLiGP70j4do1TfpDF0Dewr6cdArfyn4QARd30XKSa61xqJoW_1WbOYamCGnG8kZZ7qrToMvJKReZRSSgUnJXV7NGiktC21owjQZEwXaw32IX9_sQTXGdx1L-d8o7VzNZVfbcFWoqScv_KIwx2K8Bz2Uc-aBVyLlbnaZQZHWP_bxwYitvK0UzVD6wguFkTlqIhdMmo9KytGQQAp4CEnTu0UPOkWKvmLB6du0H66JoLBnx1WBt_4uJZ7w0suG0FFsD1BeeruTlkMdPB_4X2exqZZGkIIKAchPpPXPE24MGhuOXQI7RK7NtmPwO3PkbGv0CTcWKKIwQSxQ4tv80qdhX8t5Xuj1JLzNSwvafKTo_KZkYK-PBsh5ZIjy3VDvnv9VCTr1ZFp-MEbI-2wB3yyF02VRoiwG1WmqSpkz-E52T3y3ZBQlzHjmwWEj0Lg2PHV0LpVA-83avm3rk"},"ParentName":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5","Format":"Docker","IndexedByVersion":0,"Features":[]}}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Server:
+      - clair
+      Date:
+      - Thu, 12 Apr 2018 10:34:11 GMT
+      Content-Length:
+      - '1123'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"Layer":{"Name":"sha256:da59faba155ba522f726da405914802862317b14c957fa22d9f2fe3e1b45fccb","Path":"https://my.registry:5000/v2/node/blobs/sha256:da59faba155ba522f726da405914802862317b14c957fa22d9f2fe3e1b45fccb","Headers":{"Authorization":"Bearer
+        eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlBUV1Q6Rk5KRTo3VFc3OlVMSTc6RFpRQTpKSkpJOlJESlE6Mk03NjpIRDZHOlpSU0M6VlBJRjpPNUJVIn0.eyJpc3MiOiIxNzIuMTcuMC4xIiwic3ViIjoicG9ydHVzIiwiYXVkIjoiMTcyLjE3LjAuMTo1MDAwIiwiaWF0IjoxNTIzNTI5MjUxLCJuYmYiOjE1MjM1MjkyNDYsImV4cCI6MTUyMzUyOTU1MSwianRpIjoiZ242TE5wdjhwRURSMXVmWWNVRWN6d3oxenpoUzRFUWZYVTlweEtDQ1JKIiwiYWNjZXNzIjpbeyJ0eXBlIjoicmVwb3NpdG9yeSIsIm5hbWUiOiJub2RlIiwiYWN0aW9ucyI6WyJwdWxsIl19XX0.gggqCnQAIOzAnvMzc8aU8Odrp-6hmsemzOxiDbozzn4KB25ekszpgqLOr7Xvv95hbM7gpdQ65g0ywQ4mXZh_xKOThofmXIvUgEhrfqqoXLzL0NbA-Ch0Ueirm98t1sIW0T6QSAS4T2GjgzpX97o88DnyrCHWlfbdS7vxSP9MC_utIQK9asC5dgePfOuMijI2xsEJ6is0Zbng04NPkfIJPxDwAMsnpnDWLiGP70j4do1TfpDF0Dewr6cdArfyn4QARd30XKSa61xqJoW_1WbOYamCGnG8kZZ7qrToMvJKReZRSSgUnJXV7NGiktC21owjQZEwXaw32IX9_sQTXGdx1L-d8o7VzNZVfbcFWoqScv_KIwx2K8Bz2Uc-aBVyLlbnaZQZHWP_bxwYitvK0UzVD6wguFkTlqIhdMmo9KytGQQAp4CEnTu0UPOkWKvmLB6du0H66JoLBnx1WBt_4uJZ7w0suG0FFsD1BeeruTlkMdPB_4X2exqZZGkIIKAchPpPXPE24MGhuOXQI7RK7NtmPwO3PkbGv0CTcWKKIwQSxQ4tv80qdhX8t5Xuj1JLzNSwvafKTo_KZkYK-PBsh5ZIjy3VDvnv9VCTr1ZFp-MEbI-2wB3yyF02VRoiwG1WmqSpkz-E52T3y3ZBQlzHjmwWEj0Lg2PHV0LpVA-83avm3rk"},"ParentName":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5","Format":"Docker","IndexedByVersion":3}}
+
+'
+    http_version:
+  recorded_at: Thu, 12 Apr 2018 10:34:11 GMT
+- request:
+    method: post
+    uri: http://my.clair:6060/v1/layers
+    body:
+      encoding: UTF-8
+      string: '{"Layer":{"Name":"sha256:7f84ea62c1fd111da5519283a2ed50cb93bbe1023dd1d2c2aeda13b105ba97d0","NamespaceName":"","Path":"https://my.registry:5000/v2/node/blobs/sha256:7f84ea62c1fd111da5519283a2ed50cb93bbe1023dd1d2c2aeda13b105ba97d0","Headers":{"Authorization":"Bearer
+        eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlBUV1Q6Rk5KRTo3VFc3OlVMSTc6RFpRQTpKSkpJOlJESlE6Mk03NjpIRDZHOlpSU0M6VlBJRjpPNUJVIn0.eyJpc3MiOiIxNzIuMTcuMC4xIiwic3ViIjoicG9ydHVzIiwiYXVkIjoiMTcyLjE3LjAuMTo1MDAwIiwiaWF0IjoxNTIzNTI5MjUxLCJuYmYiOjE1MjM1MjkyNDYsImV4cCI6MTUyMzUyOTU1MSwianRpIjoiZ242TE5wdjhwRURSMXVmWWNVRWN6d3oxenpoUzRFUWZYVTlweEtDQ1JKIiwiYWNjZXNzIjpbeyJ0eXBlIjoicmVwb3NpdG9yeSIsIm5hbWUiOiJub2RlIiwiYWN0aW9ucyI6WyJwdWxsIl19XX0.gggqCnQAIOzAnvMzc8aU8Odrp-6hmsemzOxiDbozzn4KB25ekszpgqLOr7Xvv95hbM7gpdQ65g0ywQ4mXZh_xKOThofmXIvUgEhrfqqoXLzL0NbA-Ch0Ueirm98t1sIW0T6QSAS4T2GjgzpX97o88DnyrCHWlfbdS7vxSP9MC_utIQK9asC5dgePfOuMijI2xsEJ6is0Zbng04NPkfIJPxDwAMsnpnDWLiGP70j4do1TfpDF0Dewr6cdArfyn4QARd30XKSa61xqJoW_1WbOYamCGnG8kZZ7qrToMvJKReZRSSgUnJXV7NGiktC21owjQZEwXaw32IX9_sQTXGdx1L-d8o7VzNZVfbcFWoqScv_KIwx2K8Bz2Uc-aBVyLlbnaZQZHWP_bxwYitvK0UzVD6wguFkTlqIhdMmo9KytGQQAp4CEnTu0UPOkWKvmLB6du0H66JoLBnx1WBt_4uJZ7w0suG0FFsD1BeeruTlkMdPB_4X2exqZZGkIIKAchPpPXPE24MGhuOXQI7RK7NtmPwO3PkbGv0CTcWKKIwQSxQ4tv80qdhX8t5Xuj1JLzNSwvafKTo_KZkYK-PBsh5ZIjy3VDvnv9VCTr1ZFp-MEbI-2wB3yyF02VRoiwG1WmqSpkz-E52T3y3ZBQlzHjmwWEj0Lg2PHV0LpVA-83avm3rk"},"ParentName":"sha256:da59faba155ba522f726da405914802862317b14c957fa22d9f2fe3e1b45fccb","Format":"Docker","IndexedByVersion":0,"Features":[]}}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Server:
+      - clair
+      Date:
+      - Thu, 12 Apr 2018 10:34:11 GMT
+      Content-Length:
+      - '1126'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"Layer":{"Name":"sha256:7f84ea62c1fd111da5519283a2ed50cb93bbe1023dd1d2c2aeda13b105ba97d0","Path":"https://my.registry:5000/v2/node/blobs/sha256:7f84ea62c1fd111da5519283a2ed50cb93bbe1023dd1d2c2aeda13b105ba97d0","Headers":{"Authorization":"Bearer
+        eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlBUV1Q6Rk5KRTo3VFc3OlVMSTc6RFpRQTpKSkpJOlJESlE6Mk03NjpIRDZHOlpSU0M6VlBJRjpPNUJVIn0.eyJpc3MiOiIxNzIuMTcuMC4xIiwic3ViIjoicG9ydHVzIiwiYXVkIjoiMTcyLjE3LjAuMTo1MDAwIiwiaWF0IjoxNTIzNTI5MjUxLCJuYmYiOjE1MjM1MjkyNDYsImV4cCI6MTUyMzUyOTU1MSwianRpIjoiZ242TE5wdjhwRURSMXVmWWNVRWN6d3oxenpoUzRFUWZYVTlweEtDQ1JKIiwiYWNjZXNzIjpbeyJ0eXBlIjoicmVwb3NpdG9yeSIsIm5hbWUiOiJub2RlIiwiYWN0aW9ucyI6WyJwdWxsIl19XX0.gggqCnQAIOzAnvMzc8aU8Odrp-6hmsemzOxiDbozzn4KB25ekszpgqLOr7Xvv95hbM7gpdQ65g0ywQ4mXZh_xKOThofmXIvUgEhrfqqoXLzL0NbA-Ch0Ueirm98t1sIW0T6QSAS4T2GjgzpX97o88DnyrCHWlfbdS7vxSP9MC_utIQK9asC5dgePfOuMijI2xsEJ6is0Zbng04NPkfIJPxDwAMsnpnDWLiGP70j4do1TfpDF0Dewr6cdArfyn4QARd30XKSa61xqJoW_1WbOYamCGnG8kZZ7qrToMvJKReZRSSgUnJXV7NGiktC21owjQZEwXaw32IX9_sQTXGdx1L-d8o7VzNZVfbcFWoqScv_KIwx2K8Bz2Uc-aBVyLlbnaZQZHWP_bxwYitvK0UzVD6wguFkTlqIhdMmo9KytGQQAp4CEnTu0UPOkWKvmLB6du0H66JoLBnx1WBt_4uJZ7w0suG0FFsD1BeeruTlkMdPB_4X2exqZZGkIIKAchPpPXPE24MGhuOXQI7RK7NtmPwO3PkbGv0CTcWKKIwQSxQ4tv80qdhX8t5Xuj1JLzNSwvafKTo_KZkYK-PBsh5ZIjy3VDvnv9VCTr1ZFp-MEbI-2wB3yyF02VRoiwG1WmqSpkz-E52T3y3ZBQlzHjmwWEj0Lg2PHV0LpVA-83avm3rk"},"ParentName":"sha256:da59faba155ba522f726da405914802862317b14c957fa22d9f2fe3e1b45fccb","Format":"Docker","IndexedByVersion":3}}
+
+'
+    http_version:
+  recorded_at: Thu, 12 Apr 2018 10:34:11 GMT
+- request:
+    method: post
+    uri: http://my.clair:6060/v1/layers
+    body:
+      encoding: UTF-8
+      string: '{"Layer":{"Name":"sha256:0ae80f895f0292b5bb9871cf83ef266835aa590d755b4dd0839a3cb74c9d509f","NamespaceName":"","Path":"https://my.registry:5000/v2/node/blobs/sha256:0ae80f895f0292b5bb9871cf83ef266835aa590d755b4dd0839a3cb74c9d509f","Headers":{"Authorization":"Bearer
+        eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlBUV1Q6Rk5KRTo3VFc3OlVMSTc6RFpRQTpKSkpJOlJESlE6Mk03NjpIRDZHOlpSU0M6VlBJRjpPNUJVIn0.eyJpc3MiOiIxNzIuMTcuMC4xIiwic3ViIjoicG9ydHVzIiwiYXVkIjoiMTcyLjE3LjAuMTo1MDAwIiwiaWF0IjoxNTIzNTI5MjUxLCJuYmYiOjE1MjM1MjkyNDYsImV4cCI6MTUyMzUyOTU1MSwianRpIjoiZ242TE5wdjhwRURSMXVmWWNVRWN6d3oxenpoUzRFUWZYVTlweEtDQ1JKIiwiYWNjZXNzIjpbeyJ0eXBlIjoicmVwb3NpdG9yeSIsIm5hbWUiOiJub2RlIiwiYWN0aW9ucyI6WyJwdWxsIl19XX0.gggqCnQAIOzAnvMzc8aU8Odrp-6hmsemzOxiDbozzn4KB25ekszpgqLOr7Xvv95hbM7gpdQ65g0ywQ4mXZh_xKOThofmXIvUgEhrfqqoXLzL0NbA-Ch0Ueirm98t1sIW0T6QSAS4T2GjgzpX97o88DnyrCHWlfbdS7vxSP9MC_utIQK9asC5dgePfOuMijI2xsEJ6is0Zbng04NPkfIJPxDwAMsnpnDWLiGP70j4do1TfpDF0Dewr6cdArfyn4QARd30XKSa61xqJoW_1WbOYamCGnG8kZZ7qrToMvJKReZRSSgUnJXV7NGiktC21owjQZEwXaw32IX9_sQTXGdx1L-d8o7VzNZVfbcFWoqScv_KIwx2K8Bz2Uc-aBVyLlbnaZQZHWP_bxwYitvK0UzVD6wguFkTlqIhdMmo9KytGQQAp4CEnTu0UPOkWKvmLB6du0H66JoLBnx1WBt_4uJZ7w0suG0FFsD1BeeruTlkMdPB_4X2exqZZGkIIKAchPpPXPE24MGhuOXQI7RK7NtmPwO3PkbGv0CTcWKKIwQSxQ4tv80qdhX8t5Xuj1JLzNSwvafKTo_KZkYK-PBsh5ZIjy3VDvnv9VCTr1ZFp-MEbI-2wB3yyF02VRoiwG1WmqSpkz-E52T3y3ZBQlzHjmwWEj0Lg2PHV0LpVA-83avm3rk"},"ParentName":"sha256:7f84ea62c1fd111da5519283a2ed50cb93bbe1023dd1d2c2aeda13b105ba97d0","Format":"Docker","IndexedByVersion":0,"Features":[]}}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Server:
+      - clair
+      Date:
+      - Thu, 12 Apr 2018 10:34:11 GMT
+      Content-Length:
+      - '1123'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"Layer":{"Name":"sha256:0ae80f895f0292b5bb9871cf83ef266835aa590d755b4dd0839a3cb74c9d509f","Path":"https://my.registry:5000/v2/node/blobs/sha256:0ae80f895f0292b5bb9871cf83ef266835aa590d755b4dd0839a3cb74c9d509f","Headers":{"Authorization":"Bearer
+        eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlBUV1Q6Rk5KRTo3VFc3OlVMSTc6RFpRQTpKSkpJOlJESlE6Mk03NjpIRDZHOlpSU0M6VlBJRjpPNUJVIn0.eyJpc3MiOiIxNzIuMTcuMC4xIiwic3ViIjoicG9ydHVzIiwiYXVkIjoiMTcyLjE3LjAuMTo1MDAwIiwiaWF0IjoxNTIzNTI5MjUxLCJuYmYiOjE1MjM1MjkyNDYsImV4cCI6MTUyMzUyOTU1MSwianRpIjoiZ242TE5wdjhwRURSMXVmWWNVRWN6d3oxenpoUzRFUWZYVTlweEtDQ1JKIiwiYWNjZXNzIjpbeyJ0eXBlIjoicmVwb3NpdG9yeSIsIm5hbWUiOiJub2RlIiwiYWN0aW9ucyI6WyJwdWxsIl19XX0.gggqCnQAIOzAnvMzc8aU8Odrp-6hmsemzOxiDbozzn4KB25ekszpgqLOr7Xvv95hbM7gpdQ65g0ywQ4mXZh_xKOThofmXIvUgEhrfqqoXLzL0NbA-Ch0Ueirm98t1sIW0T6QSAS4T2GjgzpX97o88DnyrCHWlfbdS7vxSP9MC_utIQK9asC5dgePfOuMijI2xsEJ6is0Zbng04NPkfIJPxDwAMsnpnDWLiGP70j4do1TfpDF0Dewr6cdArfyn4QARd30XKSa61xqJoW_1WbOYamCGnG8kZZ7qrToMvJKReZRSSgUnJXV7NGiktC21owjQZEwXaw32IX9_sQTXGdx1L-d8o7VzNZVfbcFWoqScv_KIwx2K8Bz2Uc-aBVyLlbnaZQZHWP_bxwYitvK0UzVD6wguFkTlqIhdMmo9KytGQQAp4CEnTu0UPOkWKvmLB6du0H66JoLBnx1WBt_4uJZ7w0suG0FFsD1BeeruTlkMdPB_4X2exqZZGkIIKAchPpPXPE24MGhuOXQI7RK7NtmPwO3PkbGv0CTcWKKIwQSxQ4tv80qdhX8t5Xuj1JLzNSwvafKTo_KZkYK-PBsh5ZIjy3VDvnv9VCTr1ZFp-MEbI-2wB3yyF02VRoiwG1WmqSpkz-E52T3y3ZBQlzHjmwWEj0Lg2PHV0LpVA-83avm3rk"},"ParentName":"sha256:7f84ea62c1fd111da5519283a2ed50cb93bbe1023dd1d2c2aeda13b105ba97d0","Format":"Docker","IndexedByVersion":3}}
+
+'
+    http_version:
+  recorded_at: Thu, 12 Apr 2018 10:34:11 GMT
+- request:
+    method: post
+    uri: http://my.clair:6060/v1/layers
+    body:
+      encoding: UTF-8
+      string: '{"Layer":{"Name":"sha256:2f11c95c9552c41316c9c6943b1160f098c5a9700bb5fc6ae57dfba7ef10dffc","NamespaceName":"","Path":"https://my.registry:5000/v2/node/blobs/sha256:2f11c95c9552c41316c9c6943b1160f098c5a9700bb5fc6ae57dfba7ef10dffc","Headers":{"Authorization":"Bearer
+        eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlBUV1Q6Rk5KRTo3VFc3OlVMSTc6RFpRQTpKSkpJOlJESlE6Mk03NjpIRDZHOlpSU0M6VlBJRjpPNUJVIn0.eyJpc3MiOiIxNzIuMTcuMC4xIiwic3ViIjoicG9ydHVzIiwiYXVkIjoiMTcyLjE3LjAuMTo1MDAwIiwiaWF0IjoxNTIzNTI5MjUxLCJuYmYiOjE1MjM1MjkyNDYsImV4cCI6MTUyMzUyOTU1MSwianRpIjoiZ242TE5wdjhwRURSMXVmWWNVRWN6d3oxenpoUzRFUWZYVTlweEtDQ1JKIiwiYWNjZXNzIjpbeyJ0eXBlIjoicmVwb3NpdG9yeSIsIm5hbWUiOiJub2RlIiwiYWN0aW9ucyI6WyJwdWxsIl19XX0.gggqCnQAIOzAnvMzc8aU8Odrp-6hmsemzOxiDbozzn4KB25ekszpgqLOr7Xvv95hbM7gpdQ65g0ywQ4mXZh_xKOThofmXIvUgEhrfqqoXLzL0NbA-Ch0Ueirm98t1sIW0T6QSAS4T2GjgzpX97o88DnyrCHWlfbdS7vxSP9MC_utIQK9asC5dgePfOuMijI2xsEJ6is0Zbng04NPkfIJPxDwAMsnpnDWLiGP70j4do1TfpDF0Dewr6cdArfyn4QARd30XKSa61xqJoW_1WbOYamCGnG8kZZ7qrToMvJKReZRSSgUnJXV7NGiktC21owjQZEwXaw32IX9_sQTXGdx1L-d8o7VzNZVfbcFWoqScv_KIwx2K8Bz2Uc-aBVyLlbnaZQZHWP_bxwYitvK0UzVD6wguFkTlqIhdMmo9KytGQQAp4CEnTu0UPOkWKvmLB6du0H66JoLBnx1WBt_4uJZ7w0suG0FFsD1BeeruTlkMdPB_4X2exqZZGkIIKAchPpPXPE24MGhuOXQI7RK7NtmPwO3PkbGv0CTcWKKIwQSxQ4tv80qdhX8t5Xuj1JLzNSwvafKTo_KZkYK-PBsh5ZIjy3VDvnv9VCTr1ZFp-MEbI-2wB3yyF02VRoiwG1WmqSpkz-E52T3y3ZBQlzHjmwWEj0Lg2PHV0LpVA-83avm3rk"},"ParentName":"sha256:0ae80f895f0292b5bb9871cf83ef266835aa590d755b4dd0839a3cb74c9d509f","Format":"Docker","IndexedByVersion":0,"Features":[]}}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Server:
+      - clair
+      Date:
+      - Thu, 12 Apr 2018 10:34:11 GMT
+      Content-Length:
+      - '1123'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"Layer":{"Name":"sha256:2f11c95c9552c41316c9c6943b1160f098c5a9700bb5fc6ae57dfba7ef10dffc","Path":"https://my.registry:5000/v2/node/blobs/sha256:2f11c95c9552c41316c9c6943b1160f098c5a9700bb5fc6ae57dfba7ef10dffc","Headers":{"Authorization":"Bearer
+        eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlBUV1Q6Rk5KRTo3VFc3OlVMSTc6RFpRQTpKSkpJOlJESlE6Mk03NjpIRDZHOlpSU0M6VlBJRjpPNUJVIn0.eyJpc3MiOiIxNzIuMTcuMC4xIiwic3ViIjoicG9ydHVzIiwiYXVkIjoiMTcyLjE3LjAuMTo1MDAwIiwiaWF0IjoxNTIzNTI5MjUxLCJuYmYiOjE1MjM1MjkyNDYsImV4cCI6MTUyMzUyOTU1MSwianRpIjoiZ242TE5wdjhwRURSMXVmWWNVRWN6d3oxenpoUzRFUWZYVTlweEtDQ1JKIiwiYWNjZXNzIjpbeyJ0eXBlIjoicmVwb3NpdG9yeSIsIm5hbWUiOiJub2RlIiwiYWN0aW9ucyI6WyJwdWxsIl19XX0.gggqCnQAIOzAnvMzc8aU8Odrp-6hmsemzOxiDbozzn4KB25ekszpgqLOr7Xvv95hbM7gpdQ65g0ywQ4mXZh_xKOThofmXIvUgEhrfqqoXLzL0NbA-Ch0Ueirm98t1sIW0T6QSAS4T2GjgzpX97o88DnyrCHWlfbdS7vxSP9MC_utIQK9asC5dgePfOuMijI2xsEJ6is0Zbng04NPkfIJPxDwAMsnpnDWLiGP70j4do1TfpDF0Dewr6cdArfyn4QARd30XKSa61xqJoW_1WbOYamCGnG8kZZ7qrToMvJKReZRSSgUnJXV7NGiktC21owjQZEwXaw32IX9_sQTXGdx1L-d8o7VzNZVfbcFWoqScv_KIwx2K8Bz2Uc-aBVyLlbnaZQZHWP_bxwYitvK0UzVD6wguFkTlqIhdMmo9KytGQQAp4CEnTu0UPOkWKvmLB6du0H66JoLBnx1WBt_4uJZ7w0suG0FFsD1BeeruTlkMdPB_4X2exqZZGkIIKAchPpPXPE24MGhuOXQI7RK7NtmPwO3PkbGv0CTcWKKIwQSxQ4tv80qdhX8t5Xuj1JLzNSwvafKTo_KZkYK-PBsh5ZIjy3VDvnv9VCTr1ZFp-MEbI-2wB3yyF02VRoiwG1WmqSpkz-E52T3y3ZBQlzHjmwWEj0Lg2PHV0LpVA-83avm3rk"},"ParentName":"sha256:0ae80f895f0292b5bb9871cf83ef266835aa590d755b4dd0839a3cb74c9d509f","Format":"Docker","IndexedByVersion":3}}
+
+'
+    http_version:
+  recorded_at: Thu, 12 Apr 2018 10:34:11 GMT
+- request:
+    method: get
+    uri: http://my.clair:6060/v1/layers/sha256:2f11c95c9552c41316c9c6943b1160f098c5a9700bb5fc6ae57dfba7ef10dffc?features=false&vulnerabilities=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Server:
+      - clair
+      Date:
+      - Thu, 12 Apr 2018 10:34:11 GMT
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"Layer":{"Name":"sha256:2f11c95c9552c41316c9c6943b1160f098c5a9700bb5fc6ae57dfba7ef10dffc","NamespaceName":"debian:8","ParentName":"sha256:0ae80f895f0292b5bb9871cf83ef266835aa590d755b4dd0839a3cb74c9d509f","IndexedByVersion":3,"Features":[{"Name":"m4","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.4.17-4","Vulnerabilities":[{"Name":"CVE-2008-1688","NamespaceName":"debian:8","Description":"Unspecified
+        vulnerability in GNU m4 before 1.4.11 might allow context-dependent attackers
+        to execute arbitrary code, related to improper handling of filenames specified
+        with the -F option.  NOTE: it is not clear when this issue crosses privilege
+        boundaries.","Link":"https://security-tracker.debian.org/tracker/CVE-2008-1688","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}},{"Name":"CVE-2008-1687","NamespaceName":"debian:8","Description":"The
+        (1) maketemp and (2) mkstemp builtin functions in GNU m4 before 1.4.11 do
+        not quote their output when a file is created, which might allow context-dependent
+        attackers to trigger a macro expansion, leading to unspecified use of an incorrect
+        filename.","Link":"https://security-tracker.debian.org/tracker/CVE-2008-1687","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}}],"AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"libxext","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2:1.3.3-1","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"libjpeg-turbo","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1:1.3.1-12","Vulnerabilities":[{"Name":"CVE-2016-3616","NamespaceName":"debian:8","Description":"The
+        cjpeg utility in libjpeg allows remote attackers to cause a denial of service
+        (NULL pointer dereference and application crash) or execute arbitrary code
+        via a crafted file.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-3616","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-15232","NamespaceName":"debian:8","Description":"libjpeg-turbo
+        1.5.2 has a NULL Pointer Dereference in jdpostct.c and jquant1.c via a crafted
+        JPEG file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-15232","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}}],"AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"libtext-iconv-perl","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.7-5","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"djvulibre","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"3.5.25.4-4","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"libedit","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"3.1-20140620-2","AddedBy":"sha256:b313b08bab3b8bbcf0de4171a2a80a01e67fab094f272819b76a58705d21ab28"},{"Name":"libxau","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1:1.0.8-1","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"libpng","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.2.50-2+deb8u3","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"coreutils","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"8.23-4","Vulnerabilities":[{"Name":"CVE-2016-2781","NamespaceName":"debian:8","Description":"chroot
+        in GNU coreutils, when used with --userspec, allows local users to escape
+        to the parent session via a crafted TIOCSTI ioctl call, which pushes characters
+        to the terminal''s input buffer.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-2781","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":2.1,"Vectors":"AV:L/AC:L/Au:N/C:N/I:P"}}}},{"Name":"CVE-2017-18018","NamespaceName":"debian:8","Description":"In
+        GNU Coreutils through 8.29, chown-core.c in chown and chgrp does not prevent
+        replacement of a plain file with a symlink during use of the POSIX \"-R -L\"
+        options, which allows local users to modify the ownership of arbitrary files
+        by leveraging a race condition.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-18018","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":1.9,"Vectors":"AV:L/AC:M/Au:N/C:N/I:P"}}}}],"AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"serf","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.3.8-1","AddedBy":"sha256:b313b08bab3b8bbcf0de4171a2a80a01e67fab094f272819b76a58705d21ab28"},{"Name":"libgcrypt20","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.6.3-2+deb8u4","Vulnerabilities":[{"Name":"CVE-2018-6829","NamespaceName":"debian:8","Description":"cipher/elgamal.c
+        in Libgcrypt through 1.8.2, when used to encrypt messages directly, improperly
+        encodes plaintexts, which allows attackers to obtain sensitive information
+        by reading ciphertext data (i.e., it does not have semantic security in face
+        of a ciphertext-only attack). The Decisional Diffie-Hellman (DDH) assumption
+        does not hold for Libgcrypt''s ElGamal implementation.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-6829","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:N"}}}}],"AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"acl","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2.2.52-2","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"git","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1:2.1.4-2.1+deb8u5","Vulnerabilities":[{"Name":"CVE-2017-15298","NamespaceName":"debian:8","Description":"Git
+        through 2.14.2 mishandles layers of tree objects, which allows remote attackers
+        to cause a denial of service (memory consumption) via a crafted repository,
+        aka a Git bomb. This can also have an impact of disk consumption; however,
+        an affected process typically would not survive its attempt to build the data
+        structure in memory before writing to disk.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-15298","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2018-1000021","NamespaceName":"debian:8","Description":"GIT
+        version 2.15.1 and earlier contains a Input Validation Error vulnerability
+        in Client that can result in problems including messing up terminal configuration
+        to RCE. This attack appear to be exploitable via The user must interact with
+        a malicious git server, (or have their traffic modified in a MITM attack).","Link":"https://security-tracker.debian.org/tracker/CVE-2018-1000021","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}}],"AddedBy":"sha256:b313b08bab3b8bbcf0de4171a2a80a01e67fab094f272819b76a58705d21ab28"},{"Name":"libxpm","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1:3.5.12-0+deb8u1","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"imagemagick","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"8:6.8.9.9-5+deb8u11","Vulnerabilities":[{"Name":"CVE-2017-14139","NamespaceName":"debian:8","Description":"ImageMagick
+        7.0.6-2 has a memory leak vulnerability in WriteMSLImage in coders/msl.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14139","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-12664","NamespaceName":"debian:8","Description":"ImageMagick
+        7.0.6-2 has a memory leak vulnerability in WritePALMImage in coders/palm.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12664","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-11446","NamespaceName":"debian:8","Description":"The
+        ReadPESImage function in coders\\pes.c in ImageMagick 7.0.6-1 has an infinite
+        loop vulnerability that can cause CPU exhaustion via a crafted PES file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-11446","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.1,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-13058","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.6-6, a memory leak vulnerability was found in the function
+        WritePCXImage in coders/pcx.c, which allows attackers to cause a denial of
+        service via a crafted file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-13058","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-15017","NamespaceName":"debian:8","Description":"ImageMagick
+        7.0.7-0 Q16 has a NULL pointer dereference vulnerability in ReadOneMNGImage
+        in coders/png.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-15017","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-13768","NamespaceName":"debian:8","Description":"Null
+        Pointer Dereference in the IdentifyImage function in MagickCore/identify.c
+        in ImageMagick through 7.0.6-10 allows an attacker to perform denial of service
+        by sending a crafted image file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-13768","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-18209","NamespaceName":"debian:8","Description":"In
+        the GetOpenCLCachedFilesDirectory function in magick/opencl.c in ImageMagick
+        7.0.7, a NULL pointer dereference vulnerability occurs because a memory allocation
+        result is not checked, related to GetOpenCLCacheDirectory.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-18209","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-11644","NamespaceName":"debian:8","Description":"When
+        ImageMagick 7.0.6-1 processes a crafted file in convert, it can lead to a
+        Memory Leak in the ReadMATImage() function in coders/mat.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-11644","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-14342","NamespaceName":"debian:8","Description":"ImageMagick
+        7.0.6-6 has a memory exhaustion vulnerability in ReadWPGImage in coders/wpg.c
+        via a crafted wpg image file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14342","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-12668","NamespaceName":"debian:8","Description":"ImageMagick
+        7.0.6-2 has a memory leak vulnerability in WritePCXImage in coders/pcx.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12668","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-12435","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.6-1, a memory exhaustion vulnerability was found in the function
+        ReadSUNImage in coders/sun.c, which allows attackers to cause a denial of
+        service.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12435","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.8,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-13143","NamespaceName":"debian:8","Description":"In
+        ImageMagick before 6.9.7-6 and 7.x before 7.0.4-6, the ReadMATImage function
+        in coders/mat.c uses uninitialized data, which might allow remote attackers
+        to obtain sensitive information from process memory.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-13143","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:N"}}}},{"Name":"CVE-2018-6405","NamespaceName":"debian:8","Description":"In
+        the ReadDCMImage function in coders/dcm.c in ImageMagick before 7.0.7-23,
+        each redmap, greenmap, and bluemap variable can be overwritten by a new pointer.
+        The previous pointer is lost, which leads to a memory leak. This allows remote
+        attackers to cause a denial of service.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-6405","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-15032","NamespaceName":"debian:8","Description":"ImageMagick
+        version 7.0.7-2 contains a memory leak in ReadYCBCRImage in coders/ycbcr.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-15032","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}},{"Name":"CVE-2018-7470","NamespaceName":"debian:8","Description":"An
+        issue was discovered in ImageMagick 7.0.7-22 Q16. The IsWEBPImageLossless
+        function in coders/webp.c allows attackers to cause a denial of service (segmentation
+        violation) via a crafted file.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-7470","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-14341","NamespaceName":"debian:8","Description":"ImageMagick
+        7.0.6-6 has a large loop vulnerability in ReadWPGImage in coders/wpg.c, causing
+        CPU exhaustion via a crafted wpg image file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14341","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.1,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-14343","NamespaceName":"debian:8","Description":"ImageMagick
+        7.0.6-6 has a memory leak vulnerability in ReadXCFImage in coders/xcf.c via
+        a crafted xcf image file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14343","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-12693","NamespaceName":"debian:8","Description":"The
+        ReadBMPImage function in coders/bmp.c in ImageMagick 7.0.6-6 allows remote
+        attackers to cause a denial of service (memory consumption) via a crafted
+        BMP file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12693","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.1,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-11533","NamespaceName":"debian:8","Description":"When
+        ImageMagick 7.0.6-1 processes a crafted file in convert, it can lead to a
+        heap-based buffer over-read in the WriteUILImage() function in coders/uil.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-11533","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-17887","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.7-16 Q16, a memory leak vulnerability was found in the function
+        GetImagePixelCache in magick/cache.c, which allows attackers to cause a denial
+        of service via a crafted MNG image file that is processed by ReadOneMNGImage.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-17887","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-12429","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.6-1, a memory exhaustion vulnerability was found in the function
+        ReadMIFFImage in coders/miff.c, which allows attackers to cause a denial of
+        service.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12429","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.8,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-1000445","NamespaceName":"debian:8","Description":"ImageMagick
+        7.0.7-1 and older version are vulnerable to null pointer dereference in the
+        MagickCore component and might lead to denial of service","Link":"https://security-tracker.debian.org/tracker/CVE-2017-1000445","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-15218","NamespaceName":"debian:8","Description":"ImageMagick
+        7.0.7-2 has a memory leak in ReadOneJNGImage in coders/png.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-15218","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-13146","NamespaceName":"debian:8","Description":"In
+        ImageMagick before 6.9.8-5 and 7.x before 7.0.5-6, there is a memory leak
+        in the ReadMATImage function in coders/mat.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-13146","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-17504","NamespaceName":"debian:8","Description":"ImageMagick
+        before 7.0.7-12 has a coders/png.c Magick_png_read_raw_profile heap-based
+        buffer over-read via a crafted file, related to ReadOneMNGImage.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-17504","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-17882","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.7-12 Q16, a memory leak vulnerability was found in the function
+        ReadXPMImage in coders/xpm.c, which allows attackers to cause a denial of
+        service via a crafted XPM image file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-17882","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-18254","NamespaceName":"debian:8","Description":"An
+        issue was discovered in ImageMagick 7.0.7. A memory leak vulnerability was
+        found in the function WriteGIFImage in coders/gif.c, which allow remote attackers
+        to cause a denial of service via a crafted file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-18254","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-12140","NamespaceName":"debian:8","Description":"The
+        ReadDCMImage function in coders\\dcm.c in ImageMagick 7.0.6-1 has an integer
+        signedness error leading to excessive memory consumption via a crafted DCM
+        file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12140","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.1,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-18252","NamespaceName":"debian:8","Description":"An
+        issue was discovered in ImageMagick 7.0.7. The MogrifyImageList function in
+        MagickWand/mogrify.c allows attackers to cause a denial of service (assertion
+        failure and application exit in ReplaceImageInList) via a crafted file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-18252","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-12427","NamespaceName":"debian:8","Description":"The
+        ProcessMSLScript function in coders/msl.c in ImageMagick before 6.9.9-5 and
+        7.x before 7.0.6-5 allows remote attackers to cause a denial of service (memory
+        leak) via a crafted file, related to the WriteMSLImage function.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12427","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-11536","NamespaceName":"debian:8","Description":"When
+        ImageMagick 7.0.6-1 processes a crafted file in convert, it can lead to a
+        Memory Leak in the WriteJP2Image() function in coders/jp2.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-11536","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:P/I:N"}}}},{"Name":"CVE-2017-12434","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.6-1, a missing NULL check vulnerability was found in the function
+        ReadMATImage in coders/mat.c, which allows attackers to cause a denial of
+        service (assertion failure) in DestroyImageInfo in image.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12434","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-12671","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.6-3, a missing NULL assignment was found in coders/png.c,
+        leading to an invalid free in the function RelinquishMagickMemory in MagickCore/memory.c,
+        which allows attackers to cause a denial of service.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12671","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-12663","NamespaceName":"debian:8","Description":"ImageMagick
+        7.0.6-2 has a memory leak vulnerability in WriteMAPImage in coders/map.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12663","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-12667","NamespaceName":"debian:8","Description":"ImageMagick
+        7.0.6-1 has a memory leak vulnerability in ReadMATImage in coders\\mat.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12667","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-12428","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.6-1, a memory leak vulnerability was found in the function
+        ReadWMFImage in coders/wmf.c, which allows attackers to cause a denial of
+        service in CloneDrawInfo in draw.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12428","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-11531","NamespaceName":"debian:8","Description":"When
+        ImageMagick 7.0.6-1 processes a crafted file in convert, it can lead to a
+        Memory Leak in the WriteHISTOGRAMImage() function in coders/histogram.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-11531","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-11724","NamespaceName":"debian:8","Description":"The
+        ReadMATImage function in coders/mat.c in ImageMagick through 6.9.9-3 and 7.x
+        through 7.0.6-3 has memory leaks involving the quantum_info and clone_info
+        data structures.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-11724","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-17884","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.7-16 Q16, a memory leak vulnerability was found in the function
+        WriteOnePNGImage in coders/png.c, which allows attackers to cause a denial
+        of service via a crafted PNG image file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-17884","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-12662","NamespaceName":"debian:8","Description":"ImageMagick
+        7.0.6-2 has a memory leak vulnerability in WritePDFImage in coders/pdf.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12662","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-17879","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.7-16 Q16 x86_64 2017-12-21, there is a heap-based buffer over-read
+        in ReadOneMNGImage in coders/png.c, related to length calculation and caused
+        by an off-by-one error.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-17879","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-11539","NamespaceName":"debian:8","Description":"When
+        ImageMagick 7.0.6-1 processes a crafted file in convert, it can lead to a
+        Memory Leak in the ReadOnePNGImage() function in coders/png.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-11539","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-14137","NamespaceName":"debian:8","Description":"ReadWEBPImage
+        in coders/webp.c in ImageMagick 7.0.6-5 has an issue where memory allocation
+        is excessive because it depends only on a length field in a header.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14137","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-18008","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.7-17 Q16, there is a Memory Leak in ReadPWPImage in coders/pwp.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-18008","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-7275","NamespaceName":"debian:8","Description":"The
+        ReadPCXImage function in coders/pcx.c in ImageMagick 7.0.4.9 allows remote
+        attackers to cause a denial of service (attempted large memory allocation
+        and application crash) via a crafted file. NOTE: this vulnerability exists
+        because of an incomplete fix for CVE-2016-8862 and CVE-2016-8866.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-7275","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-14138","NamespaceName":"debian:8","Description":"ImageMagick
+        7.0.6-5 has a memory leak vulnerability in ReadWEBPImage in coders/webp.c
+        because memory is not freed in certain error cases, as demonstrated by VP8
+        errors.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14138","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-14324","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.7-1 Q16, a memory leak vulnerability was found in the function
+        ReadMPCImage in coders/mpc.c, which allows attackers to cause a denial of
+        service via a crafted file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14324","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-12665","NamespaceName":"debian:8","Description":"ImageMagick
+        7.0.6-2 has a memory leak vulnerability in WritePICTImage in coders/pict.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12665","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-11639","NamespaceName":"debian:8","Description":"When
+        ImageMagick 7.0.6-1 processes a crafted file in convert, it can lead to a
+        heap-based buffer over-read in the WriteCIPImage() function in coders/cip.c,
+        related to the GetPixelLuma function in MagickCore/pixel-accessor.h.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-11639","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-11534","NamespaceName":"debian:8","Description":"When
+        ImageMagick 7.0.6-1 processes a crafted file in convert, it can lead to a
+        Memory Leak in the lite_font_map() function in coders/wmf.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-11534","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-13141","NamespaceName":"debian:8","Description":"In
+        ImageMagick before 6.9.9-4 and 7.x before 7.0.6-4, a crafted file could trigger
+        a memory leak in ReadOnePNGImage in coders/png.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-13141","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-14326","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.7-1 Q16, a memory leak vulnerability was found in the function
+        ReadMATImage in coders/mat.c, which allows attackers to cause a denial of
+        service via a crafted file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14326","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-11532","NamespaceName":"debian:8","Description":"When
+        ImageMagick 7.0.6-1 processes a crafted file in convert, it can lead to a
+        Memory Leak in the WriteMPCImage() function in coders/mpc.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-11532","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-18251","NamespaceName":"debian:8","Description":"An
+        issue was discovered in ImageMagick 7.0.7. A memory leak vulnerability was
+        found in the function ReadPCDImage in coders/pcd.c, which allow remote attackers
+        to cause a denial of service via a crafted file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-18251","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-15217","NamespaceName":"debian:8","Description":"ImageMagick
+        7.0.7-2 has a memory leak in ReadSGIImage in coders/sgi.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-15217","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-14532","NamespaceName":"debian:8","Description":"ImageMagick
+        7.0.7-0 has a NULL Pointer Dereference in TIFFIgnoreTags in coders/tiff.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14532","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-12418","NamespaceName":"debian:8","Description":"ImageMagick
+        7.0.6-5 has memory leaks in the parse8BIMW and format8BIM functions in coders/meta.c,
+        related to the WriteImage function in MagickCore/constitute.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12418","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-15033","NamespaceName":"debian:8","Description":"ImageMagick
+        version 7.0.7-2 contains a memory leak in ReadYUVImage in coders/yuv.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-15033","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-11535","NamespaceName":"debian:8","Description":"When
+        ImageMagick 7.0.6-1 processes a crafted file in convert, it can lead to a
+        heap-based buffer over-read in the WritePSImage() function in coders/ps.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-11535","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-11752","NamespaceName":"debian:8","Description":"The
+        ReadMAGICKImage function in coders/magick.c in ImageMagick 7.0.6-4 allows
+        remote attackers to cause a denial of service (memory leak) via a crafted
+        file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-11752","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-18029","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.6-10 Q16, a memory leak vulnerability was found in the function
+        ReadMATImage in coders/mat.c, which allow remote attackers to cause a denial
+        of service via a crafted file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-18029","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-18022","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.7-12 Q16, there are memory leaks in MontageImageCommand in
+        MagickWand/montage.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-18022","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-14173","NamespaceName":"debian:8","Description":"In
+        the function ReadTXTImage() in coders/txt.c in ImageMagick 7.0.6-10, an integer
+        overflow might occur for the addition operation \"GetQuantumRange(depth)+1\"
+        when \"depth\" is large, producing a smaller value than expected. As a result,
+        an infinite loop would occur for a crafted TXT file that claims a very large
+        \"max_value\" value.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14173","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-14174","NamespaceName":"debian:8","Description":"In
+        coders/psd.c in ImageMagick 7.0.7-0 Q16, a DoS in ReadPSDLayersInternal()
+        due to lack of an EOF (End of File) check might cause huge CPU consumption.
+        When a crafted PSD file, which claims a large \"length\" field in the header
+        but does not contain sufficient backing data, is provided, the loop over \"length\"
+        would consume huge CPU resources, since there is no EOF check inside the loop.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14174","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.1,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-13060","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.6-5, a memory leak vulnerability was found in the function
+        ReadMATImage in coders/mat.c, which allows attackers to cause a denial of
+        service via a crafted file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-13060","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-12644","NamespaceName":"debian:8","Description":"ImageMagick
+        7.0.6-1 has a memory leak vulnerability in ReadDCMImage in coders\\dcm.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12644","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-14249","NamespaceName":"debian:8","Description":"ImageMagick
+        7.0.6-8 Q16 mishandles EOF checks in ReadMPCImage in coders/mpc.c, leading
+        to division by zero in GetPixelCacheTileSize in MagickCore/cache.c, allowing
+        remote attackers to cause a denial of service via a crafted file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14249","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-15281","NamespaceName":"debian:8","Description":"ReadPSDImage
+        in coders/psd.c in ImageMagick 7.0.7-6 allows remote attackers to cause a
+        denial of service (application crash) or possibly have unspecified other impact
+        via a crafted file, related to \"Conditional jump or move depends on uninitialised
+        value(s).\"","Link":"https://security-tracker.debian.org/tracker/CVE-2017-15281","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-11755","NamespaceName":"debian:8","Description":"The
+        WritePICONImage function in coders/xpm.c in ImageMagick 7.0.6-4 allows remote
+        attackers to cause a denial of service (memory leak) via a crafted file that
+        is mishandled in an AcquireSemaphoreInfo call.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-11755","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-14060","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.6-10, a NULL Pointer Dereference issue is present in the ReadCUTImage
+        function in coders/cut.c that could allow an attacker to cause a Denial of
+        Service (in the QueueAuthenticPixelCacheNexus function within the MagickCore/cache.c
+        file) by submitting a malformed image file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14060","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-12676","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.6-3, a memory leak vulnerability was found in the function
+        ReadOneJNGImage in coders/png.c, which allows attackers to cause a denial
+        of service.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12676","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2018-5357","NamespaceName":"debian:8","Description":"ImageMagick
+        7.0.7-22 Q16 has memory leaks in the ReadDCMImage function in coders/dcm.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-5357","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2018-7443","NamespaceName":"debian:8","Description":"The
+        ReadTIFFImage function in coders/tiff.c in ImageMagick 7.0.7-23 Q16 does not
+        properly validate the amount of image data in a file, which allows remote
+        attackers to cause a denial of service (memory allocation failure in the AcquireMagickMemory
+        function in MagickCore/memory.c).","Link":"https://security-tracker.debian.org/tracker/CVE-2018-7443","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2008-3134","NamespaceName":"debian:8","Description":"Multiple
+        unspecified vulnerabilities in GraphicsMagick before 1.2.4 allow remote attackers
+        to cause a denial of service (crash, infinite loop, or memory consumption)
+        via (a) unspecified vectors in the (1) AVI, (2) AVS, (3) DCM, (4) EPT, (5)
+        FITS, (6) MTV, (7) PALM, (8) RLA, and (9) TGA decoder readers; and (b) the
+        GetImageCharacteristics function in magick/image.c, as reachable from a crafted
+        (10) PNG, (11) JPEG, (12) BMP, or (13) TIFF file.","Link":"https://security-tracker.debian.org/tracker/CVE-2008-3134","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-12670","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.6-3, missing validation was found in coders/mat.c, leading
+        to an assertion failure in the function DestroyImage in MagickCore/image.c,
+        which allows attackers to cause a denial of service.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12670","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-12875","NamespaceName":"debian:8","Description":"The
+        WritePixelCachePixels function in ImageMagick 7.0.6-6 allows remote attackers
+        to cause a denial of service (CPU consumption) via a crafted file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12875","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.1,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-12433","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.6-1, a memory leak vulnerability was found in the function
+        ReadPESImage in coders/pes.c, which allows attackers to cause a denial of
+        service, related to ResizeMagickMemory in memory.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12433","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-17885","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.7-12 Q16, a memory leak vulnerability was found in the function
+        ReadPICTImage in coders/pict.c, which allows attackers to cause a denial of
+        service via a crafted PICT image file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-17885","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-13131","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.6-8, a memory leak vulnerability was found in the function
+        ReadMIFFImage in coders/miff.c, which allows attackers to cause a denial of
+        service (memory consumption in NewLinkedList in MagickCore/linked-list.c)
+        via a crafted file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-13131","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-18211","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.7, a NULL pointer dereference vulnerability was found in the
+        function saveBinaryCLProgram in magick/opencl.c because a program-lookup result
+        is not checked, related to CacheOpenCLKernel.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-18211","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-12565","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.6-2, a memory leak vulnerability was found in the function
+        ReadOneJNGImage in coders/png.c, which allows attackers to cause a denial
+        of service.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12565","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-13145","NamespaceName":"debian:8","Description":"In
+        ImageMagick before 6.9.8-8 and 7.x before 7.0.5-9, the ReadJP2Image function
+        in coders/jp2.c does not properly validate the channel geometry, leading to
+        a crash.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-13145","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-13142","NamespaceName":"debian:8","Description":"In
+        ImageMagick before 6.9.9-0 and 7.x before 7.0.6-1, a crafted PNG file could
+        trigger a crash because there was an insufficient check for short files.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-13142","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2018-9133","NamespaceName":"debian:8","Description":"ImageMagick
+        7.0.7-26 Q16 has excessive iteration in the DecodeLabImage and EncodeLabImage
+        functions (coders/tiff.c), which results in a hang (tens of minutes) with
+        a tiny PoC file. Remote attackers could leverage this vulnerability to cause
+        a denial of service via a crafted tiff file.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-9133","Severity":"Low"},{"Name":"CVE-2017-12669","NamespaceName":"debian:8","Description":"ImageMagick
+        7.0.6-2 has a memory leak vulnerability in WriteCALSImage in coders/cals.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12669","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-12691","NamespaceName":"debian:8","Description":"The
+        ReadOneLayer function in coders/xcf.c in ImageMagick 7.0.6-6 allows remote
+        attackers to cause a denial of service (memory consumption) via a crafted
+        file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12691","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.1,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-13059","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.6-6, a memory leak vulnerability was found in the function
+        WriteOneJNGImage in coders/png.c, which allows attackers to cause a denial
+        of service (WriteJNGImage memory consumption) via a crafted file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-13059","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2018-5247","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.7-17 Q16, there are memory leaks in ReadRLAImage in coders/rla.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-5247","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-14325","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.7-1 Q16, a memory leak vulnerability was found in the function
+        PersistPixelCache in magick/cache.c, which allows attackers to cause a denial
+        of service (memory consumption in ReadMPCImage in coders/mpc.c) via a crafted
+        file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14325","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":7.1,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-13062","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.6-6, a memory leak vulnerability was found in the function
+        formatIPTC in coders/meta.c, which allows attackers to cause a denial of service
+        (WriteMETAImage memory consumption) via a crafted file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-13062","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2005-0406","NamespaceName":"debian:8","Description":"A
+        design flaw in image processing software that modifies JPEG images might not
+        modify the original EXIF thumbnail, which could lead to an information leak
+        of potentially sensitive visual information that had been removed from the
+        main JPEG image.","Link":"https://security-tracker.debian.org/tracker/CVE-2005-0406","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":2.1,"Vectors":"AV:L/AC:L/Au:N/C:P/I:N"}}}},{"Name":"CVE-2017-11166","NamespaceName":"debian:8","Description":"The
+        ReadXWDImage function in coders\\xwd.c in ImageMagick 7.0.5-6 has a memory
+        leak vulnerability that can cause memory exhaustion via a crafted length (number
+        of color-map entries) field in the header of an XWD file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-11166","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.1,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-12672","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.6-3, a memory leak vulnerability was found in the function
+        ReadMATImage in coders/mat.c, which allows attackers to cause a denial of
+        service.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12672","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-11754","NamespaceName":"debian:8","Description":"The
+        WritePICONImage function in coders/xpm.c in ImageMagick 7.0.6-4 allows remote
+        attackers to cause a denial of service (memory leak) via a crafted file that
+        is mishandled in an OpenPixelCache call.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-11754","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-15016","NamespaceName":"debian:8","Description":"ImageMagick
+        7.0.7-0 Q16 has a NULL pointer dereference vulnerability in ReadEnhMetaFile
+        in coders/emf.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-15016","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-14172","NamespaceName":"debian:8","Description":"In
+        coders/ps.c in ImageMagick 7.0.7-0 Q16, a DoS in ReadPSImage() due to lack
+        of an EOF (End of File) check might cause huge CPU consumption. When a crafted
+        PSD file, which claims a large \"extent\" field in the header but does not
+        contain sufficient backing data, is provided, the loop over \"length\" would
+        consume huge CPU resources, since there is no EOF check inside the loop.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14172","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.1,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-14741","NamespaceName":"debian:8","Description":"The
+        ReadCAPTIONImage function in coders/caption.c in ImageMagick 7.0.7-3 allows
+        remote attackers to cause a denial of service (infinite loop) via a crafted
+        font file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14741","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-14400","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.7-1 Q16, the PersistPixelCache function in magick/cache.c
+        mishandles the pixel cache nexus, which allows remote attackers to cause a
+        denial of service (NULL pointer dereference in the function GetVirtualPixels
+        in MagickCore/cache.c) via a crafted file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14400","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-12432","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.6-1, a memory exhaustion vulnerability was found in the function
+        ReadPCXImage in coders/pcx.c, which allows attackers to cause a denial of
+        service.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12432","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.1,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-11751","NamespaceName":"debian:8","Description":"The
+        WritePICONImage function in coders/xpm.c in ImageMagick 7.0.6-4 allows remote
+        attackers to cause a denial of service (memory leak) via a crafted file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-11751","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-13133","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.6-8, the load_level function in coders/xcf.c lacks offset
+        validation, which allows attackers to cause a denial of service (load_tile
+        memory exhaustion) via a crafted file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-13133","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.1,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-14626","NamespaceName":"debian:8","Description":"ImageMagick
+        7.0.7-0 Q16 has a NULL Pointer Dereference vulnerability in the function sixel_decode
+        in coders/sixel.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14626","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-6502","NamespaceName":"debian:8","Description":"An
+        issue was discovered in ImageMagick 6.9.7. A specially crafted webp file could
+        lead to a file-descriptor leak in libmagickcore (thus, a DoS).","Link":"https://security-tracker.debian.org/tracker/CVE-2017-6502","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-12674","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.6-2, a CPU exhaustion vulnerability was found in the function
+        ReadPDBImage in coders/pdb.c, which allows attackers to cause a denial of
+        service.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12674","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.1,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-12643","NamespaceName":"debian:8","Description":"ImageMagick
+        7.0.6-1 has a memory exhaustion vulnerability in ReadOneJNGImage in coders\\png.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12643","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.1,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-14505","NamespaceName":"debian:8","Description":"DrawGetStrokeDashArray
+        in wand/drawing-wand.c in ImageMagick 7.0.7-1 mishandles certain NULL arrays,
+        which allows attackers to perform Denial of Service (NULL pointer dereference
+        and application crash in AcquireQuantumMemory within MagickCore/memory.c)
+        by providing a crafted Image File as input.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14505","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-17680","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.7-12 Q16, a memory leak vulnerability was found in the function
+        ReadXPMImage in coders/xpm.c, which allows attackers to cause a denial of
+        service via a crafted xpm image file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-17680","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-12692","NamespaceName":"debian:8","Description":"The
+        ReadVIFFImage function in coders/viff.c in ImageMagick 7.0.6-6 allows remote
+        attackers to cause a denial of service (memory consumption) via a crafted
+        VIFF file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12692","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.1,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-12587","NamespaceName":"debian:8","Description":"ImageMagick
+        7.0.6-1 has a large loop vulnerability in the ReadPWPImage function in coders\\pwp.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12587","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2018-5246","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.7-17 Q16, there are memory leaks in ReadPATTERNImage in coders/pattern.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-5246","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-10995","NamespaceName":"debian:8","Description":"The
+        mng_get_long function in coders/png.c in ImageMagick 7.0.6-0 allows remote
+        attackers to cause a denial of service (heap-based buffer over-read and application
+        crash) via a crafted MNG image.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-10995","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2018-8960","NamespaceName":"debian:8","Description":"The
+        ReadTIFFImage function in coders/tiff.c in ImageMagick 7.0.7-26 Q16 does not
+        properly restrict memory allocation, leading to a heap-based buffer over-read.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-8960","Severity":"Low"},{"Name":"CVE-2017-12563","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.6-2, a memory exhaustion vulnerability was found in the function
+        ReadPSDImage in coders/psd.c, which allows attackers to cause a denial of
+        service.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12563","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.1,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-12564","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.6-2, a memory leak vulnerability was found in the function
+        ReadMATImage in coders/mat.c, which allows attackers to cause a denial of
+        service.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12564","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-14533","NamespaceName":"debian:8","Description":"ImageMagick
+        7.0.6-6 has a memory leak in ReadMATImage in coders/mat.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14533","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2018-8804","NamespaceName":"debian:8","Description":"WriteEPTImage
+        in coders/ept.c in ImageMagick 7.0.7-25 Q16 allows remote attackers to cause
+        a denial of service (MagickCore/memory.c double free and application crash)
+        or possibly have unspecified other impact via a crafted file.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-8804","Severity":"Low"},{"Name":"CVE-2017-18028","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.7-1 Q16, a memory exhaustion vulnerability was found in the
+        function ReadTIFFImage in coders/tiff.c, which allow remote attackers to cause
+        a denial of service via a crafted file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-18028","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":7.1,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-17880","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.7-16 Q16 x86_64 2017-12-21, there is a stack-based buffer
+        over-read in WriteWEBPImage in coders/webp.c, related to a WEBP_DECODER_ABI_VERSION
+        check.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-17880","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-14531","NamespaceName":"debian:8","Description":"ImageMagick
+        7.0.7-0 has a memory exhaustion issue in ReadSUNImage in coders/sun.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14531","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":7.1,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-15015","NamespaceName":"debian:8","Description":"ImageMagick
+        7.0.7-0 Q16 has a NULL pointer dereference vulnerability in PDFDelegateMessage
+        in coders/pdf.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-15015","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-12641","NamespaceName":"debian:8","Description":"ImageMagick
+        7.0.6-1 has a memory leak vulnerability in ReadOneJNGImage in coders\\png.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12641","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-17934","NamespaceName":"debian:8","Description":"ImageMagick
+        7.0.7-17 Q16 x86_64 has memory leaks in coders/msl.c, related to MSLPopImage
+        and ProcessMSLScript, and associated with mishandling of MSLPushImage calls.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-17934","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-18027","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.7-1 Q16, a memory leak vulnerability was found in the function
+        ReadMATImage in coders/mat.c, which allow remote attackers to cause a denial
+        of service via a crafted file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-18027","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-12673","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.6-3, a memory leak vulnerability was found in the function
+        ReadOneMNGImage in coders/png.c, which allows attackers to cause a denial
+        of service.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12673","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-11523","NamespaceName":"debian:8","Description":"The
+        ReadTXTImage function in coders/txt.c in ImageMagick through 6.9.9-0 and 7.x
+        through 7.0.6-1 allows remote attackers to cause a denial of service (infinite
+        loop) via a crafted file, because the end-of-file condition is not considered.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-11523","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.1,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-12675","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.6-3, a missing check for multidimensional data was found in
+        coders/mat.c, leading to a memory leak in the function ReadImage in MagickCore/constitute.c,
+        which allows attackers to cause a denial of service.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12675","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2018-5358","NamespaceName":"debian:8","Description":"ImageMagick
+        7.0.7-22 Q16 has memory leaks in the EncodeImageAttributes function in coders/json.c,
+        as demonstrated by the ReadPSDLayersInternal function in coders/psd.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-5358","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-17883","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.7-12 Q16, a memory leak vulnerability was found in the function
+        ReadPGXImage in coders/pgx.c, which allows attackers to cause a denial of
+        service via a crafted PGX image file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-17883","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-17881","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.7-12 Q16, a memory leak vulnerability was found in the function
+        ReadMATImage in coders/mat.c, which allows attackers to cause a denial of
+        service via a crafted MAT image file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-17881","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-12566","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.6-2, a memory leak vulnerability was found in the function
+        ReadMVGImage in coders/mvg.c, which allows attackers to cause a denial of
+        service, related to the function ReadSVGImage in svg.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12566","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-1000476","NamespaceName":"debian:8","Description":"ImageMagick
+        7.0.7-12 Q16, a CPU exhaustion vulnerability was found in the function ReadDDSInfo
+        in coders/dds.c, which allows attackers to cause a denial of service.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-1000476","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.1,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2016-8678","NamespaceName":"debian:8","Description":"The
+        IsPixelMonochrome function in MagickCore/pixel-accessor.h in ImageMagick 7.0.3.0
+        allows remote attackers to cause a denial of service (out-of-bounds read and
+        crash) via a crafted file.  NOTE: the vendor says \"This is a Q64 issue and
+        we do not support Q64.\"","Link":"https://security-tracker.debian.org/tracker/CVE-2016-8678","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-13658","NamespaceName":"debian:8","Description":"In
+        ImageMagick before 6.9.9-3 and 7.x before 7.0.6-3, there is a missing NULL
+        check in the ReadMATImage function in coders/mat.c, leading to a denial of
+        service (assertion failure and application exit) in the DestroyImageInfo function
+        in MagickCore/image.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-13658","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-17914","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.7-16 Q16, a vulnerability was found in the function ReadOnePNGImage
+        in coders/png.c, which allows attackers to cause a denial of service (ReadOneMNGImage
+        large loop) via a crafted mng image file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-17914","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.1,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2018-5248","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.7-17 Q16, there is a heap-based buffer over-read in coders/sixel.c
+        in the ReadSIXELImage function, related to the sixel_decode function.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-5248","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-14624","NamespaceName":"debian:8","Description":"ImageMagick
+        7.0.7-0 Q16 has a NULL Pointer Dereference vulnerability in the function PostscriptDelegateMessage
+        in coders/ps.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14624","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-9500","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.5-8 Q16, an assertion failure was found in the function ResetImageProfileIterator,
+        which allows attackers to cause a denial of service via a crafted file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-9500","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-12642","NamespaceName":"debian:8","Description":"ImageMagick
+        7.0.6-1 has a memory leak vulnerability in ReadMPCImage in coders\\mpc.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12642","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-14625","NamespaceName":"debian:8","Description":"ImageMagick
+        7.0.7-0 Q16 has a NULL Pointer Dereference vulnerability in the function sixel_output_create
+        in coders/sixel.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14625","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-14684","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.7-4 Q16, a memory leak vulnerability was found in the function
+        ReadVIPSImage in coders/vips.c, which allows attackers to cause a denial of
+        service (memory consumption in ResizeMagickMemory in MagickCore/memory.c)
+        via a crafted file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14684","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":7.1,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-12430","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.6-1, a memory exhaustion vulnerability was found in the function
+        ReadMPCImage in coders/mpc.c, which allows attackers to cause a denial of
+        service.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12430","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.8,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-17682","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.7-12 Q16, a large loop vulnerability was found in the function
+        ExtractPostscript in coders/wpg.c, which allows attackers to cause a denial
+        of service (CPU exhaustion) via a crafted wpg image file that triggers a ReadWPGImage
+        call.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-17682","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.1,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2018-9135","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.7-24 Q16, there is a heap-based buffer over-read in IsWEBPImageLossless
+        in coders/webp.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-9135","Severity":"Negligible"},{"Name":"CVE-2017-17681","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.7-12 Q16, an infinite loop vulnerability was found in the
+        function ReadPSDChannelZip in coders/psd.c, which allows attackers to cause
+        a denial of service (CPU exhaustion) via a crafted psd image file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-17681","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":7.1,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-11537","NamespaceName":"debian:8","Description":"When
+        ImageMagick 7.0.6-1 processes a crafted file in convert, it can lead to a
+        Floating Point Exception (FPE) in the WritePALMImage() function in coders/palm.c,
+        related to an incorrect bits-per-pixel calculation.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-11537","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-17886","NamespaceName":"debian:8","Description":"In
+        ImageMagick 7.0.7-12 Q16, a memory leak vulnerability was found in the function
+        ReadPSDChannelZip in coders/psd.c, which allows attackers to cause a denial
+        of service via a crafted psd image file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-17886","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-12654","NamespaceName":"debian:8","Description":"The
+        ReadPICTImage function in coders/pict.c in ImageMagick 7.0.6-3 allows attackers
+        to cause a denial of service (memory leak) via a crafted file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12654","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-14175","NamespaceName":"debian:8","Description":"In
+        coders/xbm.c in ImageMagick 7.0.6-1 Q16, a DoS in ReadXBMImage() due to lack
+        of an EOF (End of File) check might cause huge CPU consumption. When a crafted
+        XBM file, which claims large rows and columns fields in the header but does
+        not contain sufficient backing data, is provided, the loop over the rows would
+        consume huge CPU resources, since there is no EOF check inside the loop.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14175","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.1,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-14739","NamespaceName":"debian:8","Description":"The
+        AcquireResampleFilterThreadSet function in magick/resample-private.h in ImageMagick
+        7.0.7-4 mishandles failed memory allocation, which allows remote attackers
+        to cause a denial of service (NULL Pointer Dereference in DistortImage in
+        MagickCore/distort.c, and application crash) via unspecified vectors.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14739","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}}],"AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"pango1.0","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.36.8-3","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"xz-utils","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"5.1.1alpha+20120614-2","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"libtext-wrapi18n-perl","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"0.06-7","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"jasper","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.900.1-debian1-2.4+deb8u3","Vulnerabilities":[{"Name":"CVE-2016-9398","NamespaceName":"debian:8","Description":"The
+        jpc_floorlog2 function in jpc_math.c in JasPer before 1.900.17 allows remote
+        attackers to cause a denial of service (assertion failure) via unspecified
+        vectors.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-9398","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2015-5203","NamespaceName":"debian:8","Description":"Double
+        free vulnerability in the jasper_image_stop_load function in JasPer 1.900.17
+        allows remote attackers to cause a denial of service (crash) via a crafted
+        JPEG 2000 image file.","Link":"https://security-tracker.debian.org/tracker/CVE-2015-5203","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-5498","NamespaceName":"debian:8","Description":"libjasper/include/jasper/jas_math.h
+        in JasPer 1.900.17 allows remote attackers to cause a denial of service (crash)
+        via vectors involving left shift of a negative value.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-5498","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-13745","NamespaceName":"debian:8","Description":"There
+        is a reachable assertion abort in the function jpc_dec_process_sot() in jpc/jpc_dec.c
+        in JasPer 2.0.12 that will lead to a remote denial of service attack.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-13745","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-5505","NamespaceName":"debian:8","Description":"The
+        jas_matrix_asl function in jas_seq.c in JasPer 1.900.27 allows remote attackers
+        to cause a denial of service (invalid memory read and crash) via a crafted
+        image.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-5505","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-13748","NamespaceName":"debian:8","Description":"There
+        are lots of memory leaks in JasPer 2.0.12, triggered in the function jas_strdup()
+        in base/jas_string.c, that will lead to a remote denial of service attack.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-13748","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-6852","NamespaceName":"debian:8","Description":"Heap-based
+        buffer overflow in the jpc_dec_decodepkt function in jpc_t2dec.c in JasPer
+        2.0.10 allows remote attackers to have unspecified impact via a crafted image.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-6852","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2016-8883","NamespaceName":"debian:8","Description":"The
+        jpc_dec_tiledecode function in jpc_dec.c in JasPer before 1.900.8 allows remote
+        attackers to cause a denial of service (assertion failure) via a crafted file.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-8883","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2016-9393","NamespaceName":"debian:8","Description":"The
+        jpc_pi_nextrpcl function in jpc_t2cod.c in JasPer before 1.900.17 allows remote
+        attackers to cause a denial of service (assertion failure) via a crafted file.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-9393","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2016-9396","NamespaceName":"debian:8","Description":"The
+        JPC_NOMINALGAIN function in jpc/jpc_t1cod.c in JasPer through 2.0.12 allows
+        remote attackers to cause a denial of service (JPC_COX_RFT assertion failure)
+        via unspecified vectors.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-9396","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-5504","NamespaceName":"debian:8","Description":"The
+        jpc_undo_roi function in libjasper/jpc/jpc_dec.c in JasPer 1.900.27 allows
+        remote attackers to cause a denial of service (invalid memory read and crash)
+        via a crafted image.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-5504","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2016-9391","NamespaceName":"debian:8","Description":"The
+        jpc_bitstream_getbits function in jpc_bs.c in JasPer before 2.0.10 allows
+        remote attackers to cause a denial of service (assertion failure) via a very
+        large integer.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-9391","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-13749","NamespaceName":"debian:8","Description":"There
+        is a reachable assertion abort in the function jpc_pi_nextrpcl() in jpc/jpc_t2cod.c
+        in JasPer 2.0.12 that will lead to a remote denial of service attack.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-13749","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2016-9392","NamespaceName":"debian:8","Description":"The
+        calcstepsizes function in jpc_dec.c in JasPer before 1.900.17 allows remote
+        attackers to cause a denial of service (assertion failure) via a crafted file.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-9392","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2016-9388","NamespaceName":"debian:8","Description":"The
+        ras_getcmap function in ras_dec.c in JasPer before 1.900.14 allows remote
+        attackers to cause a denial of service (assertion failure) via a crafted image
+        file.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-9388","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-14132","NamespaceName":"debian:8","Description":"JasPer
+        2.0.13 allows remote attackers to cause a denial of service (heap-based buffer
+        over-read and application crash) via a crafted image, related to the jas_image_ishomosamp
+        function in libjasper/base/jas_image.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14132","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-9782","NamespaceName":"debian:8","Description":"JasPer
+        2.0.12 allows remote attackers to cause a denial of service (heap-based buffer
+        over-read and application crash) via a crafted image, related to the jp2_decode
+        function in libjasper/jp2/jp2_dec.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-9782","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-13750","NamespaceName":"debian:8","Description":"There
+        is a reachable assertion abort in the function jpc_dec_process_siz() in jpc/jpc_dec.c:1296
+        in JasPer 2.0.12 that will lead to a remote denial of service attack.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-13750","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2016-9387","NamespaceName":"debian:8","Description":"Integer
+        overflow in the jpc_dec_process_siz function in libjasper/jpc/jpc_dec.c in
+        JasPer before 1.900.13 allows remote attackers to have unspecified impact
+        via a crafted file, which triggers an assertion failure.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-9387","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2016-9600","NamespaceName":"debian:8","Description":"JasPer
+        before version 2.0.10 is vulnerable to a null pointer dereference was found
+        in the decoded creation of JPEG 2000 image files. A specially crafted file
+        could cause an application using JasPer to crash.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-9600","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2016-10248","NamespaceName":"debian:8","Description":"The
+        jpc_tsfb_synthesize function in jpc_tsfb.c in JasPer before 1.900.9 allows
+        remote attackers to cause a denial of service (NULL pointer dereference) via
+        vectors involving an empty sequence.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-10248","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-13752","NamespaceName":"debian:8","Description":"There
+        is a reachable assertion abort in the function jpc_dequantize() in jpc/jpc_dec.c
+        in JasPer 2.0.12 that will lead to a remote denial of service attack.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-13752","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2016-9394","NamespaceName":"debian:8","Description":"The
+        jas_seq2d_create function in jas_seq.c in JasPer before 1.900.17 allows remote
+        attackers to cause a denial of service (assertion failure) via a crafted file.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-9394","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2016-8887","NamespaceName":"debian:8","Description":"The
+        jp2_colr_destroy function in libjasper/jp2/jp2_cod.c in JasPer before 1.900.10
+        allows remote attackers to cause a denial of service (NULL pointer dereference).","Link":"https://security-tracker.debian.org/tracker/CVE-2016-8887","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-13746","NamespaceName":"debian:8","Description":"There
+        is a reachable assertion abort in the function jpc_dec_process_siz() in jpc/jpc_dec.c:1297
+        in JasPer 2.0.12 that will lead to a remote denial of service attack.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-13746","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2016-9395","NamespaceName":"debian:8","Description":"The
+        jas_seq2d_create function in jas_seq.c in JasPer before 1.900.25 allows remote
+        attackers to cause a denial of service (assertion failure) via a crafted file.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-9395","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-13747","NamespaceName":"debian:8","Description":"There
+        is a reachable assertion abort in the function jpc_floorlog2() in jpc/jpc_math.c
+        in JasPer 2.0.12 that will lead to a remote denial of service attack.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-13747","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-5501","NamespaceName":"debian:8","Description":"Integer
+        overflow in libjasper/jpc/jpc_tsfb.c in JasPer 1.900.17 allows remote attackers
+        to cause a denial of service (crash) via a crafted file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-5501","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-5502","NamespaceName":"debian:8","Description":"libjasper/jp2/jp2_dec.c
+        in JasPer 1.900.17 allows remote attackers to cause a denial of service (crash)
+        via vectors involving left shift of a negative value.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-5502","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2016-9583","NamespaceName":"debian:8","Link":"https://security-tracker.debian.org/tracker/CVE-2016-9583","Severity":"Negligible"},{"Name":"CVE-2017-5499","NamespaceName":"debian:8","Description":"Integer
+        overflow in libjasper/jpc/jpc_dec.c in JasPer 1.900.17 allows remote attackers
+        to cause a denial of service (crash) via a crafted file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-5499","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2016-9399","NamespaceName":"debian:8","Description":"The
+        calcstepsizes function in jpc_dec.c in JasPer 1.900.22 allows remote attackers
+        to cause a denial of service (assertion failure) via unspecified vectors.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-9399","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2016-9397","NamespaceName":"debian:8","Description":"The
+        jpc_dequantize function in jpc_dec.c in JasPer 1.900.13 allows remote attackers
+        to cause a denial of service (assertion failure) via unspecified vectors.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-9397","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-1000050","NamespaceName":"debian:8","Description":"JasPer
+        2.0.12 is vulnerable to a NULL pointer exception in the function jp2_encode
+        which failed to check to see if the image contained at least one component
+        resulting in a denial-of-service.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-1000050","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2016-8690","NamespaceName":"debian:8","Description":"The
+        bmp_getdata function in libjasper/bmp/bmp_dec.c in JasPer before 1.900.5 allows
+        remote attackers to cause a denial of service (NULL pointer dereference) via
+        a crafted BMP image in an imginfo command.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-8690","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2016-8886","NamespaceName":"debian:8","Description":"The
+        jas_malloc function in libjasper/base/jas_malloc.c in JasPer before 1.900.11
+        allows remote attackers to have unspecified impact via a crafted file, which
+        triggers a memory allocation failure.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-8886","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2016-9390","NamespaceName":"debian:8","Description":"The
+        jas_seq2d_create function in jas_seq.c in JasPer before 1.900.14 allows remote
+        attackers to cause a denial of service (assertion failure) via a crafted image
+        file.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-9390","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-6850","NamespaceName":"debian:8","Description":"The
+        jp2_cdef_destroy function in jp2_cod.c in JasPer before 2.0.13 allows remote
+        attackers to cause a denial of service (NULL pointer dereference) via a crafted
+        image.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-6850","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2015-5221","NamespaceName":"debian:8","Description":"Use-after-free
+        vulnerability in the mif_process_cmpt function in libjasper/mif/mif_cod.c
+        in the JasPer JPEG-2000 library before 1.900.2 allows remote attackers to
+        cause a denial of service (crash) via a crafted JPEG 2000 image file.","Link":"https://security-tracker.debian.org/tracker/CVE-2015-5221","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2016-9389","NamespaceName":"debian:8","Description":"The
+        jpc_irct and jpc_iict functions in jpc_mct.c in JasPer before 1.900.14 allow
+        remote attackers to cause a denial of service (assertion failure).","Link":"https://security-tracker.debian.org/tracker/CVE-2016-9389","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2018-9252","NamespaceName":"debian:8","Description":"JasPer
+        2.0.14 allows denial of service via a reachable assertion in the function
+        jpc_abstorelstepsize in libjasper/jpc/jpc_enc.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-9252","Severity":"Negligible"},{"Name":"CVE-2017-14229","NamespaceName":"debian:8","Description":"There
+        is an infinite loop in the jpc_dec_tileinit function in jpc/jpc_dec.c of Jasper
+        2.0.13. It will lead to a remote denial of service attack.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14229","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-13751","NamespaceName":"debian:8","Description":"There
+        is a reachable assertion abort in the function calcstepsizes() in jpc/jpc_dec.c
+        in JasPer 2.0.12 that will lead to a remote denial of service attack.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-13751","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2016-9557","NamespaceName":"debian:8","Description":"Integer
+        overflow in jas_image.c in JasPer before 1.900.25 allows remote attackers
+        to cause a denial of service (application crash) via a crafted file.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-9557","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2018-9055","NamespaceName":"debian:8","Description":"JasPer
+        2.0.14 allows denial of service via a reachable assertion in the function
+        jpc_firstone in libjasper/jpc/jpc_math.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-9055","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-5500","NamespaceName":"debian:8","Description":"libjasper/jpc/jpc_dec.c
+        in JasPer 1.900.17 allows remote attackers to cause a denial of service (crash)
+        via vectors involving left shift of a negative value.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-5500","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-6851","NamespaceName":"debian:8","Description":"The
+        jas_matrix_bindsub function in jas_seq.c in JasPer 2.0.10 allows remote attackers
+        to cause a denial of service (invalid read) via a crafted image.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-6851","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}}],"AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"p11-kit","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"0.20.7-1","AddedBy":"sha256:7b491c575b06601bb07a2d88bfc3ace6c6005edc1b4d8da3ba6e37e04e9592d6"},{"Name":"python-defaults","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2.7.9-1","Vulnerabilities":[{"Name":"CVE-2008-4108","NamespaceName":"debian:8","Description":"Tools/faqwiz/move-faqwiz.sh
+        (aka the generic FAQ wizard moving tool) in Python 2.4.5 might allow local
+        users to overwrite arbitrary files via a symlink attack on a tmp$RANDOM.tmp
+        temporary file.  NOTE: there may not be common usage scenarios in which tmp$RANDOM.tmp
+        is located in an untrusted directory.","Link":"https://security-tracker.debian.org/tracker/CVE-2008-4108","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":7.2,"Vectors":"AV:L/AC:L/Au:N/C:C/I:C"}}}}],"AddedBy":"sha256:b313b08bab3b8bbcf0de4171a2a80a01e67fab094f272819b76a58705d21ab28"},{"Name":"binutils","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2.25-5+deb8u1","Vulnerabilities":[{"Name":"CVE-2017-7614","NamespaceName":"debian:8","Description":"elflink.c
+        in the Binary File Descriptor (BFD) library (aka libbfd), as distributed in
+        GNU Binutils 2.28, has a \"member access within null pointer\" undefined behavior
+        issue, which might allow remote attackers to cause a denial of service (application
+        crash) or possibly have unspecified other impact via an \"int main() {return
+        0;}\" program.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-7614","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-15020","NamespaceName":"debian:8","Description":"dwarf1.c
+        in the Binary File Descriptor (BFD) library (aka libbfd), as distributed in
+        GNU Binutils 2.29, mishandles pointers, which allows remote attackers to cause
+        a denial of service (application crash) or possibly have unspecified other
+        impact via a crafted ELF file, related to parse_die and parse_line_table,
+        as demonstrated by a parse_die heap-based buffer over-read.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-15020","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-12450","NamespaceName":"debian:8","Description":"The
+        alpha_vms_object_p function in bfd/vms-alpha.c in the Binary File Descriptor
+        (BFD) library (aka libbfd), as distributed in GNU Binutils 2.29 and earlier,
+        allows remote attackers to cause an out of bounds heap write and possibly
+        achieve code execution via a crafted vms alpha file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12450","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-8397","NamespaceName":"debian:8","Description":"The
+        Binary File Descriptor (BFD) library (aka libbfd), as distributed in GNU Binutils
+        2.28, is vulnerable to an invalid read of size 1 and an invalid write of size
+        1 during processing of a corrupt binary containing reloc(s) with negative
+        addresses. This vulnerability causes programs that conduct an analysis of
+        binary programs using the libbfd library, such as objdump, to crash.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-8397","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-16830","NamespaceName":"debian:8","Description":"The
+        print_gnu_property_note function in readelf.c in GNU Binutils 2.29.1 does
+        not have integer-overflow protection on 32-bit platforms, which allows remote
+        attackers to cause a denial of service (segmentation violation and application
+        crash) or possibly have unspecified other impact via a crafted ELF file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-16830","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-14529","NamespaceName":"debian:8","Description":"The
+        pe_print_idata function in peXXigen.c in the Binary File Descriptor (BFD)
+        library (aka libbfd), as distributed in GNU Binutils 2.29, mishandles HintName
+        vector entries, which allows remote attackers to cause a denial of service
+        (heap-based buffer over-read and application crash) via a crafted PE file,
+        related to the bfd_getl16 function.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14529","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-8394","NamespaceName":"debian:8","Description":"The
+        Binary File Descriptor (BFD) library (aka libbfd), as distributed in GNU Binutils
+        2.28, is vulnerable to an invalid read of size 4 due to NULL pointer dereferencing
+        of _bfd_elf_large_com_section. This vulnerability causes programs that conduct
+        an analysis of binary programs using the libbfd library, such as objcopy,
+        to crash.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-8394","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-14940","NamespaceName":"debian:8","Description":"scan_unit_for_symbols
+        in dwarf2.c in the Binary File Descriptor (BFD) library (aka libbfd), as distributed
+        in GNU Binutils 2.29, allows remote attackers to cause a denial of service
+        (NULL pointer dereference and application crash) via a crafted ELF file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14940","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-12458","NamespaceName":"debian:8","Description":"The
+        nlm_swap_auxiliary_headers_in function in bfd/nlmcode.h in the Binary File
+        Descriptor (BFD) library (aka libbfd), as distributed in GNU Binutils 2.29
+        and earlier, allows remote attackers to cause an out of bounds heap read via
+        a crafted nlm file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12458","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-9753","NamespaceName":"debian:8","Description":"The
+        versados_mkobject function in bfd/versados.c in the Binary File Descriptor
+        (BFD) library (aka libbfd), as distributed in GNU Binutils 2.28, does not
+        initialize a certain data structure, which allows remote attackers to cause
+        a denial of service (buffer overflow and application crash) or possibly have
+        unspecified other impact via a crafted binary file, as demonstrated by mishandling
+        of this file during \"objdump -D\" execution.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-9753","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-9745","NamespaceName":"debian:8","Description":"The
+        _bfd_vms_slurp_etir function in bfd/vms-alpha.c in the Binary File Descriptor
+        (BFD) library (aka libbfd), as distributed in GNU Binutils 2.28, allows remote
+        attackers to cause a denial of service (buffer overflow and application crash)
+        or possibly have unspecified other impact via a crafted binary file, as demonstrated
+        by mishandling of this file during \"objdump -D\" execution.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-9745","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-14333","NamespaceName":"debian:8","Description":"The
+        process_version_sections function in readelf.c in GNU Binutils 2.29 allows
+        attackers to cause a denial of service (Integer Overflow, and hang because
+        of a time-consuming loop) or possibly have unspecified other impact via a
+        crafted binary file with invalid values of ent.vn_next, during \"readelf -a\"
+        execution.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14333","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-16827","NamespaceName":"debian:8","Description":"The
+        aout_get_external_symbols function in aoutx.h in the Binary File Descriptor
+        (BFD) library (aka libbfd), as distributed in GNU Binutils 2.29.1, allows
+        remote attackers to cause a denial of service (slurp_symtab invalid free and
+        application crash) or possibly have unspecified other impact via a crafted
+        ELF file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-16827","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-17121","NamespaceName":"debian:8","Description":"The
+        Binary File Descriptor (BFD) library (aka libbfd), as distributed in GNU Binutils
+        2.29.1, allows remote attackers to cause a denial of service (memory access
+        violation) or possibly have unspecified other impact via a COFF binary in
+        which a relocation refers to a location after the end of the to-be-relocated
+        section.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-17121","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2018-8945","NamespaceName":"debian:8","Description":"The
+        bfd_section_from_shdr function in elf.c in the Binary File Descriptor (BFD)
+        library (aka libbfd), as distributed in GNU Binutils 2.30, allows remote attackers
+        to cause a denial of service (segmentation fault) via a large attribute section.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-8945","Severity":"Low"},{"Name":"CVE-2018-9138","NamespaceName":"debian:8","Description":"An
+        issue was discovered in cplus-dem.c in GNU libiberty, as distributed in GNU
+        Binutils 2.29 and 2.30. Stack Exhaustion occurs in the C++ demangling functions
+        provided by libiberty, and there are recursive stack frames: demangle_nested_args,
+        demangle_args, do_arg, and do_type.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-9138","Severity":"Low"},{"Name":"CVE-2017-14128","NamespaceName":"debian:8","Description":"The
+        decode_line_info function in dwarf2.c in the Binary File Descriptor (BFD)
+        library (aka libbfd), as distributed in GNU Binutils 2.29, allows remote attackers
+        to cause a denial of service (read_1_byte heap-based buffer over-read and
+        application crash) via a crafted ELF file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14128","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-13716","NamespaceName":"debian:8","Description":"The
+        C++ symbol demangler routine in cplus-dem.c in libiberty, as distributed in
+        GNU Binutils 2.29, allows remote attackers to cause a denial of service (excessive
+        memory allocation and application crash) via a crafted file, as demonstrated
+        by a call from the Binary File Descriptor (BFD) library (aka libbfd).","Link":"https://security-tracker.debian.org/tracker/CVE-2017-13716","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":7.1,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-9743","NamespaceName":"debian:8","Description":"The
+        print_insn_score32 function in opcodes/score7-dis.c:552 in GNU Binutils 2.28
+        allows remote attackers to cause a denial of service (buffer overflow and
+        application crash) or possibly have unspecified other impact via a crafted
+        binary file, as demonstrated by mishandling of this file during \"objdump
+        -D\" execution.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-9743","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-9040","NamespaceName":"debian:8","Description":"GNU
+        Binutils 2017-04-03 allows remote attackers to cause a denial of service (NULL
+        pointer dereference and application crash), related to the process_mips_specific
+        function in readelf.c, via a crafted ELF file that triggers a large memory-allocation
+        attempt.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-9040","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-14930","NamespaceName":"debian:8","Description":"Memory
+        leak in decode_line_info in dwarf2.c in the Binary File Descriptor (BFD) library
+        (aka libbfd), as distributed in GNU Binutils 2.29, allows remote attackers
+        to cause a denial of service (memory consumption) via a crafted ELF file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14930","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":7.1,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2018-7643","NamespaceName":"debian:8","Description":"The
+        display_debug_ranges function in dwarf.c in GNU Binutils 2.30 allows remote
+        attackers to cause a denial of service (integer overflow and application crash)
+        or possibly have unspecified other impact via a crafted ELF file, as demonstrated
+        by objdump.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-7643","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2016-2226","NamespaceName":"debian:8","Description":"Integer
+        overflow in the string_appends function in cplus-dem.c in libiberty allows
+        remote attackers to execute arbitrary code via a crafted executable, which
+        triggers a buffer overflow.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-2226","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-12457","NamespaceName":"debian:8","Description":"The
+        bfd_make_section_with_flags function in section.c in the Binary File Descriptor
+        (BFD) library (aka libbfd), as distributed in GNU Binutils 2.29 and earlier,
+        allows remote attackers to cause a NULL dereference via a crafted file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12457","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2018-7570","NamespaceName":"debian:8","Description":"The
+        assign_file_positions_for_non_load_sections function in elf.c in the Binary
+        File Descriptor (BFD) library (aka libbfd), as distributed in GNU Binutils
+        2.30, allows remote attackers to cause a denial of service (NULL pointer dereference
+        and application crash) via an ELF file with a RELRO segment that lacks a matching
+        LOAD segment, as demonstrated by objcopy.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-7570","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-8395","NamespaceName":"debian:8","Description":"The
+        Binary File Descriptor (BFD) library (aka libbfd), as distributed in GNU Binutils
+        2.28, is vulnerable to an invalid write of size 8 because of missing a malloc()
+        return-value check to see if memory had actually been allocated in the _bfd_generic_get_section_contents
+        function. This vulnerability causes programs that conduct an analysis of binary
+        programs using the libbfd library, such as objcopy, to crash.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-8395","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-9042","NamespaceName":"debian:8","Description":"readelf.c
+        in GNU Binutils 2017-04-12 has a \"cannot be represented in type long\" issue,
+        which might allow remote attackers to cause a denial of service (application
+        crash) or possibly have unspecified other impact via a crafted ELF file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-9042","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2016-4488","NamespaceName":"debian:8","Description":"Use-after-free
+        vulnerability in libiberty allows remote attackers to cause a denial of service
+        (segmentation fault and crash) via a crafted binary, related to \"ktypevec.\"","Link":"https://security-tracker.debian.org/tracker/CVE-2016-4488","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-14129","NamespaceName":"debian:8","Description":"The
+        read_section function in dwarf2.c in the Binary File Descriptor (BFD) library
+        (aka libbfd), as distributed in GNU Binutils 2.29, allows remote attackers
+        to cause a denial of service (parse_comp_unit heap-based buffer over-read
+        and application crash) via a crafted ELF file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14129","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-12452","NamespaceName":"debian:8","Description":"The
+        bfd_mach_o_i386_canonicalize_one_reloc function in bfd/mach-o-i386.c in the
+        Binary File Descriptor (BFD) library (aka libbfd), as distributed in GNU Binutils
+        2.29 and earlier, allows remote attackers to cause an out of bounds heap read
+        via a crafted mach-o file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12452","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2016-6131","NamespaceName":"debian:8","Description":"The
+        demangler in GNU Libiberty allows remote attackers to cause a denial of service
+        (infinite loop, stack overflow, and crash) via a cycle in the references of
+        remembered mangled types.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-6131","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-14934","NamespaceName":"debian:8","Description":"process_debug_info
+        in dwarf.c in the Binary File Descriptor (BFD) library (aka libbfd), as distributed
+        in GNU Binutils 2.29, allows remote attackers to cause a denial of service
+        (infinite loop) via a crafted ELF file that contains a negative size value
+        in a CU structure.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14934","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-17122","NamespaceName":"debian:8","Description":"The
+        dump_relocs_in_section function in objdump.c in GNU Binutils 2.29.1 does not
+        check for reloc count integer overflows, which allows remote attackers to
+        cause a denial of service (excessive memory allocation, or heap-based buffer
+        overflow and application crash) or possibly have unspecified other impact
+        via a crafted PE file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-17122","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-17125","NamespaceName":"debian:8","Description":"nm.c
+        and objdump.c in GNU Binutils 2.29.1 mishandle certain global symbols, which
+        allows remote attackers to cause a denial of service (_bfd_elf_get_symbol_version_string
+        buffer over-read and application crash) or possibly have unspecified other
+        impact via a crafted ELF file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-17125","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-12456","NamespaceName":"debian:8","Description":"The
+        read_symbol_stabs_debugging_info function in rddbg.c in GNU Binutils 2.29
+        and earlier allows remote attackers to cause an out of bounds heap read via
+        a crafted binary file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12456","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2018-6323","NamespaceName":"debian:8","Description":"The
+        elf_object_p function in elfcode.h in the Binary File Descriptor (BFD) library
+        (aka libbfd), as distributed in GNU Binutils 2.29.1, has an unsigned integer
+        overflow because bfd_size_type multiplication is not used. A crafted ELF file
+        allows remote attackers to cause a denial of service (application crash) or
+        possibly have unspecified other impact.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-6323","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-8396","NamespaceName":"debian:8","Description":"The
+        Binary File Descriptor (BFD) library (aka libbfd), as distributed in GNU Binutils
+        2.28, is vulnerable to an invalid read of size 1 because the existing reloc
+        offset range tests didn''t catch small negative offsets less than the size
+        of the reloc field. This vulnerability causes programs that conduct an analysis
+        of binary programs using the libbfd library, such as objdump, to crash.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-8396","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-9043","NamespaceName":"debian:8","Description":"readelf.c
+        in GNU Binutils 2017-04-12 has a \"shift exponent too large for type unsigned
+        long\" issue, which might allow remote attackers to cause a denial of service
+        (application crash) or possibly have unspecified other impact via a crafted
+        ELF file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-9043","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-9749","NamespaceName":"debian:8","Description":"The
+        *regs* macros in opcodes/bfin-dis.c in GNU Binutils 2.28 allow remote attackers
+        to cause a denial of service (buffer overflow and application crash) or possibly
+        have unspecified other impact via a crafted binary file, as demonstrated by
+        mishandling of this file during \"objdump -D\" execution.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-9749","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-9039","NamespaceName":"debian:8","Description":"GNU
+        Binutils 2.28 allows remote attackers to cause a denial of service (memory
+        consumption) via a crafted ELF file with many program headers, related to
+        the get_program_headers function in readelf.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-9039","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-14745","NamespaceName":"debian:8","Description":"The
+        *_get_synthetic_symtab functions in the Binary File Descriptor (BFD) library
+        (aka libbfd), as distributed in GNU Binutils 2.29, interpret a -1 value as
+        a sorting count instead of an error flag, which allows remote attackers to
+        cause a denial of service (integer overflow and application crash) or possibly
+        have unspecified other impact via a crafted ELF file, related to elf32-i386.c
+        and elf64-x86-64.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14745","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2014-9939","NamespaceName":"debian:8","Description":"ihex.c
+        in GNU Binutils before 2.26 contains a stack buffer overflow when printing
+        bad bytes in Intel Hex objects.","Link":"https://security-tracker.debian.org/tracker/CVE-2014-9939","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-9038","NamespaceName":"debian:8","Description":"GNU
+        Binutils 2.28 allows remote attackers to cause a denial of service (heap-based
+        buffer over-read and application crash) via a crafted ELF file, related to
+        the byte_get_little_endian function in elfcomm.c, the get_unwind_section_word
+        function in readelf.c, and ARM unwind information that contains invalid word
+        offsets.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-9038","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-7225","NamespaceName":"debian:8","Description":"The
+        find_nearest_line function in addr2line in GNU Binutils 2.28 does not handle
+        the case where the main file name and the directory name are both empty, triggering
+        a NULL pointer dereference and an invalid write, and leading to a program
+        crash.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-7225","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2018-7568","NamespaceName":"debian:8","Description":"The
+        parse_die function in dwarf1.c in the Binary File Descriptor (BFD) library
+        (aka libbfd), as distributed in GNU Binutils 2.30, allows remote attackers
+        to cause a denial of service (integer overflow and application crash) via
+        an ELF file with corrupt dwarf1 debug information, as demonstrated by nm.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-7568","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-12455","NamespaceName":"debian:8","Description":"The
+        evax_bfd_print_emh function in vms-alpha.c in the Binary File Descriptor (BFD)
+        library (aka libbfd), as distributed in GNU Binutils 2.29 and earlier, allows
+        remote attackers to cause an out of bounds heap read via a crafted vms alpha
+        file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12455","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2018-6872","NamespaceName":"debian:8","Description":"The
+        elf_parse_notes function in elf.c in the Binary File Descriptor (BFD) library
+        (aka libbfd), as distributed in GNU Binutils 2.30, allows remote attackers
+        to cause a denial of service (out-of-bounds read and segmentation violation)
+        via a note with a large alignment.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-6872","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-16828","NamespaceName":"debian:8","Description":"The
+        display_debug_frames function in dwarf.c in GNU Binutils 2.29.1 allows remote
+        attackers to cause a denial of service (integer overflow and heap-based buffer
+        over-read, and application crash) or possibly have unspecified other impact
+        via a crafted ELF file, related to print_debug_frame.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-16828","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-15021","NamespaceName":"debian:8","Description":"bfd_get_debug_link_info_1
+        in opncls.c in the Binary File Descriptor (BFD) library (aka libbfd), as distributed
+        in GNU Binutils 2.29, allows remote attackers to cause a denial of service
+        (heap-based buffer over-read and application crash) via a crafted ELF file,
+        related to bfd_getl32.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-15021","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-9955","NamespaceName":"debian:8","Description":"The
+        get_build_id function in opncls.c in the Binary File Descriptor (BFD) library
+        (aka libbfd), as distributed in GNU Binutils 2.28, allows remote attackers
+        to cause a denial of service (heap-based buffer over-read and application
+        crash) via a crafted file in which a certain size field is larger than a corresponding
+        data field, as demonstrated by mishandling within the objdump program.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-9955","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-13757","NamespaceName":"debian:8","Description":"The
+        Binary File Descriptor (BFD) library (aka libbfd), as distributed in GNU Binutils
+        2.29, does not validate the PLT section size, which allows remote attackers
+        to cause a denial of service (heap-based buffer over-read and application
+        crash) via a crafted ELF file, related to elf_i386_get_synthetic_symtab in
+        elf32-i386.c and elf_x86_64_get_synthetic_symtab in elf64-x86-64.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-13757","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-15022","NamespaceName":"debian:8","Description":"dwarf2.c
+        in the Binary File Descriptor (BFD) library (aka libbfd), as distributed in
+        GNU Binutils 2.29, does not validate the DW_AT_name data type, which allows
+        remote attackers to cause a denial of service (bfd_hash_hash NULL pointer
+        dereference, or out-of-bounds access, and application crash) via a crafted
+        ELF file, related to scan_unit_for_symbols and parse_comp_unit.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-15022","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-15938","NamespaceName":"debian:8","Description":"dwarf2.c
+        in the Binary File Descriptor (BFD) library (aka libbfd), as distributed in
+        GNU Binutils 2.29, miscalculates DW_FORM_ref_addr die refs in the case of
+        a relocatable object file, which allows remote attackers to cause a denial
+        of service (find_abstract_instance_name invalid memory read, segmentation
+        fault, and application crash).","Link":"https://security-tracker.debian.org/tracker/CVE-2017-15938","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-7301","NamespaceName":"debian:8","Description":"The
+        Binary File Descriptor (BFD) library (aka libbfd), as distributed in GNU Binutils
+        2.28, has an aout_link_add_symbols function in bfd/aoutx.h that has an off-by-one
+        vulnerability because it does not carefully check the string offset. The vulnerability
+        could lead to a GNU linker (ld) program crash.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-7301","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-15023","NamespaceName":"debian:8","Description":"read_formatted_entries
+        in dwarf2.c in the Binary File Descriptor (BFD) library (aka libbfd), as distributed
+        in GNU Binutils 2.29, does not properly validate the format count, which allows
+        remote attackers to cause a denial of service (NULL pointer dereference and
+        application crash) via a crafted ELF file, related to concat_filename.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-15023","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-8398","NamespaceName":"debian:8","Description":"dwarf.c
+        in GNU Binutils 2.28 is vulnerable to an invalid read of size 1 during dumping
+        of debug information from a corrupt binary. This vulnerability causes programs
+        that conduct an analysis of binary programs, such as objdump and readelf,
+        to crash.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-8398","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-9754","NamespaceName":"debian:8","Description":"The
+        process_otr function in bfd/versados.c in the Binary File Descriptor (BFD)
+        library (aka libbfd), as distributed in GNU Binutils 2.28, does not validate
+        a certain offset, which allows remote attackers to cause a denial of service
+        (buffer overflow and application crash) or possibly have unspecified other
+        impact via a crafted binary file, as demonstrated by mishandling of this file
+        during \"objdump -D\" execution.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-9754","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2018-7569","NamespaceName":"debian:8","Description":"dwarf2.c
+        in the Binary File Descriptor (BFD) library (aka libbfd), as distributed in
+        GNU Binutils 2.30, allows remote attackers to cause a denial of service (integer
+        underflow or overflow, and application crash) via an ELF file with a corrupt
+        DWARF FORM block, as demonstrated by nm.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-7569","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-14939","NamespaceName":"debian:8","Description":"decode_line_info
+        in dwarf2.c in the Binary File Descriptor (BFD) library (aka libbfd), as distributed
+        in GNU Binutils 2.29, mishandles a length calculation, which allows remote
+        attackers to cause a denial of service (heap-based buffer over-read and application
+        crash) via a crafted ELF file, related to read_1_byte.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14939","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2016-4489","NamespaceName":"debian:8","Description":"Integer
+        overflow in the gnu_special function in libiberty allows remote attackers
+        to cause a denial of service (segmentation fault and crash) via a crafted
+        binary, related to the \"demangling of virtual tables.\"","Link":"https://security-tracker.debian.org/tracker/CVE-2016-4489","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-15225","NamespaceName":"debian:8","Description":"_bfd_dwarf2_cleanup_debug_info
+        in dwarf2.c in the Binary File Descriptor (BFD) library (aka libbfd), as distributed
+        in GNU Binutils 2.29, allows remote attackers to cause a denial of service
+        (memory leak) via a crafted ELF file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-15225","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-14933","NamespaceName":"debian:8","Description":"read_formatted_entries
+        in dwarf2.c in the Binary File Descriptor (BFD) library (aka libbfd), as distributed
+        in GNU Binutils 2.29, allows remote attackers to cause a denial of service
+        (infinite loop) via a crafted ELF file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14933","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-7299","NamespaceName":"debian:8","Description":"The
+        Binary File Descriptor (BFD) library (aka libbfd), as distributed in GNU Binutils
+        2.28, has an invalid read (of size 8) because the code to emit relocs (bfd_elf_final_link
+        function in bfd/elflink.c) does not check the format of the input file before
+        trying to read the ELF reloc section header. The vulnerability leads to a
+        GNU linker (ld) program crash.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-7299","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-9755","NamespaceName":"debian:8","Description":"opcodes/i386-dis.c
+        in GNU Binutils 2.28 does not consider the number of registers for bnd mode,
+        which allows remote attackers to cause a denial of service (buffer overflow
+        and application crash) or possibly have unspecified other impact via a crafted
+        binary file, as demonstrated by mishandling of this file during \"objdump
+        -D\" execution.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-9755","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-16831","NamespaceName":"debian:8","Description":"coffgen.c
+        in the Binary File Descriptor (BFD) library (aka libbfd), as distributed in
+        GNU Binutils 2.29.1, does not validate the symbol count, which allows remote
+        attackers to cause a denial of service (integer overflow and application crash,
+        or excessive memory allocation) or possibly have unspecified other impact
+        via a crafted PE file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-16831","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-12448","NamespaceName":"debian:8","Description":"The
+        bfd_cache_close function in bfd/cache.c in the Binary File Descriptor (BFD)
+        library (aka libbfd), as distributed in GNU Binutils 2.29 and earlier, allows
+        remote attackers to cause a heap use after free and possibly achieve code
+        execution via a crafted nested archive file. This issue occurs because incorrect
+        functions are called during an attempt to release memory. The issue can be
+        addressed by better input validation in the bfd_generic_archive_p function
+        in bfd/archive.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12448","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-12449","NamespaceName":"debian:8","Description":"The
+        _bfd_vms_save_sized_string function in vms-misc.c in the Binary File Descriptor
+        (BFD) library (aka libbfd), as distributed in GNU Binutils 2.29 and earlier,
+        allows remote attackers to cause an out of bounds heap read via a crafted
+        vms file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12449","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-8393","NamespaceName":"debian:8","Description":"The
+        Binary File Descriptor (BFD) library (aka libbfd), as distributed in GNU Binutils
+        2.28, is vulnerable to a global buffer over-read error because of an assumption
+        made by code that runs for objcopy and strip, that SHT_REL/SHR_RELA sections
+        are always named starting with a .rel/.rela prefix. This vulnerability causes
+        programs that conduct an analysis of binary programs using the libbfd library,
+        such as objcopy and strip, to crash.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-8393","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2016-4487","NamespaceName":"debian:8","Description":"Use-after-free
+        vulnerability in libiberty allows remote attackers to cause a denial of service
+        (segmentation fault and crash) via a crafted binary, related to \"btypevec.\"","Link":"https://security-tracker.debian.org/tracker/CVE-2016-4487","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2018-9996","NamespaceName":"debian:8","Description":"An
+        issue was discovered in cplus-dem.c in GNU libiberty, as distributed in GNU
+        Binutils 2.30. Stack Exhaustion occurs in the C++ demangling functions provided
+        by libiberty, and there are recursive stack frames: demangle_template_value_parm,
+        demangle_integral_value, and demangle_expression.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-9996","Severity":"Unknown"},{"Name":"CVE-2016-4493","NamespaceName":"debian:8","Description":"The
+        demangle_template_value_parm and do_hpacc_template_literal functions in cplus-dem.c
+        in libiberty allow remote attackers to cause a denial of service (out-of-bounds
+        read and crash) via a crafted binary.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-4493","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-14130","NamespaceName":"debian:8","Description":"The
+        _bfd_elf_parse_attributes function in elf-attrs.c in the Binary File Descriptor
+        (BFD) library (aka libbfd), as distributed in GNU Binutils 2.29, allows remote
+        attackers to cause a denial of service (_bfd_elf_attr_strdup heap-based buffer
+        over-read and application crash) via a crafted ELF file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14130","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-8421","NamespaceName":"debian:8","Description":"The
+        function coff_set_alignment_hook in coffcode.h in Binary File Descriptor (BFD)
+        library (aka libbfd), as distributed in GNU Binutils 2.28, has a memory leak
+        vulnerability which can cause memory exhaustion in objdump via a crafted PE
+        file. Additional validation in dump_relocs_in_section in objdump.c can resolve
+        this.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-8421","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.1,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-12451","NamespaceName":"debian:8","Description":"The
+        _bfd_xcoff_read_ar_hdr function in bfd/coff-rs6000.c and bfd/coff64-rs6000.c
+        in the Binary File Descriptor (BFD) library (aka libbfd), as distributed in
+        GNU Binutils 2.29 and earlier, allows remote attackers to cause an out of
+        bounds stack read via a crafted COFF image file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12451","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2016-4490","NamespaceName":"debian:8","Description":"Integer
+        overflow in cp-demangle.c in libiberty allows remote attackers to cause a
+        denial of service (segmentation fault and crash) via a crafted binary, related
+        to inconsistent use of the long and int types for lengths.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-4490","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-7210","NamespaceName":"debian:8","Description":"objdump
+        in GNU Binutils 2.28 is vulnerable to multiple heap-based buffer over-reads
+        (of size 1 and size 8) while handling corrupt STABS enum type strings in a
+        crafted object file, leading to program crash.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-7210","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-16832","NamespaceName":"debian:8","Description":"The
+        pe_bfd_read_buildid function in peicode.h in the Binary File Descriptor (BFD)
+        library (aka libbfd), as distributed in GNU Binutils 2.29.1, does not validate
+        size and offset values in the data dictionary, which allows remote attackers
+        to cause a denial of service (segmentation violation and application crash)
+        or possibly have unspecified other impact via a crafted PE file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-16832","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-7226","NamespaceName":"debian:8","Description":"The
+        pe_ILF_object_p function in the Binary File Descriptor (BFD) library (aka
+        libbfd), as distributed in GNU Binutils 2.28, is vulnerable to a heap-based
+        buffer over-read of size 4049 because it uses the strlen function instead
+        of strnlen, leading to program crashes in several utilities such as addr2line,
+        size, and strings. It could lead to information disclosure as well.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-7226","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.4,"Vectors":"AV:N/AC:L/Au:N/C:P/I:N"}}}},{"Name":"CVE-2017-14938","NamespaceName":"debian:8","Description":"_bfd_elf_slurp_version_tables
+        in elf.c in the Binary File Descriptor (BFD) library (aka libbfd), as distributed
+        in GNU Binutils 2.29, allows remote attackers to cause a denial of service
+        (excessive memory allocation and application crash) via a crafted ELF file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14938","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2018-7642","NamespaceName":"debian:8","Description":"The
+        swap_std_reloc_in function in aoutx.h in the Binary File Descriptor (BFD)
+        library (aka libbfd), as distributed in GNU Binutils 2.30, allows remote attackers
+        to cause a denial of service (aout_32_swap_std_reloc_out NULL pointer dereference
+        and application crash) via a crafted ELF file, as demonstrated by objcopy.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-7642","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-9746","NamespaceName":"debian:8","Description":"The
+        disassemble_bytes function in objdump.c in GNU Binutils 2.28 allows remote
+        attackers to cause a denial of service (buffer overflow and application crash)
+        or possibly have unspecified other impact via a crafted binary file, as demonstrated
+        by mishandling of rae insns printing for this file during \"objdump -D\" execution.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-9746","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-15996","NamespaceName":"debian:8","Description":"elfcomm.c
+        in readelf in GNU Binutils 2.29 allows remote attackers to cause a denial
+        of service (excessive memory allocation) or possibly have unspecified other
+        impact via a crafted ELF file that triggers a \"buffer overflow on fuzzed
+        archive header,\" related to an uninitialized variable, an improper conditional
+        jump, and the get_archive_member_name, process_archive_index_and_symbols,
+        and setup_archive functions.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-15996","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-17080","NamespaceName":"debian:8","Description":"elf.c
+        in the Binary File Descriptor (BFD) library (aka libbfd), as distributed in
+        GNU Binutils 2.29.1, does not validate sizes of core notes, which allows remote
+        attackers to cause a denial of service (bfd_getl32 heap-based buffer over-read
+        and application crash) via a crafted object file, related to elfcore_grok_netbsd_procinfo,
+        elfcore_grok_openbsd_procinfo, and elfcore_grok_nto_status.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-17080","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2018-6543","NamespaceName":"debian:8","Description":"In
+        GNU Binutils 2.30, there''s an integer overflow in the function load_specific_debug_section()
+        in objdump.c, which results in `malloc()` with 0 size. A crafted ELF file
+        allows remote attackers to cause a denial of service (application crash) or
+        possibly have unspecified other impact.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-6543","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-9750","NamespaceName":"debian:8","Description":"opcodes/rx-decode.opc
+        in GNU Binutils 2.28 lacks bounds checks for certain scale arrays, which allows
+        remote attackers to cause a denial of service (buffer overflow and application
+        crash) or possibly have unspecified other impact via a crafted binary file,
+        as demonstrated by mishandling of this file during \"objdump -D\" execution.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-9750","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-9752","NamespaceName":"debian:8","Description":"bfd/vms-alpha.c
+        in the Binary File Descriptor (BFD) library (aka libbfd), as distributed in
+        GNU Binutils 2.28, allows remote attackers to cause a denial of service (buffer
+        overflow and application crash) or possibly have unspecified other impact
+        via a crafted binary file, as demonstrated by mishandling of this file in
+        the _bfd_vms_get_value and _bfd_vms_slurp_etir functions during \"objdump
+        -D\" execution.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-9752","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-14729","NamespaceName":"debian:8","Description":"The
+        *_get_synthetic_symtab functions in the Binary File Descriptor (BFD) library
+        (aka libbfd), as distributed in GNU Binutils 2.29, do not ensure a unique
+        PLT entry for a symbol, which allows remote attackers to cause a denial of
+        service (heap-based buffer overflow and application crash) or possibly have
+        unspecified other impact via a crafted ELF file, related to elf32-i386.c and
+        elf64-x86-64.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14729","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2018-6759","NamespaceName":"debian:8","Description":"The
+        bfd_get_debug_link_info_1 function in opncls.c in the Binary File Descriptor
+        (BFD) library (aka libbfd), as distributed in GNU Binutils 2.30, has an unchecked
+        strnlen operation. Remote attackers could leverage this vulnerability to cause
+        a denial of service (segmentation fault) via a crafted ELF file.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-6759","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-7227","NamespaceName":"debian:8","Description":"GNU
+        linker (ld) in GNU Binutils 2.28 is vulnerable to a heap-based buffer overflow
+        while processing a bogus input script, leading to a program crash. This relates
+        to lack of ''\\0'' termination of a name field in ldlex.l.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-7227","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-12799","NamespaceName":"debian:8","Description":"The
+        elf_read_notesfunction in bfd/elf.c in GNU Binutils 2.29 allows remote attackers
+        to cause a denial of service (buffer overflow and application crash) or possibly
+        have unspecified other impact via a crafted binary file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12799","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2018-7208","NamespaceName":"debian:8","Description":"In
+        the coff_pointerize_aux function in coffgen.c in the Binary File Descriptor
+        (BFD) library (aka libbfd), as distributed in GNU Binutils 2.30, an index
+        is not validated, which allows remote attackers to cause a denial of service
+        (segmentation fault) or possibly have unspecified other impact via a crafted
+        file, as demonstrated by objcopy of a COFF object.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-7208","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-14974","NamespaceName":"debian:8","Description":"The
+        *_get_synthetic_symtab functions in the Binary File Descriptor (BFD) library
+        (aka libbfd), as distributed in GNU Binutils 2.29, mishandle the failure of
+        a certain canonicalization step, which allows remote attackers to cause a
+        denial of service (NULL pointer dereference and application crash) via a crafted
+        ELF file, related to elf32-i386.c and elf64-x86-64.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14974","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-6965","NamespaceName":"debian:8","Description":"readelf
+        in GNU Binutils 2.28 writes to illegal addresses while processing corrupt
+        input files containing symbol-difference relocations, leading to a heap-based
+        buffer overflow.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-6965","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-7224","NamespaceName":"debian:8","Description":"The
+        find_nearest_line function in objdump in GNU Binutils 2.28 is vulnerable to
+        an invalid write (of size 1) while disassembling a corrupt binary that contains
+        an empty function name, leading to a program crash.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-7224","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-7304","NamespaceName":"debian:8","Description":"The
+        Binary File Descriptor (BFD) library (aka libbfd), as distributed in GNU Binutils
+        2.28, is vulnerable to an invalid read (of size 8) because of missing a check
+        (in the copy_special_section_fields function) for an invalid sh_link field
+        before attempting to follow it. This vulnerability causes Binutils utilities
+        like strip to crash.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-7304","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-17124","NamespaceName":"debian:8","Description":"The
+        _bfd_coff_read_string_table function in coffgen.c in the Binary File Descriptor
+        (BFD) library (aka libbfd), as distributed in GNU Binutils 2.29.1, does not
+        properly validate the size of the external string table, which allows remote
+        attackers to cause a denial of service (excessive memory consumption, or heap-based
+        buffer overflow and application crash) or possibly have unspecified other
+        impact via a crafted COFF binary.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-17124","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-13710","NamespaceName":"debian:8","Description":"The
+        setup_group function in elf.c in the Binary File Descriptor (BFD) library
+        (aka libbfd), as distributed in GNU Binutils 2.29, allows remote attackers
+        to cause a denial of service (NULL pointer dereference and application crash)
+        via a group section that is too small.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-13710","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2016-4491","NamespaceName":"debian:8","Description":"The
+        d_print_comp function in cp-demangle.c in libiberty allows remote attackers
+        to cause a denial of service (segmentation fault and crash) via a crafted
+        binary, which triggers infinite recursion and a buffer overflow, related to
+        a node having \"itself as ancestor more than once.\"","Link":"https://security-tracker.debian.org/tracker/CVE-2016-4491","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-7223","NamespaceName":"debian:8","Description":"GNU
+        assembler in GNU Binutils 2.28 is vulnerable to a global buffer overflow (of
+        size 1) while attempting to unget an EOF character from the input stream,
+        potentially leading to a program crash.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-7223","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-15024","NamespaceName":"debian:8","Description":"find_abstract_instance_name
+        in dwarf2.c in the Binary File Descriptor (BFD) library (aka libbfd), as distributed
+        in GNU Binutils 2.29, allows remote attackers to cause a denial of service
+        (infinite recursion and application crash) via a crafted ELF file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-15024","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-9748","NamespaceName":"debian:8","Description":"The
+        ieee_object_p function in bfd/ieee.c in the Binary File Descriptor (BFD) library
+        (aka libbfd), as distributed in GNU Binutils 2.28, might allow remote attackers
+        to cause a denial of service (buffer overflow and application crash) or possibly
+        have unspecified other impact via a crafted binary file, as demonstrated by
+        mishandling of this file during \"objdump -D\" execution. NOTE: this may be
+        related to a compiler bug.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-9748","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-17126","NamespaceName":"debian:8","Description":"The
+        load_debug_section function in readelf.c in GNU Binutils 2.29.1 allows remote
+        attackers to cause a denial of service (invalid memory access and application
+        crash) or possibly have unspecified other impact via an ELF file that lacks
+        section headers.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-17126","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-9747","NamespaceName":"debian:8","Description":"The
+        ieee_archive_p function in bfd/ieee.c in the Binary File Descriptor (BFD)
+        library (aka libbfd), as distributed in GNU Binutils 2.28, might allow remote
+        attackers to cause a denial of service (buffer overflow and application crash)
+        or possibly have unspecified other impact via a crafted binary file, as demonstrated
+        by mishandling of this file during \"objdump -D\" execution. NOTE: this may
+        be related to a compiler bug.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-9747","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-16829","NamespaceName":"debian:8","Description":"The
+        _bfd_elf_parse_gnu_properties function in elf-properties.c in the Binary File
+        Descriptor (BFD) library (aka libbfd), as distributed in GNU Binutils 2.29.1,
+        does not prevent negative pointers, which allows remote attackers to cause
+        a denial of service (out-of-bounds read and application crash) or possibly
+        have unspecified other impact via a crafted ELF file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-16829","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-9041","NamespaceName":"debian:8","Description":"GNU
+        Binutils 2.28 allows remote attackers to cause a denial of service (heap-based
+        buffer over-read and application crash) via a crafted ELF file, related to
+        MIPS GOT mishandling in the process_mips_specific function in readelf.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-9041","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-12967","NamespaceName":"debian:8","Description":"The
+        getsym function in tekhex.c in the Binary File Descriptor (BFD) library (aka
+        libbfd), as distributed in GNU Binutils 2.29, allows remote attackers to cause
+        a denial of service (stack-based buffer over-read and application crash) via
+        a malformed tekhex binary.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12967","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-7300","NamespaceName":"debian:8","Description":"The
+        Binary File Descriptor (BFD) library (aka libbfd), as distributed in GNU Binutils
+        2.28, has an aout_link_add_symbols function in bfd/aoutx.h that is vulnerable
+        to a heap-based buffer over-read (off-by-one) because of an incomplete check
+        for invalid string offsets while loading symbols, leading to a GNU linker
+        (ld) program crash.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-7300","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-9744","NamespaceName":"debian:8","Description":"The
+        sh_elf_set_mach_from_flags function in bfd/elf32-sh.c in the Binary File Descriptor
+        (BFD) library (aka libbfd), as distributed in GNU Binutils 2.28, allows remote
+        attackers to cause a denial of service (buffer overflow and application crash)
+        or possibly have unspecified other impact via a crafted binary file, as demonstrated
+        by mishandling of this file during \"objdump -D\" execution.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-9744","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2016-4492","NamespaceName":"debian:8","Description":"Buffer
+        overflow in the do_type function in cplus-dem.c in libiberty allows remote
+        attackers to cause a denial of service (segmentation fault and crash) via
+        a crafted binary.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-4492","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-15025","NamespaceName":"debian:8","Description":"decode_line_info
+        in dwarf2.c in the Binary File Descriptor (BFD) library (aka libbfd), as distributed
+        in GNU Binutils 2.29, allows remote attackers to cause a denial of service
+        (divide-by-zero error and application crash) via a crafted ELF file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-15025","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-9751","NamespaceName":"debian:8","Description":"opcodes/rl78-decode.opc
+        in GNU Binutils 2.28 has an unbounded GETBYTE macro, which allows remote attackers
+        to cause a denial of service (buffer overflow and application crash) or possibly
+        have unspecified other impact via a crafted binary file, as demonstrated by
+        mishandling of this file during \"objdump -D\" execution.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-9751","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-6966","NamespaceName":"debian:8","Description":"readelf
+        in GNU Binutils 2.28 has a use-after-free (specifically read-after-free) error
+        while processing multiple, relocated sections in an MSP430 binary. This is
+        caused by mishandling of an invalid symbol index, and mishandling of state
+        across invocations.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-6966","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-14932","NamespaceName":"debian:8","Description":"decode_line_info
+        in dwarf2.c in the Binary File Descriptor (BFD) library (aka libbfd), as distributed
+        in GNU Binutils 2.29, allows remote attackers to cause a denial of service
+        (infinite loop) via a crafted ELF file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14932","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-12454","NamespaceName":"debian:8","Description":"The
+        _bfd_vms_slurp_egsd function in bfd/vms-alpha.c in the Binary File Descriptor
+        (BFD) library (aka libbfd), as distributed in GNU Binutils 2.29 and earlier,
+        allows remote attackers to cause an arbitrary memory read via a crafted vms
+        alpha file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12454","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-17123","NamespaceName":"debian:8","Description":"The
+        coff_slurp_reloc_table function in coffcode.h in the Binary File Descriptor
+        (BFD) library (aka libbfd), as distributed in GNU Binutils 2.29.1, allows
+        remote attackers to cause a denial of service (NULL pointer dereference and
+        application crash) via a crafted COFF based file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-17123","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-9044","NamespaceName":"debian:8","Description":"The
+        print_symbol_for_build_attribute function in readelf.c in GNU Binutils 2017-04-12
+        allows remote attackers to cause a denial of service (invalid read and SEGV)
+        via a crafted ELF file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-9044","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-9954","NamespaceName":"debian:8","Description":"The
+        getvalue function in tekhex.c in the Binary File Descriptor (BFD) library
+        (aka libbfd), as distributed in GNU Binutils 2.28, allows remote attackers
+        to cause a denial of service (stack-based buffer over-read and application
+        crash) via a crafted tekhex file, as demonstrated by mishandling within the
+        nm program.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-9954","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-6969","NamespaceName":"debian:8","Description":"readelf
+        in GNU Binutils 2.28 is vulnerable to a heap-based buffer over-read while
+        processing corrupt RL78 binaries. The vulnerability can trigger program crashes.
+        It may lead to an information leak as well.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-6969","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.4,"Vectors":"AV:N/AC:L/Au:N/C:P/I:N"}}}},{"Name":"CVE-2017-7302","NamespaceName":"debian:8","Description":"The
+        Binary File Descriptor (BFD) library (aka libbfd), as distributed in GNU Binutils
+        2.28, has a swap_std_reloc_out function in bfd/aoutx.h that is vulnerable
+        to an invalid read (of size 4) because of missing checks for relocs that could
+        not be recognised. This vulnerability causes Binutils utilities like strip
+        to crash.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-7302","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-12453","NamespaceName":"debian:8","Description":"The
+        _bfd_vms_slurp_eeom function in libbfd.c in the Binary File Descriptor (BFD)
+        library (aka libbfd), as distributed in GNU Binutils 2.29 and earlier, allows
+        remote attackers to cause an out of bounds heap read via a crafted vms alpha
+        file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12453","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-9756","NamespaceName":"debian:8","Description":"The
+        aarch64_ext_ldst_reglist function in opcodes/aarch64-dis.c in GNU Binutils
+        2.28 allows remote attackers to cause a denial of service (buffer overflow
+        and application crash) or possibly have unspecified other impact via a crafted
+        binary file, as demonstrated by mishandling of this file during \"objdump
+        -D\" execution.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-9756","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-7303","NamespaceName":"debian:8","Description":"The
+        Binary File Descriptor (BFD) library (aka libbfd), as distributed in GNU Binutils
+        2.28, is vulnerable to an invalid read (of size 4) because of missing a check
+        (in the find_link function) for null headers before attempting to match them.
+        This vulnerability causes Binutils utilities like strip to crash.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-7303","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-16826","NamespaceName":"debian:8","Description":"The
+        coff_slurp_line_table function in coffcode.h in the Binary File Descriptor
+        (BFD) library (aka libbfd), as distributed in GNU Binutils 2.29.1, allows
+        remote attackers to cause a denial of service (invalid memory access and application
+        crash) or possibly have unspecified other impact via a crafted PE file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-16826","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-9742","NamespaceName":"debian:8","Description":"The
+        score_opcodes function in opcodes/score7-dis.c in GNU Binutils 2.28 allows
+        remote attackers to cause a denial of service (buffer overflow and application
+        crash) or possibly have unspecified other impact via a crafted binary file,
+        as demonstrated by mishandling of this file during \"objdump -D\" execution.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-9742","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-12459","NamespaceName":"debian:8","Description":"The
+        bfd_mach_o_read_symtab_strtab function in bfd/mach-o.c in the Binary File
+        Descriptor (BFD) library (aka libbfd), as distributed in GNU Binutils 2.29
+        and earlier, allows remote attackers to cause an out of bounds heap write
+        and possibly achieve code execution via a crafted mach-o file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12459","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}}],"AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"mysql-5.5","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"5.5.58-0+deb8u1","Vulnerabilities":[{"Name":"CVE-2012-5613","NamespaceName":"debian:8","Description":"**
+        DISPUTED **  MySQL 5.5.19 and possibly other versions, and MariaDB 5.5.28a
+        and possibly other versions, when configured to assign the FILE privilege
+        to users who should not have administrative privileges, allows remote authenticated
+        users to gain privileges by leveraging the FILE privilege to create files
+        as the MySQL administrator.  NOTE: the vendor disputes this issue, stating
+        that this is only a vulnerability when the administrator does not follow recommendations
+        in the product''s installation documentation.  NOTE: it could be argued that
+        this should not be included in CVE because it is a configuration issue.","Link":"https://security-tracker.debian.org/tracker/CVE-2012-5613","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":6,"Vectors":"AV:N/AC:M/Au:S/C:P/I:P"}}}},{"Name":"CVE-2018-2562","NamespaceName":"debian:8","Description":"Vulnerability
+        in the MySQL Server component of Oracle MySQL (subcomponent: Server : Partition).
+        Supported versions that are affected are 5.5.58 and prior, 5.6.38 and prior
+        and 5.7.19 and prior. Easily exploitable vulnerability allows low privileged
+        attacker with network access via multiple protocols to compromise MySQL Server.
+        Successful attacks of this vulnerability can result in unauthorized ability
+        to cause a hang or frequently repeatable crash (complete DOS) of MySQL Server
+        as well as unauthorized update, insert or delete access to some of MySQL Server
+        accessible data. CVSS 3.0 Base Score 7.1 (Integrity and Availability impacts).
+        CVSS Vector: (CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:H).","Link":"https://security-tracker.debian.org/tracker/CVE-2018-2562","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:S/C:N/I:P"}}},"FixedBy":"5.5.59-0+deb8u1"},{"Name":"CVE-2018-2767","NamespaceName":"debian:8","Link":"https://security-tracker.debian.org/tracker/CVE-2018-2767","Severity":"Unknown"},{"Name":"CVE-2018-2665","NamespaceName":"debian:8","Description":"Vulnerability
+        in the MySQL Server component of Oracle MySQL (subcomponent: Server: Optimizer).
+        Supported versions that are affected are 5.5.58 and prior, 5.6.38 and prior
+        and 5.7.20 and prior. Easily exploitable vulnerability allows low privileged
+        attacker with network access via multiple protocols to compromise MySQL Server.
+        Successful attacks of this vulnerability can result in unauthorized ability
+        to cause a hang or frequently repeatable crash (complete DOS) of MySQL Server.
+        CVSS 3.0 Base Score 6.5 (Availability impacts). CVSS Vector: (CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H).","Link":"https://security-tracker.debian.org/tracker/CVE-2018-2665","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:L/Au:S/C:N/I:N"}}},"FixedBy":"5.5.59-0+deb8u1"},{"Name":"CVE-2018-2622","NamespaceName":"debian:8","Description":"Vulnerability
+        in the MySQL Server component of Oracle MySQL (subcomponent: Server: DDL).
+        Supported versions that are affected are 5.5.58 and prior, 5.6.38 and prior
+        and 5.7.20 and prior. Easily exploitable vulnerability allows low privileged
+        attacker with network access via multiple protocols to compromise MySQL Server.
+        Successful attacks of this vulnerability can result in unauthorized ability
+        to cause a hang or frequently repeatable crash (complete DOS) of MySQL Server.
+        CVSS 3.0 Base Score 6.5 (Availability impacts). CVSS Vector: (CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H).","Link":"https://security-tracker.debian.org/tracker/CVE-2018-2622","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:L/Au:S/C:N/I:N"}}},"FixedBy":"5.5.59-0+deb8u1"},{"Name":"CVE-2018-2640","NamespaceName":"debian:8","Description":"Vulnerability
+        in the MySQL Server component of Oracle MySQL (subcomponent: Server: Optimizer).
+        Supported versions that are affected are 5.5.58 and prior, 5.6.38 and prior
+        and 5.7.20 and prior. Easily exploitable vulnerability allows low privileged
+        attacker with network access via multiple protocols to compromise MySQL Server.
+        Successful attacks of this vulnerability can result in unauthorized ability
+        to cause a hang or frequently repeatable crash (complete DOS) of MySQL Server.
+        CVSS 3.0 Base Score 6.5 (Availability impacts). CVSS Vector: (CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H).","Link":"https://security-tracker.debian.org/tracker/CVE-2018-2640","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:L/Au:S/C:N/I:N"}}},"FixedBy":"5.5.59-0+deb8u1"},{"Name":"CVE-2018-2668","NamespaceName":"debian:8","Description":"Vulnerability
+        in the MySQL Server component of Oracle MySQL (subcomponent: Server: Optimizer).
+        Supported versions that are affected are 5.5.58 and prior, 5.6.38 and prior
+        and 5.7.20 and prior. Easily exploitable vulnerability allows low privileged
+        attacker with network access via multiple protocols to compromise MySQL Server.
+        Successful attacks of this vulnerability can result in unauthorized ability
+        to cause a hang or frequently repeatable crash (complete DOS) of MySQL Server.
+        CVSS 3.0 Base Score 6.5 (Availability impacts). CVSS Vector: (CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H).","Link":"https://security-tracker.debian.org/tracker/CVE-2018-2668","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:L/Au:S/C:N/I:N"}}},"FixedBy":"5.5.59-0+deb8u1"},{"Name":"CVE-2012-5627","NamespaceName":"debian:8","Description":"Oracle
+        MySQL and MariaDB 5.5.x before 5.5.29, 5.3.x before 5.3.12, and 5.2.x before
+        5.2.14 does not modify the salt during multiple executions of the change_user
+        command within the same connection which makes it easier for remote authenticated
+        users to conduct brute force password guessing attacks.","Link":"https://security-tracker.debian.org/tracker/CVE-2012-5627","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4,"Vectors":"AV:N/AC:L/Au:S/C:P/I:N"}}}}],"AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"libsemanage","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2.3-1","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"gnutls28","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"3.3.8-6+deb8u7","Vulnerabilities":[{"Name":"CVE-2011-3389","NamespaceName":"debian:8","Description":"The
+        SSL protocol, as used in certain configurations in Microsoft Windows and Microsoft
+        Internet Explorer, Mozilla Firefox, Google Chrome, Opera, and other products,
+        encrypts data by using CBC mode with chained initialization vectors, which
+        allows man-in-the-middle attackers to obtain plaintext HTTP headers via a
+        blockwise chosen-boundary attack (BCBA) on an HTTPS session, in conjunction
+        with JavaScript code that uses (1) the HTML5 WebSocket API, (2) the Java URLConnection
+        API, or (3) the Silverlight WebClient API, aka a \"BEAST\" attack.","Link":"https://security-tracker.debian.org/tracker/CVE-2011-3389","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:P/I:N"}}}}],"AddedBy":"sha256:7b491c575b06601bb07a2d88bfc3ace6c6005edc1b4d8da3ba6e37e04e9592d6"},{"Name":"bash","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"4.3-11+deb8u1","Vulnerabilities":[{"Name":"CVE-2016-9401","NamespaceName":"debian:8","Description":"popd
+        in bash might allow local users to bypass the restricted shell and cause a
+        use-after-free via a crafted address.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-9401","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":2.1,"Vectors":"AV:L/AC:L/Au:N/C:N/I:P"}}}}],"AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"openssh","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1:6.7p1-5+deb8u4","Vulnerabilities":[{"Name":"CVE-2016-10708","NamespaceName":"debian:8","Description":"sshd
+        in OpenSSH before 7.4 allows remote attackers to cause a denial of service
+        (NULL pointer dereference and daemon crash) via an out-of-sequence NEWKEYS
+        message, as demonstrated by Honggfuzz, related to kex.c and packet.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-10708","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2015-6563","NamespaceName":"debian:8","Description":"The
+        monitor component in sshd in OpenSSH before 7.0 on non-OpenBSD platforms accepts
+        extraneous username data in MONITOR_REQ_PAM_INIT_CTX requests, which allows
+        local users to conduct impersonation attacks by leveraging any SSH login access
+        in conjunction with control of the sshd uid to send a crafted MONITOR_REQ_PWNAM
+        request, related to monitor.c and monitor_wrap.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2015-6563","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":1.9,"Vectors":"AV:L/AC:M/Au:N/C:N/I:P"}}}},{"Name":"CVE-2016-10011","NamespaceName":"debian:8","Description":"authfile.c
+        in sshd in OpenSSH before 7.4 does not properly consider the effects of realloc
+        on buffer contents, which might allow local users to obtain sensitive private-key
+        information by leveraging access to a privilege-separated child process.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-10011","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":2.1,"Vectors":"AV:L/AC:L/Au:N/C:P/I:N"}}}},{"Name":"CVE-2016-3115","NamespaceName":"debian:8","Description":"Multiple
+        CRLF injection vulnerabilities in session.c in sshd in OpenSSH before 7.2p2
+        allow remote authenticated users to bypass intended shell-command restrictions
+        via crafted X11 forwarding data, related to the (1) do_authenticated1 and
+        (2) session_x11_req functions.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-3115","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":5.5,"Vectors":"AV:N/AC:L/Au:S/C:P/I:P"}}}},{"Name":"CVE-2008-3234","NamespaceName":"debian:8","Description":"sshd
+        in OpenSSH 4 on Debian GNU/Linux, and the 20070303 OpenSSH snapshot, allows
+        remote authenticated users to obtain access to arbitrary SELinux roles by
+        appending a :/ (colon slash) sequence, followed by the role name, to the username.","Link":"https://security-tracker.debian.org/tracker/CVE-2008-3234","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":6.5,"Vectors":"AV:N/AC:L/Au:S/C:P/I:P"}}}},{"Name":"CVE-2016-10012","NamespaceName":"debian:8","Description":"The
+        shared memory manager (associated with pre-authentication compression) in
+        sshd in OpenSSH before 7.4 does not ensure that a bounds check is enforced
+        by all compilers, which might allows local users to gain privileges by leveraging
+        access to a sandboxed privilege-separation process, related to the m_zback
+        and m_zlib data structures.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-10012","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":7.2,"Vectors":"AV:L/AC:L/Au:N/C:C/I:C"}}}},{"Name":"CVE-2015-6564","NamespaceName":"debian:8","Description":"Use-after-free
+        vulnerability in the mm_answer_pam_free_ctx function in monitor.c in sshd
+        in OpenSSH before 7.0 on non-OpenBSD platforms might allow local users to
+        gain privileges by leveraging control of the sshd uid to send an unexpectedly
+        early MONITOR_REQ_PAM_FREE_CTX request.","Link":"https://security-tracker.debian.org/tracker/CVE-2015-6564","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.9,"Vectors":"AV:L/AC:M/Au:N/C:C/I:C"}}}},{"Name":"CVE-2007-2768","NamespaceName":"debian:8","Description":"OpenSSH,
+        when using OPIE (One-Time Passwords in Everything) for PAM, allows remote
+        attackers to determine the existence of certain user accounts, which displays
+        a different response if the user account exists and is configured to use one-time
+        passwords (OTP), a similar issue to CVE-2007-2243.","Link":"https://security-tracker.debian.org/tracker/CVE-2007-2768","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:P/I:N"}}}},{"Name":"CVE-2016-8858","NamespaceName":"debian:8","Description":"**
+        DISPUTED ** The kex_input_kexinit function in kex.c in OpenSSH 6.x and 7.x
+        through 7.3 allows remote attackers to cause a denial of service (memory consumption)
+        by sending many duplicate KEXINIT requests.  NOTE: a third party reports that
+        \"OpenSSH upstream does not consider this as a security issue.\"","Link":"https://security-tracker.debian.org/tracker/CVE-2016-8858","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.8,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2016-6515","NamespaceName":"debian:8","Description":"The
+        auth_password function in auth-passwd.c in sshd in OpenSSH before 7.3 does
+        not limit password lengths for password authentication, which allows remote
+        attackers to cause a denial of service (crypt CPU consumption) via a long
+        string.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-6515","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.8,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2015-5600","NamespaceName":"debian:8","Description":"The
+        kbdint_next_device function in auth2-chall.c in sshd in OpenSSH through 6.9
+        does not properly restrict the processing of keyboard-interactive devices
+        within a single connection, which makes it easier for remote attackers to
+        conduct brute-force attacks or cause a denial of service (CPU consumption)
+        via a long and duplicative list in the ssh -oKbdInteractiveDevices option,
+        as demonstrated by a modified client that provides a different password for
+        each pam element on this list.","Link":"https://security-tracker.debian.org/tracker/CVE-2015-5600","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":8.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:N"}}}},{"Name":"CVE-2015-5352","NamespaceName":"debian:8","Description":"The
+        x11_open_helper function in channels.c in ssh in OpenSSH before 6.9, when
+        ForwardX11Trusted mode is not used, lacks a check of the refusal deadline
+        for X connections, which makes it easier for remote attackers to bypass intended
+        access restrictions via a connection outside of the permitted time window.","Link":"https://security-tracker.debian.org/tracker/CVE-2015-5352","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:P"}}}},{"Name":"CVE-2016-1908","NamespaceName":"debian:8","Description":"The
+        client in OpenSSH before 7.2 mishandles failed cookie generation for untrusted
+        X11 forwarding and relies on the local X11 server for access-control decisions,
+        which allows remote X11 clients to trigger a fallback and obtain trusted X11
+        forwarding privileges by leveraging configuration issues on this X11 server,
+        as demonstrated by lack of the SECURITY extension on this X11 server.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-1908","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}},{"Name":"CVE-2016-10010","NamespaceName":"debian:8","Description":"sshd
+        in OpenSSH before 7.4, when privilege separation is not used, creates forwarded
+        Unix-domain sockets as root, which might allow local users to gain privileges
+        via unspecified vectors, related to serverloop.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-10010","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":6.9,"Vectors":"AV:L/AC:M/Au:N/C:C/I:C"}}}},{"Name":"CVE-2016-10009","NamespaceName":"debian:8","Description":"Untrusted
+        search path vulnerability in ssh-agent.c in ssh-agent in OpenSSH before 7.4
+        allows remote attackers to execute arbitrary local PKCS#11 modules by leveraging
+        control over a forwarded agent-socket.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-10009","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-15906","NamespaceName":"debian:8","Description":"The
+        process_open function in sftp-server.c in OpenSSH before 7.6 does not properly
+        prevent write operations in readonly mode, which allows attackers to create
+        zero-length files.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-15906","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:P"}}}},{"Name":"CVE-2007-2243","NamespaceName":"debian:8","Description":"OpenSSH
+        4.6 and earlier, when ChallengeResponseAuthentication is enabled, allows remote
+        attackers to determine the existence of user accounts by attempting to authenticate
+        via S/KEY, which displays a different response if the user account exists,
+        a similar issue to CVE-2001-1483.","Link":"https://security-tracker.debian.org/tracker/CVE-2007-2243","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:N"}}}}],"AddedBy":"sha256:b313b08bab3b8bbcf0de4171a2a80a01e67fab094f272819b76a58705d21ab28"},{"Name":"fonts-dejavu","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2.34-1","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"libsigsegv","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2.10-4","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"shadow","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1:4.2-3+deb8u4","Vulnerabilities":[{"Name":"CVE-2007-5686","NamespaceName":"debian:8","Description":"initscripts
+        in rPath Linux 1 sets insecure permissions for the /var/log/btmp file, which
+        allows local users to obtain sensitive information regarding authentication
+        attempts.  NOTE: because sshd detects the insecure permissions and does not
+        log certain events, this also prevents sshd from logging failed authentication
+        attempts by remote attackers.","Link":"https://security-tracker.debian.org/tracker/CVE-2007-5686","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.9,"Vectors":"AV:L/AC:L/Au:N/C:C/I:N"}}}},{"Name":"CVE-2017-12424","NamespaceName":"debian:8","Description":"In
+        shadow before 4.5, the newusers tool could be made to manipulate internal
+        data structures in ways unintended by the authors. Malformed input may lead
+        to crashes (with a buffer overflow or other memory corruption) or other unspecified
+        behaviors. This crosses a privilege boundary in, for example, certain web-hosting
+        environments in which a Control Panel allows an unprivileged user account
+        to create subaccounts.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12424","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}},{"Name":"CVE-2018-7169","NamespaceName":"debian:8","Description":"An
+        issue was discovered in shadow 4.5. newgidmap (in shadow-utils) is setuid
+        and allows an unprivileged user to be placed in a user namespace where setgroups(2)
+        is permitted. This allows an attacker to remove themselves from a supplementary
+        group, which may allow access to certain filesystem paths if the administrator
+        has used \"group blacklisting\" (e.g., chmod g-rwx) to restrict access to
+        paths. This flaw effectively reverts a security feature in the kernel (in
+        particular, the /proc/self/setgroups knob) to prevent this sort of privilege
+        escalation.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-7169","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:N"}}}},{"Name":"CVE-2013-4235","NamespaceName":"debian:8","Link":"https://security-tracker.debian.org/tracker/CVE-2013-4235","Severity":"Negligible"}],"AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"liblocale-gettext-perl","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.05-8","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"libidn","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.29-1+deb8u2","Vulnerabilities":[{"Name":"CVE-2017-14062","NamespaceName":"debian:8","Description":"Integer
+        overflow in the decode_digit function in puny_decode.c in Libidn2 before 2.0.4
+        allows remote attackers to cause a denial of service or possibly have unspecified
+        other impact.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14062","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}}],"AddedBy":"sha256:7b491c575b06601bb07a2d88bfc3ace6c6005edc1b4d8da3ba6e37e04e9592d6"},{"Name":"ca-certificates","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"20141019+deb8u3","AddedBy":"sha256:7b491c575b06601bb07a2d88bfc3ace6c6005edc1b4d8da3ba6e37e04e9592d6"},{"Name":"keyutils","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.5.9-5","AddedBy":"sha256:7b491c575b06601bb07a2d88bfc3ace6c6005edc1b4d8da3ba6e37e04e9592d6"},{"Name":"linux","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"3.16.51-2","Vulnerabilities":[{"Name":"CVE-2018-7492","NamespaceName":"debian:8","Description":"A
+        NULL pointer dereference was found in the net/rds/rdma.c __rds_rdma_map()
+        function in the Linux kernel before 4.14.7 allowing local attackers to cause
+        a system panic and a denial-of-service, related to RDS_GET_MR and RDS_GET_MR_FOR_DEST.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-7492","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.9,"Vectors":"AV:L/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2015-4003","NamespaceName":"debian:8","Description":"The
+        oz_usb_handle_ep_data function in drivers/staging/ozwpan/ozusbsvc1.c in the
+        OZWPAN driver in the Linux kernel through 4.0.5 allows remote attackers to
+        cause a denial of service (divide-by-zero error and system crash) via a crafted
+        packet.","Link":"https://security-tracker.debian.org/tracker/CVE-2015-4003","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":7.8,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-16914","NamespaceName":"debian:8","Description":"The
+        \"stub_send_ret_submit()\" function (drivers/usb/usbip/stub_tx.c) in the Linux
+        Kernel before version 4.14.8, 4.9.71, 4.1.49, and 4.4.107 allows attackers
+        to cause a denial of service (NULL pointer dereference) via a specially crafted
+        USB over IP packet.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-16914","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.1,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2018-1092","NamespaceName":"debian:8","Description":"The
+        ext4_iget function in fs/ext4/inode.c in the Linux kernel through 4.15.15
+        mishandles the case of a root directory with a zero i_links_count, which allows
+        attackers to cause a denial of service (ext4_process_freed_data NULL pointer
+        dereference and OOPS) via a crafted ext4 image.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-1092","Severity":"Unknown"},{"Name":"CVE-2018-7757","NamespaceName":"debian:8","Description":"Memory
+        leak in the sas_smp_get_phy_events function in drivers/scsi/libsas/sas_expander.c
+        in the Linux kernel through 4.15.7 allows local users to cause a denial of
+        service (memory consumption) via many read accesses to files in the /sys/class/sas_phy
+        directory, as demonstrated by the /sys/class/sas_phy/phy-1:0:12/invalid_dword_count
+        file.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-7757","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":2.1,"Vectors":"AV:L/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2018-1000004","NamespaceName":"debian:8","Description":"In
+        the Linux kernel 4.12, 3.10, 2.6 and possibly earlier versions a race condition
+        vulnerability exists in the sound system, this can lead to a deadlock and
+        denial of service condition.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-1000004","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.1,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-13220","NamespaceName":"debian:8","Description":"An
+        elevation of privilege vulnerability in the Upstream kernel bluez. Product:
+        Android. Versions: Android kernel. Android ID: A-63527053.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-13220","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.6,"Vectors":"AV:L/AC:L/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-18017","NamespaceName":"debian:8","Description":"The
+        tcpmss_mangle_packet function in net/netfilter/xt_TCPMSS.c in the Linux kernel
+        before 4.11, and 4.9.x before 4.9.36, allows remote attackers to cause a denial
+        of service (use-after-free and memory corruption) or possibly have unspecified
+        other impact by leveraging the presence of xt_TCPMSS in an iptables action.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-18017","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":10,"Vectors":"AV:N/AC:L/Au:N/C:C/I:C"}}}},{"Name":"CVE-2017-15868","NamespaceName":"debian:8","Description":"The
+        bnep_add_connection function in net/bluetooth/bnep/core.c in the Linux kernel
+        before 3.19 does not ensure that an l2cap socket is available, which allows
+        local users to gain privileges via a crafted application.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-15868","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.2,"Vectors":"AV:L/AC:L/Au:N/C:C/I:C"}}},"FixedBy":"3.16.51-3+deb8u1"},{"Name":"CVE-2014-9900","NamespaceName":"debian:8","Description":"The
+        ethtool_get_wol function in net/core/ethtool.c in the Linux kernel through
+        4.7, as used in Android before 2016-08-05 on Nexus 5 and 7 (2013) devices,
+        does not initialize a certain data structure, which allows local users to
+        obtain sensitive information via a crafted application, aka Android internal
+        bug 28803952 and Qualcomm internal bug CR570754.","Link":"https://security-tracker.debian.org/tracker/CVE-2014-9900","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:P/I:N"}}}},{"Name":"CVE-2018-5333","NamespaceName":"debian:8","Description":"In
+        the Linux kernel through 4.14.13, the rds_cmsg_atomic function in net/rds/rdma.c
+        mishandles cases where page pinning fails or an invalid address is supplied,
+        leading to an rds_atomic_free_op NULL pointer dereference.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-5333","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.9,"Vectors":"AV:L/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-17449","NamespaceName":"debian:8","Description":"The
+        __netlink_deliver_tap_skb function in net/netlink/af_netlink.c in the Linux
+        kernel through 4.14.4, when CONFIG_NLMON is enabled, does not restrict observations
+        of Netlink messages to a single net namespace, which allows local users to
+        obtain sensitive information by leveraging the CAP_NET_ADMIN capability to
+        sniff an nlmon interface for all Netlink activity on the system.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-17449","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":1.9,"Vectors":"AV:L/AC:M/Au:N/C:P/I:N"}}},"FixedBy":"3.16.51-3+deb8u1"},{"Name":"CVE-2017-18255","NamespaceName":"debian:8","Description":"The
+        perf_cpu_time_max_percent_handler function in kernel/events/core.c in the
+        Linux kernel before 4.11 allows local users to cause a denial of service (integer
+        overflow) or possibly have unspecified other impact via a large value, as
+        demonstrated by an incorrect sample-rate calculation.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-18255","Severity":"Unknown"},{"Name":"CVE-2017-17805","NamespaceName":"debian:8","Description":"The
+        Salsa20 encryption algorithm in the Linux kernel before 4.14.8 does not correctly
+        handle zero-length inputs, allowing a local attacker able to use the AF_ALG-based
+        skcipher interface (CONFIG_CRYPTO_USER_API_SKCIPHER) to cause a denial of
+        service (uninitialized-memory free and kernel crash) or have unspecified other
+        impact by executing a crafted sequence of system calls that use the blkcipher_walk
+        API. Both the generic implementation (crypto/salsa20_generic.c) and x86 implementation
+        (arch/x86/crypto/salsa20_glue.c) of Salsa20 were vulnerable.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-17805","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.2,"Vectors":"AV:L/AC:L/Au:N/C:C/I:C"}}},"FixedBy":"3.16.51-3+deb8u1"},{"Name":"CVE-2017-1000410","NamespaceName":"debian:8","Description":"The
+        Linux kernel version 3.3-rc1 and later is affected by a vulnerability lies
+        in the processing of incoming L2CAP commands - ConfigRequest, and ConfigResponse
+        messages. This info leak is a result of uninitialized stack variables that
+        may be returned to an attacker in their uninitialized state. By manipulating
+        the code flows that precede the handling of these configuration messages,
+        an attacker can also gain some control over which data will be held in the
+        uninitialized stack variables. This can allow him to bypass KASLR, and stack
+        canaries protection - as both pointers and stack canaries may be leaked in
+        this manner. Combining this vulnerability (for example) with the previously
+        disclosed RCE vulnerability in L2CAP configuration parsing (CVE-2017-1000251)
+        may allow an attacker to exploit the RCE against kernels which were built
+        with the above mitigations. These are the specifics of this vulnerability:
+        In the function l2cap_parse_conf_rsp and in the function l2cap_parse_conf_req
+        the following variable is declared without initialization: struct l2cap_conf_efs
+        efs; In addition, when parsing input configuration parameters in both of these
+        functions, the switch case for handling EFS elements may skip the memcpy call
+        that will write to the efs variable: ... case L2CAP_CONF_EFS: if (olen ==
+        sizeof(efs)) memcpy(\u0026efs, (void *)val, olen); ... The olen in the above
+        if is attacker controlled, and regardless of that if, in both of these functions
+        the efs variable would eventually be added to the outgoing configuration request
+        that is being built: l2cap_add_conf_opt(\u0026ptr, L2CAP_CONF_EFS, sizeof(efs),
+        (unsigned long) \u0026efs); So by sending a configuration request, or response,
+        that contains an L2CAP_CONF_EFS element, but with an element length that is
+        not sizeof(efs) - the memcpy to the uninitialized efs variable can be avoided,
+        and the uninitialized variable would be returned to the attacker (16 bytes).","Link":"https://security-tracker.debian.org/tracker/CVE-2017-1000410","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:N"}}},"FixedBy":"3.16.51-3+deb8u1"},{"Name":"CVE-2017-10663","NamespaceName":"debian:8","Description":"The
+        sanity_check_ckpt function in fs/f2fs/super.c in the Linux kernel before 4.12.4
+        does not validate the blkoff and segno arrays, which allows local users to
+        gain privileges via unspecified vectors.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-10663","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.2,"Vectors":"AV:L/AC:L/Au:N/C:C/I:C"}}}},{"Name":"CVE-2014-9892","NamespaceName":"debian:8","Description":"The
+        snd_compr_tstamp function in sound/core/compress_offload.c in the Linux kernel
+        through 4.7, as used in Android before 2016-08-05 on Nexus 5 and 7 (2013)
+        devices, does not properly initialize a timestamp data structure, which allows
+        attackers to obtain sensitive information via a crafted application, aka Android
+        internal bug 28770164 and Qualcomm internal bug CR568717.","Link":"https://security-tracker.debian.org/tracker/CVE-2014-9892","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:P/I:N"}}}},{"Name":"CVE-2017-18241","NamespaceName":"debian:8","Description":"fs/f2fs/segment.c
+        in the Linux kernel before 4.13 allows local users to cause a denial of service
+        (NULL pointer dereference and panic) by using a noflush_merge option that
+        triggers a NULL value for a flush_cmd_control data structure.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-18241","Severity":"Unknown"},{"Name":"CVE-2017-18249","NamespaceName":"debian:8","Description":"The
+        add_free_nid function in fs/f2fs/node.c in the Linux kernel before 4.12 does
+        not properly track an allocated nid, which allows local users to cause a denial
+        of service (race condition) or possibly have unspecified other impact via
+        concurrent threads.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-18249","Severity":"Unknown"},{"Name":"CVE-2010-5321","NamespaceName":"debian:8","Description":"Memory
+        leak in drivers/media/video/videobuf-core.c in the videobuf subsystem in the
+        Linux kernel 2.6.x through 4.x allows local users to cause a denial of service
+        (memory consumption) by leveraging /dev/video access for a series of mmap
+        calls that require new allocations, a different vulnerability than CVE-2007-6761.  NOTE:
+        as of 2016-06-18, this affects only 11 drivers that have not been updated
+        to use videobuf2 instead of videobuf.","Link":"https://security-tracker.debian.org/tracker/CVE-2010-5321","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.9,"Vectors":"AV:L/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2018-5332","NamespaceName":"debian:8","Description":"In
+        the Linux kernel through 4.14.13, the rds_message_alloc_sgs() function does
+        not validate a value that is used during DMA page allocation, leading to a
+        heap-based out-of-bounds write (related to the rds_rdma_extra_size function
+        in net/rds/rdma.c).","Link":"https://security-tracker.debian.org/tracker/CVE-2018-5332","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.2,"Vectors":"AV:L/AC:L/Au:N/C:C/I:C"}}}},{"Name":"CVE-2017-17450","NamespaceName":"debian:8","Description":"net/netfilter/xt_osf.c
+        in the Linux kernel through 4.14.4 does not require the CAP_NET_ADMIN capability
+        for add_callback and remove_callback operations, which allows local users
+        to bypass intended access restrictions because the xt_osf_fingers data structure
+        is shared across all net namespaces.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-17450","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.6,"Vectors":"AV:L/AC:L/Au:N/C:P/I:P"}}},"FixedBy":"3.16.51-3+deb8u1"},{"Name":"CVE-2018-10021","NamespaceName":"debian:8","Link":"https://security-tracker.debian.org/tracker/CVE-2018-10021","Severity":"Unknown"},{"Name":"CVE-2017-13216","NamespaceName":"debian:8","Description":"In
+        ashmem_ioctl of ashmem.c, there is an out-of-bounds write due to insufficient
+        locking when accessing asma. This could lead to a local elevation of privilege
+        enabling code execution as a privileged process with no additional execution
+        privileges needed. User interaction is not needed for exploitation. Product:
+        Android. Versions: Android kernel. Android ID: A-66954097.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-13216","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.2,"Vectors":"AV:L/AC:L/Au:N/C:C/I:C"}}}},{"Name":"CVE-2016-2854","NamespaceName":"debian:8","Description":"The
+        aufs module for the Linux kernel 3.x and 4.x does not properly maintain POSIX
+        ACL xattr data, which allows local users to gain privileges by leveraging
+        a group-writable setgid directory.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-2854","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.6,"Vectors":"AV:L/AC:L/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-8824","NamespaceName":"debian:8","Description":"The
+        dccp_disconnect function in net/dccp/proto.c in the Linux kernel through 4.14.3
+        allows local users to gain privileges or cause a denial of service (use-after-free)
+        via an AF_UNSPEC connect system call during the DCCP_LISTEN state.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-8824","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.2,"Vectors":"AV:L/AC:L/Au:N/C:C/I:C"}}},"FixedBy":"3.16.51-3+deb8u1"},{"Name":"CVE-2017-9985","NamespaceName":"debian:8","Description":"The
+        snd_msndmidi_input_read function in sound/isa/msnd/msnd_midi.c in the Linux
+        kernel through 4.11.7 allows local users to cause a denial of service (over-boundary
+        access) or possibly have unspecified other impact by changing the value of
+        a message queue head pointer between two kernel reads of that value, aka a
+        \"double fetch\" vulnerability.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-9985","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.2,"Vectors":"AV:L/AC:L/Au:N/C:C/I:C"}}}},{"Name":"CVE-2018-5803","NamespaceName":"debian:8","Link":"https://security-tracker.debian.org/tracker/CVE-2018-5803","Severity":"Unknown"},{"Name":"CVE-2007-3719","NamespaceName":"debian:8","Description":"The
+        process scheduler in the Linux kernel 2.6.16 gives preference to \"interactive\"
+        processes that perform voluntary sleeps, which allows local users to cause
+        a denial of service (CPU consumption), as described in \"Secretly Monopolizing
+        the CPU Without Superuser Privileges.\"","Link":"https://security-tracker.debian.org/tracker/CVE-2007-3719","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":2.1,"Vectors":"AV:L/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-17807","NamespaceName":"debian:8","Description":"The
+        KEYS subsystem in the Linux kernel before 4.14.6 omitted an access-control
+        check when adding a key to the current task''s \"default request-key keyring\"
+        via the request_key() system call, allowing a local user to use a sequence
+        of crafted system calls to add keys to a keyring with only Search permission
+        (not Write permission) to that keyring, related to construct_get_dest_keyring()
+        in security/keys/request_key.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-17807","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":2.1,"Vectors":"AV:L/AC:L/Au:N/C:N/I:P"}}},"FixedBy":"3.16.51-3+deb8u1"},{"Name":"CVE-2014-9717","NamespaceName":"debian:8","Description":"fs/namespace.c
+        in the Linux kernel before 4.0.2 processes MNT_DETACH umount2 system calls
+        without verifying that the MNT_LOCKED flag is unset, which allows local users
+        to bypass intended access restrictions and navigate to filesystem locations
+        beneath a mount by calling umount2 within a user namespace.","Link":"https://security-tracker.debian.org/tracker/CVE-2014-9717","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":3.6,"Vectors":"AV:L/AC:L/Au:N/C:P/I:P"}}}},{"Name":"CVE-2010-4563","NamespaceName":"debian:8","Description":"The
+        Linux kernel, when using IPv6, allows remote attackers to determine whether
+        a host is sniffing the network by sending an ICMPv6 Echo Request to a multicast
+        address and determining whether an Echo Reply is sent, as demonstrated by
+        thcping.","Link":"https://security-tracker.debian.org/tracker/CVE-2010-4563","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:N"}}}},{"Name":"CVE-2018-7740","NamespaceName":"debian:8","Description":"The
+        resv_map_release function in mm/hugetlb.c in the Linux kernel through 4.15.7
+        allows local users to cause a denial of service (BUG) via a crafted application
+        that makes mmap system calls and has a large pgoff argument to the remap_file_pages
+        system call.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-7740","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.9,"Vectors":"AV:L/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2018-1095","NamespaceName":"debian:8","Description":"The
+        ext4_xattr_check_entries function in fs/ext4/xattr.c in the Linux kernel through
+        4.15.15 does not properly validate xattr sizes, which causes misinterpretation
+        of a size as an error code, and consequently allows attackers to cause a denial
+        of service (get_acl NULL pointer dereference and system crash) via a crafted
+        ext4 image.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-1095","Severity":"Unknown"},{"Name":"CVE-2004-0230","NamespaceName":"debian:8","Description":"TCP,
+        when using a large Window Size, makes it easier for remote attackers to guess
+        sequence numbers and cause a denial of service (connection loss) to persistent
+        TCP connections by repeatedly injecting a TCP RST packet, especially in protocols
+        that use long-lived connections, such as BGP.","Link":"https://security-tracker.debian.org/tracker/CVE-2004-0230","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2011-4915","NamespaceName":"debian:8","Link":"https://security-tracker.debian.org/tracker/CVE-2011-4915","Severity":"Negligible"},{"Name":"CVE-2017-1000407","NamespaceName":"debian:8","Description":"The
+        Linux Kernel 2.6.32 and later are affected by a denial of service, by flooding
+        the diagnostic port 0x80 an exception can be triggered leading to a kernel
+        panic.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-1000407","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.1,"Vectors":"AV:A/AC:L/Au:N/C:N/I:N"}}},"FixedBy":"3.16.51-3+deb8u1"},{"Name":"CVE-2018-6412","NamespaceName":"debian:8","Description":"In
+        the function sbusfb_ioctl_helper() in drivers/video/fbdev/sbuslib.c in the
+        Linux kernel through 4.15, an integer signedness error allows arbitrary information
+        leakage for the FBIOPUTCMAP_SPARC and FBIOGETCMAP_SPARC commands.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-6412","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:N"}}}},{"Name":"CVE-2017-9984","NamespaceName":"debian:8","Description":"The
+        snd_msnd_interrupt function in sound/isa/msnd/msnd_pinnacle.c in the Linux
+        kernel through 4.11.7 allows local users to cause a denial of service (over-boundary
+        access) or possibly have unspecified other impact by changing the value of
+        a message queue head pointer between two kernel reads of that value, aka a
+        \"double fetch\" vulnerability.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-9984","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.2,"Vectors":"AV:L/AC:L/Au:N/C:C/I:C"}}}},{"Name":"CVE-2017-13693","NamespaceName":"debian:8","Description":"The
+        acpi_ds_create_operands() function in drivers/acpi/acpica/dsutils.c in the
+        Linux kernel through 4.12.9 does not flush the operand cache and causes a
+        kernel stack dump, which allows local users to obtain sensitive information
+        from kernel memory and bypass the KASLR protection mechanism (in the kernel
+        through 4.9) via a crafted ACPI table.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-13693","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.9,"Vectors":"AV:L/AC:L/Au:N/C:C/I:N"}}}},{"Name":"CVE-2017-10662","NamespaceName":"debian:8","Description":"The
+        sanity_check_raw_super function in fs/f2fs/super.c in the Linux kernel before
+        4.11.1 does not validate the segment count, which allows local users to gain
+        privileges via unspecified vectors.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-10662","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.2,"Vectors":"AV:L/AC:L/Au:N/C:C/I:C"}}}},{"Name":"CVE-2015-9016","NamespaceName":"debian:8","Description":"In
+        blk_mq_tag_to_rq in blk-mq.c in the upstream kernel, there is a possible use
+        after free due to a race condition when a request has been previously freed
+        by blk_mq_complete_request. This could lead to local escalation of privilege.
+        Product: Android. Versions: Android kernel. Android ID: A-63083046.","Link":"https://security-tracker.debian.org/tracker/CVE-2015-9016","Severity":"Negligible"},{"Name":"CVE-2015-2877","NamespaceName":"debian:8","Description":"**
+        DISPUTED ** Kernel Samepage Merging (KSM) in the Linux kernel 2.6.32 through
+        4.x does not prevent use of a write-timing side channel, which allows guest
+        OS users to defeat the ASLR protection mechanism on other guest OS instances
+        via a Cross-VM ASL INtrospection (CAIN) attack.  NOTE: the vendor states \"Basically
+        if you care about this attack vector, disable deduplication.\" Share-until-written
+        approaches for memory conservation among mutually untrusting tenants are inherently
+        detectable for information disclosure, and can be classified as potentially
+        misunderstood behaviors rather than vulnerabilities.","Link":"https://security-tracker.debian.org/tracker/CVE-2015-2877","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":2.1,"Vectors":"AV:L/AC:L/Au:N/C:P/I:N"}}}},{"Name":"CVE-2015-8839","NamespaceName":"debian:8","Description":"Multiple
+        race conditions in the ext4 filesystem implementation in the Linux kernel
+        before 4.5 allow local users to cause a denial of service (disk corruption)
+        by writing to a page that is associated with a different user''s file after
+        unsynchronized hole punching and page-fault handling.","Link":"https://security-tracker.debian.org/tracker/CVE-2015-8839","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":1.9,"Vectors":"AV:L/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2018-5750","NamespaceName":"debian:8","Description":"The
+        acpi_smbus_hc_add function in drivers/acpi/sbshc.c in the Linux kernel through
+        4.14.15 allows local users to obtain sensitive address information by reading
+        dmesg data from an SBS HC printk call.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-5750","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":2.1,"Vectors":"AV:L/AC:L/Au:N/C:P/I:N"}}}},{"Name":"CVE-2018-7273","NamespaceName":"debian:8","Description":"In
+        the Linux kernel through 4.15.4, the floppy driver reveals the addresses of
+        kernel functions and global variables using printk calls within the function
+        show_floppy in drivers/block/floppy.c. An attacker can read this information
+        from dmesg and use the addresses to find the locations of kernel code and
+        data and bypass kernel security protections such as KASLR.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-7273","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.9,"Vectors":"AV:L/AC:L/Au:N/C:C/I:N"}}}},{"Name":"CVE-2017-17806","NamespaceName":"debian:8","Description":"The
+        HMAC implementation (crypto/hmac.c) in the Linux kernel before 4.14.8 does
+        not validate that the underlying cryptographic hash algorithm is unkeyed,
+        allowing a local attacker able to use the AF_ALG-based hash interface (CONFIG_CRYPTO_USER_API_HASH)
+        and the SHA-3 hash algorithm (CONFIG_CRYPTO_SHA3) to cause a kernel stack
+        buffer overflow by executing a crafted sequence of system calls that encounter
+        a missing SHA-3 initialization.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-17806","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.2,"Vectors":"AV:L/AC:L/Au:N/C:C/I:C"}}},"FixedBy":"3.16.51-3+deb8u1"},{"Name":"CVE-2018-8822","NamespaceName":"debian:8","Description":"Incorrect
+        buffer length handling in the ncp_read_kernel function in fs/ncpfs/ncplib_kernel.c
+        in the Linux kernel through 4.15.11, and in drivers/staging/ncpfs/ncplib_kernel.c
+        in the Linux kernel 4.16-rc through 4.16-rc6, could be exploited by malicious
+        NCPFS servers to crash the kernel or execute code.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-8822","Severity":"Unknown"},{"Name":"CVE-2016-3139","NamespaceName":"debian:8","Description":"The
+        wacom_probe function in drivers/input/tablet/wacom_sys.c in the Linux kernel
+        before 3.17 allows physically proximate attackers to cause a denial of service
+        (NULL pointer dereference and system crash) via a crafted endpoints value
+        in a USB device descriptor.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-3139","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":4.9,"Vectors":"AV:L/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2005-3660","NamespaceName":"debian:8","Description":"Linux
+        kernel 2.4 and 2.6 allows attackers to cause a denial of service (memory exhaustion
+        and panic) by creating a large number of connected file descriptors or socketpairs
+        and setting a large data transfer buffer, then preventing Linux from being
+        able to finish the transfer by causing the process to become a zombie, or
+        closing the file descriptor without closing an associated reference.","Link":"https://security-tracker.debian.org/tracker/CVE-2005-3660","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.9,"Vectors":"AV:L/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2015-8952","NamespaceName":"debian:8","Description":"The
+        mbcache feature in the ext2 and ext4 filesystem implementations in the Linux
+        kernel before 4.6 mishandles xattr block caching, which allows local users
+        to cause a denial of service (soft lockup) via filesystem operations in environments
+        that use many attributes, as demonstrated by Ceph and Samba.","Link":"https://security-tracker.debian.org/tracker/CVE-2015-8952","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":2.1,"Vectors":"AV:L/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-16645","NamespaceName":"debian:8","Description":"The
+        ims_pcu_get_cdc_union_desc function in drivers/input/misc/ims-pcu.c in the
+        Linux kernel through 4.13.11 allows local users to cause a denial of service
+        (ims_pcu_parse_cdc_data out-of-bounds read and system crash) or possibly have
+        unspecified other impact via a crafted USB device.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-16645","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.2,"Vectors":"AV:L/AC:L/Au:N/C:C/I:C"}}}},{"Name":"CVE-2015-7837","NamespaceName":"debian:8","Description":"The
+        Linux kernel, as used in Red Hat Enterprise Linux 7, kernel-rt, and Enterprise
+        MRG 2 and when booted with UEFI Secure Boot enabled, allows local users to
+        bypass intended securelevel/secureboot restrictions by leveraging improper
+        handling of secure_boot flag across kexec reboot.","Link":"https://security-tracker.debian.org/tracker/CVE-2015-7837","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":2.1,"Vectors":"AV:L/AC:L/Au:N/C:N/I:P"}}}},{"Name":"CVE-2017-18232","NamespaceName":"debian:8","Description":"The
+        Serial Attached SCSI (SAS) implementation in the Linux kernel through 4.15.9
+        mishandles a mutex within libsas, which allows local users to cause a denial
+        of service (deadlock) by triggering certain error-handling code.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-18232","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":2.1,"Vectors":"AV:L/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-5972","NamespaceName":"debian:8","Description":"The
+        TCP stack in the Linux kernel 3.x does not properly implement a SYN cookie
+        protection mechanism for the case of a fast network connection, which allows
+        remote attackers to cause a denial of service (CPU consumption) by sending
+        many TCP SYN packets, as demonstrated by an attack against the kernel-3.10.0
+        package in CentOS Linux 7. NOTE: third parties have been unable to discern
+        any relationship between the GitHub Engineering finding and the Trigemini.c
+        attack code.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-5972","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.8,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2018-7755","NamespaceName":"debian:8","Description":"An
+        issue was discovered in the fd_locked_ioctl function in drivers/block/floppy.c
+        in the Linux kernel through 4.15.7. The floppy driver will copy a kernel pointer
+        to user memory in response to the FDGETPRM ioctl. An attacker can send the
+        FDGETPRM ioctl and use the obtained kernel pointer to discover the location
+        of kernel code and data and bypass kernel security protections such as KASLR.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-7755","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:N"}}}},{"Name":"CVE-2015-4004","NamespaceName":"debian:8","Description":"The
+        OZWPAN driver in the Linux kernel through 4.0.5 relies on an untrusted length
+        field during packet parsing, which allows remote attackers to obtain sensitive
+        information from kernel memory or cause a denial of service (out-of-bounds
+        read and system crash) via a crafted packet.","Link":"https://security-tracker.debian.org/tracker/CVE-2015-4004","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":8.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:N"}}}},{"Name":"CVE-2017-0861","NamespaceName":"debian:8","Description":"Use-after-free
+        vulnerability in the snd_pcm_info function in the ALSA subsystem in the Linux
+        kernel allows attackers to gain privileges via unspecified vectors.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-0861","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.6,"Vectors":"AV:L/AC:L/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-5753","NamespaceName":"debian:8","Description":"Systems
+        with microprocessors utilizing speculative execution and branch prediction
+        may allow unauthorized disclosure of information to an attacker with local
+        user access via a side-channel analysis.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-5753","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.7,"Vectors":"AV:L/AC:M/Au:N/C:C/I:N"}}}},{"Name":"CVE-2017-18216","NamespaceName":"debian:8","Description":"In
+        fs/ocfs2/cluster/nodemanager.c in the Linux kernel before 4.15, local users
+        can cause a denial of service (NULL pointer dereference and BUG) because a
+        required mutex is not used.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-18216","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":2.1,"Vectors":"AV:L/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2015-8553","NamespaceName":"debian:8","Description":"Xen
+        allows guest OS users to obtain sensitive information from uninitialized locations
+        in host OS kernel memory by not enabling memory and I/O decoding control bits.  NOTE:
+        this vulnerability exists because of an incomplete fix for CVE-2015-0777.","Link":"https://security-tracker.debian.org/tracker/CVE-2015-8553","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":2.1,"Vectors":"AV:L/AC:L/Au:N/C:P/I:N"}}}},{"Name":"CVE-2017-18208","NamespaceName":"debian:8","Description":"The
+        madvise_willneed function in mm/madvise.c in the Linux kernel before 4.14.4
+        allows local users to cause a denial of service (infinite loop) by triggering
+        use of MADVISE_WILLNEED for a DAX mapping.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-18208","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.9,"Vectors":"AV:L/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-13694","NamespaceName":"debian:8","Description":"The
+        acpi_ps_complete_final_op() function in drivers/acpi/acpica/psobject.c in
+        the Linux kernel through 4.12.9 does not flush the node and node_ext caches
+        and causes a kernel stack dump, which allows local users to obtain sensitive
+        information from kernel memory and bypass the KASLR protection mechanism (in
+        the kernel through 4.9) via a crafted ACPI table.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-13694","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":2.1,"Vectors":"AV:L/AC:L/Au:N/C:P/I:N"}}}},{"Name":"CVE-2017-16538","NamespaceName":"debian:8","Description":"drivers/media/usb/dvb-usb-v2/lmedm04.c
+        in the Linux kernel through 4.13.11 allows local users to cause a denial of
+        service (general protection fault and system crash) or possibly have unspecified
+        other impact via a crafted USB device, related to a missing warm-start check
+        and incorrect attach timing (dm04_lme2510_frontend_attach versus dm04_lme2510_tuner).","Link":"https://security-tracker.debian.org/tracker/CVE-2017-16538","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.2,"Vectors":"AV:L/AC:L/Au:N/C:C/I:C"}}},"FixedBy":"3.16.51-3+deb8u1"},{"Name":"CVE-2015-7885","NamespaceName":"debian:8","Description":"The
+        dgnc_mgmt_ioctl function in drivers/staging/dgnc/dgnc_mgmt.c in the Linux
+        kernel through 4.3.3 does not initialize a certain structure member, which
+        allows local users to obtain sensitive information from kernel memory via
+        a crafted application.","Link":"https://security-tracker.debian.org/tracker/CVE-2015-7885","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":2.1,"Vectors":"AV:L/AC:L/Au:N/C:P/I:N"}}}},{"Name":"CVE-2015-4002","NamespaceName":"debian:8","Description":"drivers/staging/ozwpan/ozusbsvc1.c
+        in the OZWPAN driver in the Linux kernel through 4.0.5 does not ensure that
+        certain length values are sufficiently large, which allows remote attackers
+        to cause a denial of service (system crash or large loop) or possibly execute
+        arbitrary code via a crafted packet, related to the (1) oz_usb_rx and (2)
+        oz_usb_handle_ep_data functions.","Link":"https://security-tracker.debian.org/tracker/CVE-2015-4002","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":9,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}},{"Name":"CVE-2015-4001","NamespaceName":"debian:8","Description":"Integer
+        signedness error in the oz_hcd_get_desc_cnf function in drivers/staging/ozwpan/ozhcd.c
+        in the OZWPAN driver in the Linux kernel through 4.0.5 allows remote attackers
+        to cause a denial of service (system crash) or possibly execute arbitrary
+        code via a crafted packet.","Link":"https://security-tracker.debian.org/tracker/CVE-2015-4001","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":9,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}},{"Name":"CVE-2008-4609","NamespaceName":"debian:8","Description":"The
+        TCP implementation in (1) Linux, (2) platforms based on BSD Unix, (3) Microsoft
+        Windows, (4) Cisco products, and probably other operating systems allows remote
+        attackers to cause a denial of service (connection queue exhaustion) via multiple
+        vectors that manipulate information in the TCP state table, as demonstrated
+        by sockstress.","Link":"https://security-tracker.debian.org/tracker/CVE-2008-4609","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":7.1,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-17741","NamespaceName":"debian:8","Description":"The
+        KVM implementation in the Linux kernel through 4.14.7 allows attackers to
+        obtain potentially sensitive information from kernel memory, aka a write_mmio
+        stack-based out-of-bounds read, related to arch/x86/kvm/x86.c and include/trace/events/kvm.h.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-17741","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":2.1,"Vectors":"AV:L/AC:L/Au:N/C:P/I:N"}}},"FixedBy":"3.16.51-3+deb8u1"},{"Name":"CVE-2018-1091","NamespaceName":"debian:8","Description":"In
+        the flush_tmregs_to_thread function in arch/powerpc/kernel/ptrace.c in the
+        Linux kernel before 4.13.5, a guest kernel crash can be triggered from unprivileged
+        userspace during a core dump on a POWER host due to a missing processor feature
+        check and an erroneous use of transactional memory (TM) instructions in the
+        core dump path, leading to a denial of service.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-1091","Severity":"Unknown"},{"Name":"CVE-2017-16911","NamespaceName":"debian:8","Description":"The
+        vhci_hcd driver in the Linux Kernel before version 4.14.8 and 4.4.114 allows
+        allows local attackers to disclose kernel memory addresses. Successful exploitation
+        requires that a USB device is attached over IP.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-16911","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":1.9,"Vectors":"AV:L/AC:M/Au:N/C:P/I:N"}}}},{"Name":"CVE-2012-4542","NamespaceName":"debian:8","Description":"block/scsi_ioctl.c
+        in the Linux kernel through 3.8 does not properly consider the SCSI device
+        class during authorization of SCSI commands, which allows local users to bypass
+        intended access restrictions via an SG_IO ioctl call that leverages overlapping
+        opcodes.","Link":"https://security-tracker.debian.org/tracker/CVE-2012-4542","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.6,"Vectors":"AV:L/AC:L/Au:N/C:P/I:P"}}}},{"Name":"CVE-2008-2544","NamespaceName":"debian:8","Link":"https://security-tracker.debian.org/tracker/CVE-2008-2544","Severity":"Negligible"},{"Name":"CVE-2018-1000026","NamespaceName":"debian:8","Description":"Linux
+        Linux kernel version at least v4.8 onwards, probably well before contains
+        a Insufficient input validation vulnerability in bnx2x network card driver
+        that can result in DoS: Network card firmware assertion takes card off-line.
+        This attack appear to be exploitable via An attacker on a must pass a very
+        large, specially crafted packet to the bnx2x card. This can be done from an
+        untrusted guest VM..","Link":"https://security-tracker.debian.org/tracker/CVE-2018-1000026","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:L/Au:S/C:N/I:N"}}}},{"Name":"CVE-2017-16526","NamespaceName":"debian:8","Description":"drivers/uwb/uwbd.c
+        in the Linux kernel before 4.13.6 allows local users to cause a denial of
+        service (general protection fault and system crash) or possibly have unspecified
+        other impact via a crafted USB device.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-16526","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.2,"Vectors":"AV:L/AC:L/Au:N/C:C/I:C"}}}},{"Name":"CVE-2018-7995","NamespaceName":"debian:8","Description":"**
+        DISPUTED ** Race condition in the store_int_with_restart() function in arch/x86/kernel/cpu/mcheck/mce.c
+        in the Linux kernel through 4.15.7 allows local users to cause a denial of
+        service (panic) by leveraging root access to write to the check_interval file
+        in a /sys/devices/system/machinecheck/machinecheck\u003ccpu number\u003e directory.
+        NOTE: a third party has indicated that this report is not security relevant.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-7995","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.7,"Vectors":"AV:L/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-13166","NamespaceName":"debian:8","Description":"An
+        elevation of privilege vulnerability in the kernel v4l2 video driver. Product:
+        Android. Versions: Android kernel. Android ID A-34624167.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-13166","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.6,"Vectors":"AV:L/AC:L/Au:N/C:P/I:P"}}}},{"Name":"CVE-2018-1094","NamespaceName":"debian:8","Description":"The
+        ext4_fill_super function in fs/ext4/super.c in the Linux kernel through 4.15.15
+        does not always initialize the crc32c checksum driver, which allows attackers
+        to cause a denial of service (ext4_xattr_inode_hash NULL pointer dereference
+        and system crash) via a crafted ext4 image.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-1094","Severity":"Unknown"},{"Name":"CVE-2016-9120","NamespaceName":"debian:8","Description":"Race
+        condition in the ion_ioctl function in drivers/staging/android/ion/ion.c in
+        the Linux kernel before 4.6 allows local users to gain privileges or cause
+        a denial of service (use-after-free) by calling ION_IOC_FREE on two CPUs at
+        the same time.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-9120","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":9.3,"Vectors":"AV:N/AC:M/Au:N/C:C/I:C"}}}},{"Name":"CVE-2018-1066","NamespaceName":"debian:8","Description":"The
+        Linux kernel before version 4.11 is vulnerable to a NULL pointer dereference
+        in fs/cifs/cifsencrypt.c:setup_ntlmv2_rsp() that allows an attacker controlling
+        a CIFS server to kernel panic a client that has this server mounted, because
+        an empty TargetInfo field in an NTLMSSP setup negotiation response is mishandled
+        during session recovery.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-1066","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.1,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-1000379","NamespaceName":"debian:8","Description":"The
+        Linux Kernel running on AMD64 systems will sometimes map the contents of PIE
+        executable, the heap or ld.so to where the stack is mapped allowing attackers
+        to more easily manipulate the stack. Linux Kernel version 4.11.5 is affected.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-1000379","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.2,"Vectors":"AV:L/AC:L/Au:N/C:C/I:C"}}}},{"Name":"CVE-2015-8967","NamespaceName":"debian:8","Description":"arch/arm64/kernel/sys.c
+        in the Linux kernel before 4.0 allows local users to bypass the \"strict page
+        permissions\" protection mechanism and modify the system-call table, and consequently
+        gain privileges, by leveraging write access.","Link":"https://security-tracker.debian.org/tracker/CVE-2015-8967","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":9.3,"Vectors":"AV:N/AC:M/Au:N/C:C/I:C"}}}},{"Name":"CVE-2017-9986","NamespaceName":"debian:8","Description":"The
+        intr function in sound/oss/msnd_pinnacle.c in the Linux kernel through 4.11.7
+        allows local users to cause a denial of service (over-boundary access) or
+        possibly have unspecified other impact by changing the value of a message
+        queue head pointer between two kernel reads of that value, aka a \"double
+        fetch\" vulnerability.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-9986","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":7.2,"Vectors":"AV:L/AC:L/Au:N/C:C/I:C"}}}},{"Name":"CVE-2013-7445","NamespaceName":"debian:8","Description":"The
+        Direct Rendering Manager (DRM) subsystem in the Linux kernel through 4.x mishandles
+        requests for Graphics Execution Manager (GEM) objects, which allows context-dependent
+        attackers to cause a denial of service (memory consumption) via an application
+        that processes graphics data, as demonstrated by JavaScript code that creates
+        many CANVAS elements for rendering by Chrome or Firefox.","Link":"https://security-tracker.debian.org/tracker/CVE-2013-7445","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.8,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-16939","NamespaceName":"debian:8","Description":"The
+        XFRM dump policy implementation in net/xfrm/xfrm_user.c in the Linux kernel
+        before 4.13.11 allows local users to gain privileges or cause a denial of
+        service (use-after-free) via a crafted SO_RCVBUF setsockopt system call in
+        conjunction with XFRM_MSG_GETPOLICY Netlink messages.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-16939","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.2,"Vectors":"AV:L/AC:L/Au:N/C:C/I:C"}}},"FixedBy":"3.16.51-3+deb8u1"},{"Name":"CVE-2016-3857","NamespaceName":"debian:8","Description":"The
+        kernel in Android before 2016-08-05 on Nexus 7 (2013) devices allows attackers
+        to gain privileges via a crafted application, aka internal bug 28522518.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-3857","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":9.3,"Vectors":"AV:N/AC:M/Au:N/C:C/I:C"}}}},{"Name":"CVE-2018-1093","NamespaceName":"debian:8","Description":"The
+        ext4_valid_block_bitmap function in fs/ext4/balloc.c in the Linux kernel through
+        4.15.15 allows attackers to cause a denial of service (out-of-bounds read
+        and system crash) via a crafted ext4 image because balloc.c and ialloc.c do
+        not validate bitmap block numbers.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-1093","Severity":"Unknown"},{"Name":"CVE-2017-16912","NamespaceName":"debian:8","Description":"The
+        \"get_pipe()\" function (drivers/usb/usbip/stub_rx.c) in the Linux Kernel
+        before version 4.14.8, 4.9.71, and 4.4.114 allows attackers to cause a denial
+        of service (out-of-bounds read) via a specially crafted USB over IP packet.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-16912","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.1,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-11472","NamespaceName":"debian:8","Description":"The
+        acpi_ns_terminate() function in drivers/acpi/acpica/nsutils.c in the Linux
+        kernel before 4.12 does not flush the operand cache and causes a kernel stack
+        dump, which allows local users to obtain sensitive information from kernel
+        memory and bypass the KASLR protection mechanism (in the kernel through 4.9)
+        via a crafted ACPI table.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-11472","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":3.6,"Vectors":"AV:L/AC:L/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-18257","NamespaceName":"debian:8","Description":"The
+        __get_data_block function in fs/f2fs/data.c in the Linux kernel before 4.11
+        allows local users to cause a denial of service (integer overflow and loop)
+        via crafted use of the open and fallocate system calls with an FS_IOC_FIEMAP
+        ioctl.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-18257","Severity":"Unknown"},{"Name":"CVE-2017-15116","NamespaceName":"debian:8","Description":"The
+        rngapi_reset function in crypto/rng.c in the Linux kernel before 4.2 allows
+        attackers to cause a denial of service (NULL pointer dereference).","Link":"https://security-tracker.debian.org/tracker/CVE-2017-15116","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.9,"Vectors":"AV:L/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2011-4917","NamespaceName":"debian:8","Link":"https://security-tracker.debian.org/tracker/CVE-2011-4917","Severity":"Negligible"},{"Name":"CVE-2018-7566","NamespaceName":"debian:8","Description":"The
+        Linux kernel 4.15 has a Buffer Overflow via an SNDRV_SEQ_IOCTL_SET_CLIENT_POOL
+        ioctl write operation to /dev/snd/seq by a local user.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-7566","Severity":"Unknown"},{"Name":"CVE-2017-16913","NamespaceName":"debian:8","Description":"The
+        \"stub_recv_cmd_submit()\" function (drivers/usb/usbip/stub_rx.c) in the Linux
+        Kernel before version 4.14.8, 4.9.71, and 4.4.114 when handling CMD_SUBMIT
+        packets allows attackers to cause a denial of service (arbitrary memory allocation)
+        via a specially crafted USB over IP packet.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-16913","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.1,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-12762","NamespaceName":"debian:8","Description":"In
+        /drivers/isdn/i4l/isdn_net.c: A user-controlled buffer is copied into a local
+        buffer of constant size using strcpy without a length check which can cause
+        a buffer overflow. This affects the Linux kernel 4.9-stable tree, 4.12-stable
+        tree, 3.18-stable tree, and 4.4-stable tree.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12762","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":10,"Vectors":"AV:N/AC:L/Au:N/C:C/I:C"}}}},{"Name":"CVE-2017-5715","NamespaceName":"debian:8","Description":"Systems
+        with microprocessors utilizing speculative execution and indirect branch prediction
+        may allow unauthorized disclosure of information to an attacker with local
+        user access via a side-channel analysis.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-5715","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.7,"Vectors":"AV:L/AC:M/Au:N/C:C/I:N"}}}},{"Name":"CVE-2017-5754","NamespaceName":"debian:8","Description":"Systems
+        with microprocessors utilizing speculative execution and indirect branch prediction
+        may allow unauthorized disclosure of information to an attacker with local
+        user access via a side-channel analysis of the data cache.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-5754","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.7,"Vectors":"AV:L/AC:M/Au:N/C:C/I:N"}}},"FixedBy":"3.16.51-3+deb8u1"},{"Name":"CVE-2017-18203","NamespaceName":"debian:8","Description":"The
+        dm_get_from_kobject function in drivers/md/dm.c in the Linux kernel before
+        4.14.3 allow local users to cause a denial of service (BUG) by leveraging
+        a race condition with __dm_destroy during creation and removal of DM devices.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-18203","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":1.9,"Vectors":"AV:L/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-13695","NamespaceName":"debian:8","Description":"The
+        acpi_ns_evaluate() function in drivers/acpi/acpica/nseval.c in the Linux kernel
+        through 4.12.9 does not flush the operand cache and causes a kernel stack
+        dump, which allows local users to obtain sensitive information from kernel
+        memory and bypass the KASLR protection mechanism (in the kernel through 4.9)
+        via a crafted ACPI table.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-13695","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":2.1,"Vectors":"AV:L/AC:L/Au:N/C:P/I:N"}}}},{"Name":"CVE-2017-17558","NamespaceName":"debian:8","Description":"The
+        usb_destroy_configuration function in drivers/usb/core/config.c in the USB
+        core subsystem in the Linux kernel through 4.14.5 does not consider the maximum
+        number of configurations and interfaces before attempting to release resources,
+        which allows local users to cause a denial of service (out-of-bounds write
+        access) or possibly have unspecified other impact via a crafted USB device.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-17558","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.2,"Vectors":"AV:L/AC:L/Au:N/C:C/I:C"}}},"FixedBy":"3.16.51-3+deb8u1"},{"Name":"CVE-2018-1068","NamespaceName":"debian:8","Description":"A
+        flaw was found in the Linux 4.x kernel''s implementation of 32-bit syscall
+        interface for bridging. This allowed a privileged user to arbitrarily write
+        to a limited range of kernel memory.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-1068","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.2,"Vectors":"AV:L/AC:L/Au:N/C:C/I:C"}}}},{"Name":"CVE-2016-2853","NamespaceName":"debian:8","Description":"The
+        aufs module for the Linux kernel 3.x and 4.x does not properly restrict the
+        mount namespace, which allows local users to gain privileges by mounting an
+        aufs filesystem on top of a FUSE filesystem, and then executing a crafted
+        setuid program.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-2853","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.4,"Vectors":"AV:L/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2018-6927","NamespaceName":"debian:8","Description":"The
+        futex_requeue function in kernel/futex.c in the Linux kernel before 4.14.15
+        might allow attackers to cause a denial of service (integer overflow) or possibly
+        have unspecified other impact by triggering a negative wake or requeue value.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-6927","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.6,"Vectors":"AV:L/AC:L/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-17448","NamespaceName":"debian:8","Description":"net/netfilter/nfnetlink_cthelper.c
+        in the Linux kernel through 4.14.4 does not require the CAP_NET_ADMIN capability
+        for new, get, and del operations, which allows local users to bypass intended
+        access restrictions because the nfnl_cthelper_list data structure is shared
+        across all net namespaces.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-17448","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.6,"Vectors":"AV:L/AC:L/Au:N/C:P/I:P"}}},"FixedBy":"3.16.51-3+deb8u1"}],"AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"sysvinit","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2.88dsf-59","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"netbase","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"5.3","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"apr-util","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.5.4-1","Vulnerabilities":[{"Name":"CVE-2017-12618","NamespaceName":"debian:8","Description":"Apache
+        Portable Runtime Utility (APR-util) 1.6.0 and prior fail to validate the integrity
+        of SDBM database files used by apr_sdbm*() functions, resulting in a possible
+        out of bound read access. A local user with write access to the database can
+        make a program or process using these functions crash, and cause a denial
+        of service.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12618","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":1.9,"Vectors":"AV:L/AC:M/Au:N/C:N/I:N"}}}}],"AddedBy":"sha256:b313b08bab3b8bbcf0de4171a2a80a01e67fab094f272819b76a58705d21ab28"},{"Name":"libxml2","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2.9.1+dfsg1-5+deb8u5","Vulnerabilities":[{"Name":"CVE-2017-8872","NamespaceName":"debian:8","Description":"The
+        htmlParseTryOrFinish function in HTMLparser.c in libxml2 2.9.4 allows attackers
+        to cause a denial of service (buffer over-read) or information disclosure.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-8872","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.4,"Vectors":"AV:N/AC:L/Au:N/C:P/I:N"}}}},{"Name":"CVE-2017-16932","NamespaceName":"debian:8","Description":"parser.c
+        in libxml2 before 2.9.5 does not prevent infinite recursion in parameter entities.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-16932","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-18258","NamespaceName":"debian:8","Description":"The
+        xz_head function in xzlib.c in libxml2 before 2.9.6 allows remote attackers
+        to cause a denial of service (memory consumption) via a crafted LZMA file,
+        because the decoder functionality does not restrict memory usage to what is
+        required for a legitimate file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-18258","Severity":"Unknown"},{"Name":"CVE-2016-9318","NamespaceName":"debian:8","Description":"libxml2
+        2.9.4 and earlier, as used in XMLSec 1.2.23 and earlier and other products,
+        does not offer a flag directly indicating that the current document may be
+        read but other files may not be opened, which makes it easier for remote attackers
+        to conduct XML External Entity (XXE) attacks via a crafted document.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-9318","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-5130","NamespaceName":"debian:8","Description":"An
+        integer overflow in xmlmemory.c in libxml2 before 2.9.5, as used in Google
+        Chrome prior to 62.0.3202.62 and other products, allowed a remote attacker
+        to potentially exploit heap corruption via a crafted XML file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-5130","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-15412","NamespaceName":"debian:8","Link":"https://security-tracker.debian.org/tracker/CVE-2017-15412","Severity":"Unknown","FixedBy":"2.9.1+dfsg1-5+deb8u6"},{"Name":"CVE-2017-5969","NamespaceName":"debian:8","Description":"**
+        DISPUTED ** libxml2 2.9.4, when used in recover mode, allows remote attackers
+        to cause a denial of service (NULL pointer dereference) via a crafted XML
+        document.  NOTE: The maintainer states \"I would disagree of a CVE with the
+        Recover parsing option which should only be used for manual recovery at least
+        for XML parser.\"","Link":"https://security-tracker.debian.org/tracker/CVE-2017-5969","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":2.6,"Vectors":"AV:N/AC:H/Au:N/C:N/I:N"}}}},{"Name":"CVE-2016-4448","NamespaceName":"debian:8","Description":"Format
+        string vulnerability in libxml2 before 2.9.4 allows attackers to have unspecified
+        impact via format string specifiers in unknown vectors.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-4448","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":10,"Vectors":"AV:N/AC:L/Au:N/C:C/I:C"}}}}],"AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"x11proto-render","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2:0.11.1-2","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"mpclib3","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.0.2-1","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"lzo2","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2.08-1.2","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"apt","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.0.9.8.4","Vulnerabilities":[{"Name":"CVE-2011-3374","NamespaceName":"debian:8","Link":"https://security-tracker.debian.org/tracker/CVE-2011-3374","Severity":"Negligible"}],"AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"cyrus-sasl2","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2.1.26.dfsg1-13+deb8u1","AddedBy":"sha256:7b491c575b06601bb07a2d88bfc3ace6c6005edc1b4d8da3ba6e37e04e9592d6"},{"Name":"systemd","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"215-17+deb8u7","Vulnerabilities":[{"Name":"CVE-2013-4392","NamespaceName":"debian:8","Description":"systemd,
+        when updating file permissions, allows local users to change the permissions
+        and SELinux security contexts for arbitrary files via a symlink attack on
+        unspecified files.","Link":"https://security-tracker.debian.org/tracker/CVE-2013-4392","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":3.3,"Vectors":"AV:L/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-18078","NamespaceName":"debian:8","Description":"systemd-tmpfiles
+        in systemd before 237 attempts to support ownership/permission changes on
+        hardlinked files even if the fs.protected_hardlinks sysctl is turned off,
+        which allows local users to bypass intended access restrictions via vectors
+        involving a hard link to a file for which the user lacks write access, as
+        demonstrated by changing the ownership of the /etc/passwd file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-18078","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.6,"Vectors":"AV:L/AC:L/Au:N/C:P/I:P"}}}},{"Name":"CVE-2018-1049","NamespaceName":"debian:8","Description":"In
+        systemd prior to 234 a race condition exists between .mount and .automount
+        units such that automount requests from kernel may not be serviced by systemd
+        resulting in kernel holding the mountpoint and any processes that try to use
+        said mount will hang. A race condition like this may lead to denial of service,
+        until mount points are unmounted.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-1049","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2018-6954","NamespaceName":"debian:8","Description":"systemd-tmpfiles
+        in systemd through 237 mishandles symlinks present in non-terminal path components,
+        which allows local users to obtain ownership of arbitrary files via vectors
+        involving creation of a directory and a file under that directory, and later
+        replacing that directory with a symlink. This occurs even if the fs.protected_symlinks
+        sysctl is turned on.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-6954","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.2,"Vectors":"AV:L/AC:L/Au:N/C:C/I:C"}}}}],"AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"six","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.8.0-1","AddedBy":"sha256:b313b08bab3b8bbcf0de4171a2a80a01e67fab094f272819b76a58705d21ab28"},{"Name":"sqlite3","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"3.8.7.1-1+deb8u2","Vulnerabilities":[{"Name":"CVE-2017-2520","NamespaceName":"debian:8","Description":"An
+        issue was discovered in certain Apple products. iOS before 10.3.2 is affected.
+        macOS before 10.12.5 is affected. tvOS before 10.2.1 is affected. watchOS
+        before 3.2.2 is affected. The issue involves the \"SQLite\" component. It
+        allows remote attackers to execute arbitrary code or cause a denial of service
+        (buffer overflow and application crash) via a crafted SQL statement.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-2520","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-2519","NamespaceName":"debian:8","Description":"An
+        issue was discovered in certain Apple products. iOS before 10.3.2 is affected.
+        macOS before 10.12.5 is affected. tvOS before 10.2.1 is affected. watchOS
+        before 3.2.2 is affected. The issue involves the \"SQLite\" component. It
+        allows remote attackers to execute arbitrary code or cause a denial of service
+        (memory corruption and application crash) via a crafted SQL statement.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-2519","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}},{"Name":"CVE-2018-8740","NamespaceName":"debian:8","Description":"In
+        SQLite through 3.22.0, databases whose schema is corrupted using a CREATE
+        TABLE AS statement could cause a NULL pointer dereference, related to build.c
+        and prepare.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-8740","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-2518","NamespaceName":"debian:8","Description":"An
+        issue was discovered in certain Apple products. iOS before 10.3.2 is affected.
+        macOS before 10.12.5 is affected. tvOS before 10.2.1 is affected. watchOS
+        before 3.2.2 is affected. The issue involves the \"SQLite\" component. It
+        allows remote attackers to execute arbitrary code or cause a denial of service
+        (buffer overflow and application crash) via a crafted SQL statement.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-2518","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-10989","NamespaceName":"debian:8","Description":"The
+        getNodeSize function in ext/rtree/rtree.c in SQLite through 3.19.3, as used
+        in GDAL and other products, mishandles undersized RTree blobs in a crafted
+        database, leading to a heap-based buffer over-read or possibly unspecified
+        other impact.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-10989","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-13685","NamespaceName":"debian:8","Description":"The
+        dump_callback function in SQLite 3.20.0 allows remote attackers to cause a
+        denial of service (EXC_BAD_ACCESS and application crash) via a crafted file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-13685","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}}],"AddedBy":"sha256:b313b08bab3b8bbcf0de4171a2a80a01e67fab094f272819b76a58705d21ab28"},{"Name":"make-dfsg","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"4.0-8.1","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"postgresql-9.4","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"9.4.15-0+deb8u1","Vulnerabilities":[{"Name":"CVE-2018-1053","NamespaceName":"debian:8","Description":"In
+        postgresql 9.3.x before 9.3.21, 9.4.x before 9.4.16, 9.5.x before 9.5.11,
+        9.6.x before 9.6.7 and 10.x before 10.2, pg_upgrade creates file in current
+        working directory containing the output of `pg_dumpall -g` under umask which
+        was in effect when the user invoked pg_upgrade, and not under 0077 which is
+        normally used for other temporary files. This can allow an authenticated attacker
+        to read or modify the one file, which may contain encrypted or unencrypted
+        database passwords. The attack is infeasible if a directory mode blocks the
+        attacker searching the current working directory or if the prevailing umask
+        blocks the attacker opening the file.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-1053","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":3.3,"Vectors":"AV:L/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2018-1058","NamespaceName":"debian:8","Description":"A
+        flaw was found in the way Postgresql allowed a user to modify the behavior
+        of a query for other users. An attacker with a user account could use this
+        flaw to execute code with the permissions of superuser in the database. Versions
+        9.3 through 10 are affected.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-1058","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.5,"Vectors":"AV:N/AC:L/Au:S/C:P/I:P"}}}}],"AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"debianutils","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"4.4","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"libusb","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2:0.1.12-25","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"lvm2","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2.02.111-2.2+deb8u1","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"ncurses","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"5.9+20140913-1+deb8u2","Vulnerabilities":[{"Name":"CVE-2017-16879","NamespaceName":"debian:8","Description":"Stack-based
+        buffer overflow in the _nc_write_entry function in tinfo/write_entry.c in
+        ncurses 6.0 allows attackers to cause a denial of service (application crash)
+        or possibly execute arbitrary code via a crafted terminfo file, as demonstrated
+        by tic.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-16879","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}}],"AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"libtasn1-6","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"4.2-3+deb8u3","Vulnerabilities":[{"Name":"CVE-2017-10790","NamespaceName":"debian:8","Description":"The
+        _asn1_check_identifier function in GNU Libtasn1 through 4.12 causes a NULL
+        pointer dereference and crash when reading crafted input that triggers assignment
+        of a NULL value within an asn1_node structure. It may lead to a remote denial
+        of service attack.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-10790","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}}],"AddedBy":"sha256:7b491c575b06601bb07a2d88bfc3ace6c6005edc1b4d8da3ba6e37e04e9592d6"},{"Name":"liberror-perl","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"0.17-1.1","AddedBy":"sha256:b313b08bab3b8bbcf0de4171a2a80a01e67fab094f272819b76a58705d21ab28"},{"Name":"grep","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2.20-4.1","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"krb5","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.12.1+dfsg-19+deb8u4","Vulnerabilities":[{"Name":"CVE-2018-5729","NamespaceName":"debian:8","Description":"MIT
+        krb5 1.6 or later allows an authenticated kadmin with permission to add principals
+        to an LDAP Kerberos database to cause a denial of service (NULL pointer dereference)
+        or bypass a DN container check by supplying tagged data that is internal to
+        the database module.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-5729","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.5,"Vectors":"AV:N/AC:L/Au:S/C:P/I:P"}}}},{"Name":"CVE-2018-5730","NamespaceName":"debian:8","Description":"MIT
+        krb5 1.6 or later allows an authenticated kadmin with permission to add principals
+        to an LDAP Kerberos database to circumvent a DN containership check by supplying
+        both a \"linkdn\" and \"containerdn\" database argument, or by supplying a
+        DN string which is a left extension of a container DN string but is not hierarchically
+        within the container DN.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-5730","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":5.5,"Vectors":"AV:N/AC:L/Au:S/C:P/I:P"}}}},{"Name":"CVE-2017-15088","NamespaceName":"debian:8","Description":"plugins/preauth/pkinit/pkinit_crypto_openssl.c
+        in MIT Kerberos 5 (aka krb5) through 1.15.2 mishandles Distinguished Name
+        (DN) fields, which allows remote attackers to execute arbitrary code or cause
+        a denial of service (buffer overflow and application crash) in situations
+        involving untrusted X.509 data, related to the get_matching_data and X509_NAME_oneline_ex
+        functions. NOTE: this has security relevance only in use cases outside of
+        the MIT Kerberos distribution, e.g., the use of get_matching_data in KDC certauth
+        plugin code that is specific to Red Hat.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-15088","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}},{"Name":"CVE-2018-5710","NamespaceName":"debian:8","Description":"An
+        issue was discovered in MIT Kerberos 5 (aka krb5) through 1.16. The pre-defined
+        function \"strlen\" is getting a \"NULL\" string as a parameter value in plugins/kdb/ldap/libkdb_ldap/ldap_principal2.c
+        in the Key Distribution Center (KDC), which allows remote authenticated users
+        to cause a denial of service (NULL pointer dereference) via a modified kadmin
+        client.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-5710","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4,"Vectors":"AV:N/AC:L/Au:S/C:N/I:N"}}}},{"Name":"CVE-2018-5709","NamespaceName":"debian:8","Description":"An
+        issue was discovered in MIT Kerberos 5 (aka krb5) through 1.16. There is a
+        variable \"dbentry-\u003en_key_data\" in kadmin/dbutil/dump.c that can store
+        16-bit data but unknowingly the developer has assigned a \"u4\" variable to
+        it, which is for 32-bit data. An attacker can use this vulnerability to affect
+        other artifacts of the database as we know that a Kerberos database dump file
+        contains trusted data.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-5709","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:P"}}}},{"Name":"CVE-2004-0971","NamespaceName":"debian:8","Description":"The
+        krb5-send-pr script in the kerberos5 (krb5) package in Trustix Secure Linux
+        1.5 through 2.1, and possibly other operating systems, allows local users
+        to overwrite files via a symlink attack on temporary files.","Link":"https://security-tracker.debian.org/tracker/CVE-2004-0971","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":2.1,"Vectors":"AV:L/AC:L/Au:N/C:N/I:P"}}}},{"Name":"CVE-2017-11462","NamespaceName":"debian:8","Description":"Double
+        free vulnerability in MIT Kerberos 5 (aka krb5) allows attackers to have unspecified
+        impact via vectors involving automatic deletion of security contexts on error.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-11462","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}}],"AddedBy":"sha256:7b491c575b06601bb07a2d88bfc3ace6c6005edc1b4d8da3ba6e37e04e9592d6"},{"Name":"libbsd","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"0.7.0-2","Vulnerabilities":[{"Name":"CVE-2016-2090","NamespaceName":"debian:8","Description":"Off-by-one
+        vulnerability in the fgetwln function in libbsd before 0.8.2 allows attackers
+        to have unspecified impact via unknown vectors, which trigger a heap-based
+        buffer overflow.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-2090","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}}],"AddedBy":"sha256:b313b08bab3b8bbcf0de4171a2a80a01e67fab094f272819b76a58705d21ab28"},{"Name":"librsvg","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2.40.5-1+deb8u2","Vulnerabilities":[{"Name":"CVE-2016-6163","NamespaceName":"debian:8","Description":"The
+        rsvg_pattern_fix_fallback function in rsvg-paint_server.c in librsvg2 2.40.2
+        allows remote attackers to cause a denial of service (out-of-bounds read)
+        via a crafted svg file.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-6163","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}}],"AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"libcroco","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"0.6.8-3","Vulnerabilities":[{"Name":"CVE-2017-7960","NamespaceName":"debian:8","Description":"The
+        cr_input_new_from_uri function in cr-input.c in libcroco 0.6.11 and 0.6.12
+        allows remote attackers to cause a denial of service (heap-based buffer over-read)
+        via a crafted CSS file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-7960","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-8871","NamespaceName":"debian:8","Description":"The
+        cr_parser_parse_selector_core function in cr-parser.c in libcroco 0.6.12 allows
+        remote attackers to cause a denial of service (infinite loop and CPU consumption)
+        via a crafted CSS file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-8871","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":7.1,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-8834","NamespaceName":"debian:8","Description":"The
+        cr_tknzr_parse_comment function in cr-tknzr.c in libcroco 0.6.12 allows remote
+        attackers to cause a denial of service (memory allocation error) via a crafted
+        CSS file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-8834","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-7961","NamespaceName":"debian:8","Description":"**
+        DISPUTED ** The cr_tknzr_parse_rgb function in cr-tknzr.c in libcroco 0.6.11
+        and 0.6.12 has an \"outside the range of representable values of type long\"
+        undefined behavior issue, which might allow remote attackers to cause a denial
+        of service (application crash) or possibly have unspecified other impact via
+        a crafted CSS file. NOTE: third-party analysis reports \"This is not a security
+        issue in my view. The conversion surely is truncating the double into a long
+        value, but there is no impact as the value is one of the RGB components.\"","Link":"https://security-tracker.debian.org/tracker/CVE-2017-7961","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}}],"AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"pkg-config","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"0.28-1","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"perl","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"5.20.2-3+deb8u9","Vulnerabilities":[{"Name":"CVE-2011-4116","NamespaceName":"debian:8","Link":"https://security-tracker.debian.org/tracker/CVE-2011-4116","Severity":"Negligible"}],"AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"hostname","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"3.15","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"shared-mime-info","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.3-1","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"gdbm","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.8.3-13.1","AddedBy":"sha256:b313b08bab3b8bbcf0de4171a2a80a01e67fab094f272819b76a58705d21ab28"},{"Name":"openssl","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.0.1t-1+deb8u7","Vulnerabilities":[{"Name":"CVE-2010-0928","NamespaceName":"debian:8","Description":"OpenSSL
+        0.9.8i on the Gaisler Research LEON3 SoC on the Xilinx Virtex-II Pro FPGA
+        uses a Fixed Width Exponentiation (FWE) algorithm for certain signature calculations,
+        and does not verify the signature before providing it to a caller, which makes
+        it easier for physically proximate attackers to determine the private key
+        via a modified supply voltage for the microprocessor, related to a \"fault-based
+        attack.\"","Link":"https://security-tracker.debian.org/tracker/CVE-2010-0928","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4,"Vectors":"AV:L/AC:H/Au:N/C:C/I:N"}}}},{"Name":"CVE-2018-0739","NamespaceName":"debian:8","Description":"Constructed
+        ASN.1 types with a recursive definition (such as can be found in PKCS7) could
+        eventually exceed the stack given malicious input with excessive recursion.
+        This could result in a Denial Of Service attack. There are no such structures
+        used within SSL/TLS that come from untrusted sources so this is considered
+        safe. Fixed in OpenSSL 1.1.0h (Affected 1.1.0-1.1.0g). Fixed in OpenSSL 1.0.2o
+        (Affected 1.0.2b-1.0.2n).","Link":"https://security-tracker.debian.org/tracker/CVE-2018-0739","Severity":"Unknown","FixedBy":"1.0.1t-1+deb8u8"},{"Name":"CVE-2007-6755","NamespaceName":"debian:8","Description":"The
+        NIST SP 800-90A default statement of the Dual Elliptic Curve Deterministic
+        Random Bit Generation (Dual_EC_DRBG) algorithm contains point Q constants
+        with a possible relationship to certain \"skeleton key\" values, which might
+        allow context-dependent attackers to defeat cryptographic protection mechanisms
+        by leveraging knowledge of those values.  NOTE: this is a preliminary CVE
+        for Dual_EC_DRBG; future research may provide additional details about point
+        Q and associated attacks, and could potentially lead to a RECAST or REJECT
+        of this CVE.","Link":"https://security-tracker.debian.org/tracker/CVE-2007-6755","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":5.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}}],"AddedBy":"sha256:7b491c575b06601bb07a2d88bfc3ace6c6005edc1b4d8da3ba6e37e04e9592d6"},{"Name":"libffi","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"3.1-2+deb8u1","AddedBy":"sha256:7b491c575b06601bb07a2d88bfc3ace6c6005edc1b4d8da3ba6e37e04e9592d6"},{"Name":"util-linux","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2.25.2-6","Vulnerabilities":[{"Name":"CVE-2015-5224","NamespaceName":"debian:8","Description":"The
+        mkostemp function in login-utils in util-linux when used incorrectly allows
+        remote attackers to cause file name collision and possibly other attacks.","Link":"https://security-tracker.debian.org/tracker/CVE-2015-5224","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-2616","NamespaceName":"debian:8","Link":"https://security-tracker.debian.org/tracker/CVE-2017-2616","Severity":"Negligible"},{"Name":"CVE-2016-2779","NamespaceName":"debian:8","Description":"runuser
+        in util-linux allows local users to escape to the parent session via a crafted
+        TIOCSTI ioctl call, which pushes characters to the terminal''s input buffer.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-2779","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.2,"Vectors":"AV:L/AC:L/Au:N/C:C/I:C"}}}},{"Name":"CVE-2016-5011","NamespaceName":"debian:8","Description":"The
+        parse_dos_extended function in partitions/dos.c in the libblkid library in
+        util-linux allows physically proximate attackers to cause a denial of service
+        (memory consumption) via a crafted MSDOS partition table with an extended
+        partition boot record at zero offset.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-5011","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.7,"Vectors":"AV:L/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2015-5218","NamespaceName":"debian:8","Description":"Buffer
+        overflow in text-utils/colcrt.c in colcrt in util-linux before 2.27 allows
+        local users to cause a denial of service (crash) via a crafted file, related
+        to the page global variable.","Link":"https://security-tracker.debian.org/tracker/CVE-2015-5218","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":2.1,"Vectors":"AV:L/AC:L/Au:N/C:N/I:N"}}}}],"AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"ustr","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.0.4-3","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"mime-support","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"3.58","AddedBy":"sha256:b313b08bab3b8bbcf0de4171a2a80a01e67fab094f272819b76a58705d21ab28"},{"Name":"x11proto-kb","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.0.6-2","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"pixman","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"0.32.6-3","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"libexif","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"0.6.21-2","Vulnerabilities":[{"Name":"CVE-2017-7544","NamespaceName":"debian:8","Description":"libexif
+        through 0.6.21 is vulnerable to out-of-bounds heap read vulnerability in exif_data_save_data_entry
+        function in libexif/exif-data.c caused by improper length computation of the
+        allocated data of an ExifMnote entry which can cause denial-of-service or
+        possibly information disclosure.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-7544","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.4,"Vectors":"AV:N/AC:L/Au:N/C:P/I:N"}}}},{"Name":"CVE-2016-6328","NamespaceName":"debian:8","Link":"https://security-tracker.debian.org/tracker/CVE-2016-6328","Severity":"Unknown"}],"AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"procps","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2:3.3.9-9","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"init-system-helpers","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.22","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"fontconfig","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2.11.0-6.3+deb8u1","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"sensible-utils","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"0.0.9","Vulnerabilities":[{"Name":"CVE-2017-17512","NamespaceName":"debian:8","Description":"sensible-browser
+        in sensible-utils before 0.0.11 does not validate strings before launching
+        the program specified by the BROWSER environment variable, which allows remote
+        attackers to conduct argument-injection attacks via a crafted URL, as demonstrated
+        by a --proxy-pac-file argument.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-17512","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}},"FixedBy":"0.0.9+deb8u1"}],"AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"libssh2","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.4.3-4.1+deb8u1","AddedBy":"sha256:7b491c575b06601bb07a2d88bfc3ace6c6005edc1b4d8da3ba6e37e04e9592d6"},{"Name":"libevent","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2.0.21-stable-2+deb8u1","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"libselinux","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2.3-2","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"zlib","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1:1.2.8.dfsg-2","Vulnerabilities":[{"Name":"CVE-2016-9840","NamespaceName":"debian:8","Description":"inftrees.c
+        in zlib 1.2.8 might allow context-dependent attackers to have unspecified
+        impact by leveraging improper pointer arithmetic.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-9840","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2016-9842","NamespaceName":"debian:8","Description":"The
+        inflateMark function in inflate.c in zlib 1.2.8 might allow context-dependent
+        attackers to have unspecified impact via vectors involving left shifts of
+        negative integers.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-9842","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2016-9843","NamespaceName":"debian:8","Description":"The
+        crc32_big function in crc32.c in zlib 1.2.8 might allow context-dependent
+        attackers to have unspecified impact via vectors involving big-endian CRC
+        calculation.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-9843","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}},{"Name":"CVE-2016-9841","NamespaceName":"debian:8","Description":"inffast.c
+        in zlib 1.2.8 might allow context-dependent attackers to have unspecified
+        impact by leveraging improper pointer arithmetic.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-9841","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}}],"AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"findutils","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"4.4.2-9","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"rtmpdump","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2.4+20150115.gita107cef-1+deb8u1","AddedBy":"sha256:7b491c575b06601bb07a2d88bfc3ace6c6005edc1b4d8da3ba6e37e04e9592d6"},{"Name":"liblqr","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"0.4.2-2","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"libxdmcp","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1:1.1.1-1","Vulnerabilities":[{"Name":"CVE-2017-2625","NamespaceName":"debian:8","Link":"https://security-tracker.debian.org/tracker/CVE-2017-2625","Severity":"Unknown"}],"AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"libyaml","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"0.1.6-3","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"e2fsprogs","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.42.12-2","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"base-passwd","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"3.5.37","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"pam","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.1.8-3.1+deb8u2","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"libpsl","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"0.5.1-1","AddedBy":"sha256:7b491c575b06601bb07a2d88bfc3ace6c6005edc1b4d8da3ba6e37e04e9592d6"},{"Name":"expat","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2.1.0-6+deb8u4","Vulnerabilities":[{"Name":"CVE-2013-0340","NamespaceName":"debian:8","Description":"expat
+        2.1.0 and earlier does not properly handle entities expansion unless an application
+        developer uses the XML_SetEntityDeclHandler function, which allows remote
+        attackers to cause a denial of service (resource consumption), send HTTP requests
+        to intranet servers, or read arbitrary files via a crafted XML document, aka
+        an XML External Entity (XXE) issue.  NOTE: it could be argued that because
+        expat already provides the ability to disable external entity expansion, the
+        responsibility for resolving this issue lies with application developers;
+        according to this argument, this entry should be REJECTed, and each affected
+        application would need its own CVE.","Link":"https://security-tracker.debian.org/tracker/CVE-2013-0340","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}}],"AddedBy":"sha256:b313b08bab3b8bbcf0de4171a2a80a01e67fab094f272819b76a58705d21ab28"},{"Name":"libsm","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2:1.2.2-1","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"isl","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"0.12.2-2","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"pcre3","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2:8.35-3.3+deb8u4","Vulnerabilities":[{"Name":"CVE-2017-7245","NamespaceName":"debian:8","Description":"Stack-based
+        buffer overflow in the pcre32_copy_substring function in pcre_get.c in libpcre1
+        in PCRE 8.40 allows remote attackers to cause a denial of service (WRITE of
+        size 4) or possibly have unspecified other impact via a crafted file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-7245","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-7186","NamespaceName":"debian:8","Description":"libpcre1
+        in PCRE 8.40 and libpcre2 in PCRE2 10.23 allow remote attackers to cause a
+        denial of service (segmentation violation for read access, and application
+        crash) by triggering an invalid Unicode property lookup.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-7186","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2015-3217","NamespaceName":"debian:8","Description":"PCRE
+        7.8 and 8.32 through 8.37, and PCRE2 10.10 mishandle group empty matches,
+        which might allow remote attackers to cause a denial of service (stack-based
+        buffer overflow) via a crafted regular expression, as demonstrated by /^(?:(?(1)\\\\.|([^\\\\\\\\W_])?)+)+$/.","Link":"https://security-tracker.debian.org/tracker/CVE-2015-3217","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-11164","NamespaceName":"debian:8","Description":"In
+        PCRE 8.41, the OP_KETRMAX feature in the match function in pcre_exec.c allows
+        stack exhaustion (uncontrolled recursion) when processing a crafted regular
+        expression.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-11164","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":7.8,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-7246","NamespaceName":"debian:8","Description":"Stack-based
+        buffer overflow in the pcre32_copy_substring function in pcre_get.c in libpcre1
+        in PCRE 8.40 allows remote attackers to cause a denial of service (WRITE of
+        size 268) or possibly have unspecified other impact via a crafted file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-7246","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-16231","NamespaceName":"debian:8","Link":"https://security-tracker.debian.org/tracker/CVE-2017-16231","Severity":"Negligible"},{"Name":"CVE-2017-7244","NamespaceName":"debian:8","Description":"The
+        _pcre32_xclass function in pcre_xclass.c in libpcre1 in PCRE 8.40 allows remote
+        attackers to cause a denial of service (invalid memory read) via a crafted
+        file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-7244","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}}],"AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"mawk","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.3.3-17","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"insserv","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.14.0-5","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"kmod","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"18-3","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"libwmf","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"0.2.8.4-10.3+deb8u2","Vulnerabilities":[{"Name":"CVE-2007-3476","NamespaceName":"debian:8","Description":"Array
+        index error in gd_gif_in.c in the GD Graphics Library (libgd) before 2.0.35
+        allows user-assisted remote attackers to cause a denial of service (crash
+        and heap corruption) via large color index values in crafted image data, which
+        results in a segmentation fault.","Link":"https://security-tracker.debian.org/tracker/CVE-2007-3476","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2007-3996","NamespaceName":"debian:8","Description":"Multiple
+        integer overflows in libgd in PHP before 5.2.4 allow remote attackers to cause
+        a denial of service (application crash) and possibly execute arbitrary code
+        via a large (1) srcW or (2) srcH value to the (a) gdImageCopyResized function,
+        or a large (3) sy (height) or (4) sx (width) value to the (b) gdImageCreate
+        or the (c) gdImageCreateTrueColor function.","Link":"https://security-tracker.debian.org/tracker/CVE-2007-3996","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2007-3477","NamespaceName":"debian:8","Description":"The
+        (a) imagearc and (b) imagefilledarc functions in GD Graphics Library (libgd)
+        before 2.0.35 allow attackers to cause a denial of service (CPU consumption)
+        via a large (1) start or (2) end angle degree value.","Link":"https://security-tracker.debian.org/tracker/CVE-2007-3477","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2009-3546","NamespaceName":"debian:8","Description":"The
+        _gdGetColors function in gd_gd.c in PHP 5.2.11 and 5.3.x before 5.3.1, and
+        the GD Graphics Library 2.x, does not properly verify a certain colorsTotal
+        structure member, which might allow remote attackers to conduct buffer overflow
+        or buffer over-read attacks via a crafted GD file, a different vulnerability
+        than CVE-2009-3293. NOTE: some of these details are obtained from third party
+        information.","Link":"https://security-tracker.debian.org/tracker/CVE-2009-3546","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":9.3,"Vectors":"AV:N/AC:M/Au:N/C:C/I:C"}}}}],"AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"libdatrie","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"0.2.8-1","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"audit","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1:2.4-1","Vulnerabilities":[{"Name":"CVE-2015-5186","NamespaceName":"debian:8","Description":"Audit
+        before 2.4.4 in Linux does not sanitize escape characters in filenames.","Link":"https://security-tracker.debian.org/tracker/CVE-2015-5186","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:P"}}}}],"AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"cdebconf","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"0.192","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"cairo","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.14.0-2.1+deb8u2","Vulnerabilities":[{"Name":"CVE-2017-7475","NamespaceName":"debian:8","Description":"Cairo
+        version 1.15.4 is vulnerable to a NULL pointer dereference related to the
+        FT_Load_Glyph and FT_Render_Glyph resulting in an application crash.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-7475","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-9814","NamespaceName":"debian:8","Description":"cairo-truetype-subset.c
+        in cairo 1.15.6 and earlier allows remote attackers to cause a denial of service
+        (out-of-bounds read) because of mishandling of an unexpected malloc(0) call.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-9814","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}}],"AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"debconf","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.5.56+deb8u1","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"nettle","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2.7.1-5+deb8u2","AddedBy":"sha256:7b491c575b06601bb07a2d88bfc3ace6c6005edc1b4d8da3ba6e37e04e9592d6"},{"Name":"libpthread-stubs","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"0.3-4","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"libxrender","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1:0.9.8-1","Vulnerabilities":[{"Name":"CVE-2016-7949","NamespaceName":"debian:8","Description":"Multiple
+        buffer overflows in the (1) XvQueryAdaptors and (2) XvQueryEncodings functions
+        in X.org libXrender before 0.9.10 allow remote X servers to trigger out-of-bounds
+        write operations via vectors involving length fields.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-7949","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}},{"Name":"CVE-2016-7950","NamespaceName":"debian:8","Description":"The
+        XRenderQueryFilters function in X.org libXrender before 0.9.10 allows remote
+        X servers to trigger out-of-bounds write operations via vectors involving
+        filter name lengths.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-7950","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}}],"AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"xorg","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1:7.7+7","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"cloog","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"0.18.2-1","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"x11proto-core","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"7.0.26-1","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"gnupg","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.4.18-7+deb8u4","Vulnerabilities":[{"Name":"CVE-2018-6829","NamespaceName":"debian:8","Description":"cipher/elgamal.c
+        in Libgcrypt through 1.8.2, when used to encrypt messages directly, improperly
+        encodes plaintexts, which allows attackers to obtain sensitive information
+        by reading ciphertext data (i.e., it does not have semantic security in face
+        of a ciphertext-only attack). The Decisional Diffie-Hellman (DDH) assumption
+        does not hold for Libgcrypt''s ElGamal implementation.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-6829","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:N"}}}}],"AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"ucf","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"3.0030","AddedBy":"sha256:b313b08bab3b8bbcf0de4171a2a80a01e67fab094f272819b76a58705d21ab28"},{"Name":"explorercanvas","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"0.r3-3","AddedBy":"sha256:b313b08bab3b8bbcf0de4171a2a80a01e67fab094f272819b76a58705d21ab28"},{"Name":"libxslt","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.1.28-2+deb8u3","Vulnerabilities":[{"Name":"CVE-2015-9019","NamespaceName":"debian:8","Description":"In
+        libxslt 1.1.29 and earlier, the EXSLT math.random function was not initialized
+        with a random seed during startup, which could cause usage of this function
+        to produce predictable outputs.","Link":"https://security-tracker.debian.org/tracker/CVE-2015-9019","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:N"}}}}],"AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"libwebp","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"0.4.1-1.2","Vulnerabilities":[{"Name":"CVE-2016-9085","NamespaceName":"debian:8","Description":"Multiple
+        integer overflows in libwebp allows attackers to have unspecified impact via
+        unknown vectors.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-9085","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}}],"AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"ilmbase","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.0.1-6.1","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"gdk-pixbuf","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2.31.1-2+deb8u6","Vulnerabilities":[{"Name":"CVE-2017-6312","NamespaceName":"debian:8","Description":"Integer
+        overflow in io-ico.c in gdk-pixbuf allows context-dependent attackers to cause
+        a denial of service (segmentation fault and application crash) via a crafted
+        image entry offset in an ICO file, which triggers an out-of-bounds read, related
+        to compiler optimizations.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-6312","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-1000422","NamespaceName":"debian:8","Description":"Gnome
+        gdk-pixbuf 2.36.8 and older is vulnerable to several integer overflow in the
+        gif_get_lzw function resulting in memory corruption and potential code execution","Link":"https://security-tracker.debian.org/tracker/CVE-2017-1000422","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}},"FixedBy":"2.31.1-2+deb8u7"},{"Name":"CVE-2017-2870","NamespaceName":"debian:8","Description":"An
+        exploitable integer overflow vulnerability exists in the tiff_image_parse
+        functionality of Gdk-Pixbuf 2.36.6 when compiled with Clang. A specially crafted
+        tiff file can cause a heap-overflow resulting in remote code execution. An
+        attacker can send a file or a URL to trigger this vulnerability.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-2870","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2016-6352","NamespaceName":"debian:8","Description":"The
+        OneLine32 function in io-ico.c in gdk-pixbuf before 2.35.3 allows remote attackers
+        to cause a denial of service (out-of-bounds write and crash) via crafted dimensions
+        in an ICO file.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-6352","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-6314","NamespaceName":"debian:8","Description":"The
+        make_available_at_least function in io-tiff.c in gdk-pixbuf allows context-dependent
+        attackers to cause a denial of service (infinite loop) via a large TIFF file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-6314","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-6313","NamespaceName":"debian:8","Description":"Integer
+        underflow in the load_resources function in io-icns.c in gdk-pixbuf allows
+        context-dependent attackers to cause a denial of service (out-of-bounds read
+        and program crash) via a crafted image entry size in an ICO file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-6313","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}}],"AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"curl","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"7.38.0-4+deb8u8","Vulnerabilities":[{"Name":"CVE-2018-1000122","NamespaceName":"debian:8","Description":"A
+        buffer over-read exists in curl 7.20.0 to and including curl 7.58.0 in the
+        RTSP+RTP handling code that allows an attacker to cause a denial of service
+        or information leakage","Link":"https://security-tracker.debian.org/tracker/CVE-2018-1000122","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.4,"Vectors":"AV:N/AC:L/Au:N/C:P/I:N"}}},"FixedBy":"7.38.0-4+deb8u10"},{"Name":"CVE-2016-9586","NamespaceName":"debian:8","Link":"https://security-tracker.debian.org/tracker/CVE-2016-9586","Severity":"Unknown"},{"Name":"CVE-2016-7141","NamespaceName":"debian:8","Description":"curl
+        and libcurl before 7.50.2, when built with NSS and the libnsspem.so library
+        is available at runtime, allow remote attackers to hijack the authentication
+        of a TLS connection by leveraging reuse of a previously loaded client certificate
+        from file for a connection for which no certificate has been set, a different
+        vulnerability than CVE-2016-5420.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-7141","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:P"}}}},{"Name":"CVE-2018-1000007","NamespaceName":"debian:8","Description":"libcurl
+        7.1 through 7.57.0 might accidentally leak authentication data to third parties.
+        When asked to send custom headers in its HTTP requests, libcurl will send
+        that set of headers first to the host in the initial URL but also, if asked
+        to follow redirects and a 30X HTTP response code is returned, to the host
+        mentioned in URL in the `Location:` response header value. Sending the same
+        set of headers to subsequest hosts is in particular a problem for applications
+        that pass on custom `Authorization:` headers, as this header often contains
+        privacy sensitive information or data that could allow others to impersonate
+        the libcurl-using client''s request.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-1000007","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:N"}}},"FixedBy":"7.38.0-4+deb8u9"},{"Name":"CVE-2018-1000120","NamespaceName":"debian:8","Description":"A
+        buffer overflow exists in curl 7.12.3 to and including curl 7.58.0 in the
+        FTP URL handling that allows an attacker to cause a denial of service or worse.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-1000120","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}},"FixedBy":"7.38.0-4+deb8u10"},{"Name":"CVE-2018-1000121","NamespaceName":"debian:8","Description":"A
+        NULL pointer dereference exists in curl 7.21.0 to and including curl 7.58.0
+        in the LDAP code that allows an attacker to cause a denial of service","Link":"https://security-tracker.debian.org/tracker/CVE-2018-1000121","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}},"FixedBy":"7.38.0-4+deb8u10"},{"Name":"CVE-2016-8625","NamespaceName":"debian:8","Link":"https://security-tracker.debian.org/tracker/CVE-2016-8625","Severity":"Unknown"},{"Name":"CVE-2016-7167","NamespaceName":"debian:8","Description":"Multiple
+        integer overflows in the (1) curl_escape, (2) curl_easy_escape, (3) curl_unescape,
+        and (4) curl_easy_unescape functions in libcurl before 7.50.3 allow attackers
+        to have unspecified impact via a string of length 0xffffffff, which triggers
+        a heap-based buffer overflow.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-7167","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-7407","NamespaceName":"debian:8","Description":"The
+        ourWriteOut function in tool_writeout.c in curl 7.53.1 might allow physically
+        proximate attackers to obtain sensitive information from process memory in
+        opportunistic circumstances by reading a workstation screen during use of
+        a --write-out argument ending in a ''%'' character, which leads to a heap-based
+        buffer over-read.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-7407","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":2.1,"Vectors":"AV:L/AC:L/Au:N/C:P/I:N"}}}},{"Name":"CVE-2016-3739","NamespaceName":"debian:8","Description":"The
+        (1) mbed_connect_step1 function in lib/vtls/mbedtls.c and (2) polarssl_connect_step1
+        function in lib/vtls/polarssl.c in cURL and libcurl before 7.49.0, when using
+        SSLv3 or making a TLS connection to a URL that uses a numerical IP address,
+        allow remote attackers to spoof servers via an arbitrary valid certificate.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-3739","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":2.6,"Vectors":"AV:N/AC:H/Au:N/C:N/I:P"}}}}],"AddedBy":"sha256:7b491c575b06601bb07a2d88bfc3ace6c6005edc1b4d8da3ba6e37e04e9592d6"},{"Name":"mercurial","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"3.1.2-2+deb8u4","Vulnerabilities":[{"Name":"CVE-2018-1000132","NamespaceName":"debian:8","Description":"Mercurial
+        version 4.5 and earlier contains a Incorrect Access Control (CWE-285) vulnerability
+        in Protocol server that can result in Unauthorized data access. This attack
+        appear to be exploitable via network connectivity. This vulnerability appears
+        to have been fixed in 4.5.1.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-1000132","Severity":"Unknown"},{"Name":"CVE-2017-17458","NamespaceName":"debian:8","Description":"In
+        Mercurial before 4.4.1, it is possible that a specially malformed repository
+        can cause Git subrepositories to run arbitrary code in the form of a .git/hooks/post-update
+        script checked into the repository. Typical use of Mercurial prevents construction
+        of such repositories, but they can be created programmatically.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-17458","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":10,"Vectors":"AV:N/AC:L/Au:N/C:C/I:C"}}}},{"Name":"CVE-2017-9462","NamespaceName":"debian:8","Description":"In
+        Mercurial before 4.1.3, \"hg serve --stdio\" allows remote authenticated users
+        to launch the Python debugger, and consequently execute arbitrary code, by
+        using --debugger as a repository name.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-9462","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":9,"Vectors":"AV:N/AC:L/Au:S/C:C/I:C"}}}}],"AddedBy":"sha256:b313b08bab3b8bbcf0de4171a2a80a01e67fab094f272819b76a58705d21ab28"},{"Name":"wget","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.16-1+deb8u4","Vulnerabilities":[{"Name":"CVE-2016-7098","NamespaceName":"debian:8","Description":"Race
+        condition in wget 1.17 and earlier, when used in recursive or mirroring mode
+        to download a single file, might allow remote servers to bypass intended access
+        list restrictions by keeping an HTTP connection open.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-7098","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}}],"AddedBy":"sha256:7b491c575b06601bb07a2d88bfc3ace6c6005edc1b4d8da3ba6e37e04e9592d6"},{"Name":"db-defaults","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"5.3.0","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"freetype","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2.5.2-3+deb8u2","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"xtrans","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.3.4-1","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"dpkg","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.17.27","Vulnerabilities":[{"Name":"CVE-2017-8283","NamespaceName":"debian:8","Description":"dpkg-source
+        in dpkg 1.3.0 through 1.18.23 is able to use a non-GNU patch program and does
+        not offer a protection mechanism for blank-indented diff hunks, which allows
+        remote attackers to conduct directory traversal attacks via a crafted Debian
+        source package, as demonstrated by use of dpkg-source on NetBSD.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-8283","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}}],"AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"dash","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"0.5.7-4","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"glib2.0","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2.42.1-1","Vulnerabilities":[{"Name":"CVE-2012-0039","NamespaceName":"debian:8","Description":"**
+        DISPUTED ** GLib 2.31.8 and earlier, when the g_str_hash function is used,
+        computes hash values without restricting the ability to trigger hash collisions
+        predictably, which allows context-dependent attackers to cause a denial of
+        service (CPU consumption) via crafted input to an application that maintains
+        a hash table.  NOTE: this issue may be disputed by the vendor; the existence
+        of the g_str_hash function is not a vulnerability in the library, because
+        callers of g_hash_table_new and g_hash_table_new_full can specify an arbitrary
+        hash function that is appropriate for the application.","Link":"https://security-tracker.debian.org/tracker/CVE-2012-0039","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}}],"AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"gcc-defaults","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.136","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"lsb","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"4.1+Debian13+nmu1","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"graphite2","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.3.10-1~deb8u1","Vulnerabilities":[{"Name":"CVE-2018-7999","NamespaceName":"debian:8","Description":"In
+        libgraphite2 in graphite2 1.3.11, a NULL pointer dereference vulnerability
+        was found in Segment.cpp during a dumbRendering operation, which may allow
+        attackers to cause a denial of service or possibly have unspecified other
+        impact via a crafted .ttf file.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-7999","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}}],"AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"tzdata","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2017c-0+deb8u1","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"gmp","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2:6.0.0+dfsg-6","AddedBy":"sha256:7b491c575b06601bb07a2d88bfc3ace6c6005edc1b4d8da3ba6e37e04e9592d6"},{"Name":"libtool","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2.4.2-1.11","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"libxcb","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.10-3","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"automake-1.14","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1:1.14.1-4+deb8u1","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"libsepol","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2.3-2","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"libtext-charwidth-perl","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"0.04-7","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"adduser","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"3.113+nmu3","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"subversion","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.8.10-6+deb8u5","AddedBy":"sha256:b313b08bab3b8bbcf0de4171a2a80a01e67fab094f272819b76a58705d21ab28"},{"Name":"jbigkit","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2.1-3.1","Vulnerabilities":[{"Name":"CVE-2017-9937","NamespaceName":"debian:8","Description":"In
+        LibTIFF 4.0.8, there is a memory malloc failure in tif_jbig.c. A crafted TIFF
+        document can lead to an abort resulting in a remote denial of service attack.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-9937","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}}],"AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"jquery","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.7.2+dfsg-3.2","Vulnerabilities":[{"Name":"CVE-2007-2379","NamespaceName":"debian:8","Description":"The
+        jQuery framework exchanges data using JavaScript Object Notation (JSON) without
+        an associated protection scheme, which allows remote attackers to obtain the
+        data via a web page that retrieves the data through a URL in the SRC attribute
+        of a SCRIPT element and captures the data using other JavaScript code, aka
+        \"JavaScript Hijacking.\"","Link":"https://security-tracker.debian.org/tracker/CVE-2007-2379","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:N"}}}},{"Name":"CVE-2012-6708","NamespaceName":"debian:8","Description":"jQuery
+        before 1.9.0 is vulnerable to Cross-site Scripting (XSS) attacks. The jQuery(strInput)
+        function does not differentiate selectors from HTML in a reliable fashion.
+        In vulnerable versions, jQuery determined whether the input was HTML by looking
+        for the ''\u003c'' character anywhere in the string, giving attackers more
+        flexibility when attempting to construct a malicious payload. In fixed versions,
+        jQuery only deems the input to be HTML if it explicitly starts with the ''\u003c''
+        character, limiting exploitability only to attackers who can control the beginning
+        of a string, which is far less common.","Link":"https://security-tracker.debian.org/tracker/CVE-2012-6708","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:P"}}}},{"Name":"CVE-2015-9251","NamespaceName":"debian:8","Description":"jQuery
+        before 3.0.0 is vulnerable to Cross-site Scripting (XSS) attacks when a cross-domain
+        Ajax request is performed without the dataType option, causing text/javascript
+        responses to be executed.","Link":"https://security-tracker.debian.org/tracker/CVE-2015-9251","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:P"}}}}],"AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"patch","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2.7.5-1","Vulnerabilities":[{"Name":"CVE-2018-6951","NamespaceName":"debian:8","Description":"An
+        issue was discovered in GNU patch through 2.7.6. There is a segmentation fault,
+        associated with a NULL pointer dereference, leading to a denial of service
+        in the intuit_diff_type function in pch.c, aka a \"mangled rename\" issue.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-6951","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2018-6952","NamespaceName":"debian:8","Description":"A
+        double free exists in the another_hunk function in pch.c in GNU patch through
+        2.7.6.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-6952","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2010-4651","NamespaceName":"debian:8","Description":"Directory
+        traversal vulnerability in util.c in GNU patch 2.6.1 and earlier allows user-assisted
+        remote attackers to create or overwrite arbitrary files via a filename that
+        is specified with a .. (dot dot) or full pathname, a related issue to CVE-2010-1679.","Link":"https://security-tracker.debian.org/tracker/CVE-2010-4651","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":5.8,"Vectors":"AV:N/AC:M/Au:N/C:N/I:P"}}}},{"Name":"CVE-2016-10713","NamespaceName":"debian:8","Description":"An
+        issue was discovered in GNU patch before 2.7.6. Out-of-bounds access within
+        pch_write_line() in pch.c can possibly lead to DoS via a crafted input file.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-10713","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2018-1000156","NamespaceName":"debian:8","Description":"GNU
+        Patch version 2.7.6 contains an input validation vulnerability when processing
+        patch files, specifically the EDITOR_PROGRAM invocation (using ed) can result
+        in code execution. This attack appear to be exploitable via a patch file processed
+        via the patch utility. This is similar to FreeBSD''s CVE-2015-1418 however
+        although they share a common ancestry the code bases have diverged over time.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-1000156","Severity":"Unknown"}],"AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"debian-archive-keyring","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2017.5~deb8u1","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"libgpg-error","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.17-3","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"libvpx","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.3.0-3","Vulnerabilities":[{"Name":"CVE-2016-6711","NamespaceName":"debian:8","Description":"A
+        remote denial of service vulnerability in libvpx in Mediaserver in Android
+        4.x before 4.4.4, 5.0.x before 5.0.2, 5.1.x before 5.1.1, and 6.x before 2016-11-01
+        could enable an attacker to use a specially crafted file to cause a device
+        hang or reboot. This issue is rated as High due to the possibility of remote
+        denial of service. Android ID: A-30593765.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-6711","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.1,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-0641","NamespaceName":"debian:8","Description":"A
+        remote denial of service vulnerability in libvpx in Mediaserver could enable
+        an attacker to use a specially crafted file to cause a device hang or reboot.
+        This issue is rated as High severity due to the possibility of remote denial
+        of service. Product: Android. Versions: 4.4.4, 5.0.2, 5.1.1, 6.0, 6.0.1, 7.0,
+        7.1.1, 7.1.2. Android ID: A-34360591.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-0641","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":7.1,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2015-4506","NamespaceName":"debian:8","Description":"Buffer
+        overflow in the vp9_init_context_buffers function in libvpx, as used in Mozilla
+        Firefox before 41.0 and Firefox ESR 38.x before 38.3, allows remote attackers
+        to execute arbitrary code via a crafted VP9 file.","Link":"https://security-tracker.debian.org/tracker/CVE-2015-4506","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2016-6712","NamespaceName":"debian:8","Description":"A
+        remote denial of service vulnerability in libvpx in Mediaserver in Android
+        4.x before 4.4.4, 5.0.x before 5.0.2, 5.1.x before 5.1.1, and 6.x before 2016-11-01
+        could enable an attacker to use a specially crafted file to cause a device
+        hang or reboot. This issue is rated as High due to the possibility of remote
+        denial of service. Android ID: A-30593752.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-6712","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.1,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-0393","NamespaceName":"debian:8","Description":"A
+        denial of service vulnerability in libvpx in Mediaserver could enable a remote
+        attacker to use a specially crafted file to cause a device hang or reboot.
+        This issue is rated as High due to the possibility of remote denial of service.
+        Product: Android. Versions: 4.4.4, 5.0.2, 5.1.1, 6.0, 6.0.1, 7.0, 7.1. Android
+        ID: A-30436808.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-0393","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.1,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-13194","NamespaceName":"debian:8","Description":"A
+        vulnerability in the Android media framework (libvpx) related to odd frame
+        width. Product: Android. Versions: 7.0, 7.1.1, 7.1.2, 8.0, 8.1. Android ID:
+        A-64710201.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-13194","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.8,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}},"FixedBy":"1.3.0-3+deb8u1"},{"Name":"CVE-2016-3881","NamespaceName":"debian:8","Description":"The
+        decoder_peek_si_internal function in vp9/vp9_dx_iface.c in libvpx in mediaserver
+        in Android 4.x before 4.4.4, 5.0.x before 5.0.2, 5.1.x before 5.1.1, 6.x before
+        2016-09-01, and 7.0 before 2016-09-01 allows remote attackers to cause a denial
+        of service (buffer over-read, and device hang or reboot) via a crafted media
+        file, aka internal bug 30013856.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-3881","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.1,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2015-1258","NamespaceName":"debian:8","Description":"Google
+        Chrome before 43.0.2357.65 relies on libvpx code that was not built with an
+        appropriate --size-limit value, which allows remote attackers to trigger a
+        negative value for a size field, and consequently cause a denial of service
+        or possibly have unspecified other impact, via a crafted frame size in VP9
+        video data.","Link":"https://security-tracker.debian.org/tracker/CVE-2015-1258","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}}],"AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"openldap","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2.4.40+dfsg-1+deb8u3","Vulnerabilities":[{"Name":"CVE-2017-17740","NamespaceName":"debian:8","Description":"contrib/slapd-modules/nops/nops.c
+        in OpenLDAP through 2.4.45, when both the nops module and the memberof overlay
+        are enabled, attempts to free a buffer that was allocated on the stack, which
+        allows remote attackers to cause a denial of service (slapd crash) via a member
+        MODDN operation.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-17740","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-14159","NamespaceName":"debian:8","Description":"slapd
+        in OpenLDAP 2.4.45 and earlier creates a PID file after dropping privileges
+        to a non-root account, which might allow local users to kill arbitrary processes
+        by leveraging access to this non-root account for PID file modification before
+        a root script executes a \"kill `cat /pathname`\" command, as demonstrated
+        by openldap-initscript.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14159","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":1.9,"Vectors":"AV:L/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2015-3276","NamespaceName":"debian:8","Description":"The
+        nss_parse_ciphers function in libraries/libldap/tls_m.c in OpenLDAP does not
+        properly parse OpenSSL-style multi-keyword mode cipher strings, which might
+        cause a weaker than intended cipher to be used and allow remote attackers
+        to have unspecified impact via unknown vectors.","Link":"https://security-tracker.debian.org/tracker/CVE-2015-3276","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:P"}}}}],"AddedBy":"sha256:7b491c575b06601bb07a2d88bfc3ace6c6005edc1b4d8da3ba6e37e04e9592d6"},{"Name":"configobj","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"5.0.6-1","AddedBy":"sha256:b313b08bab3b8bbcf0de4171a2a80a01e67fab094f272819b76a58705d21ab28"},{"Name":"db5.3","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"5.3.28-9+deb8u1","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"python2.7","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2.7.9-2+deb8u1","Vulnerabilities":[{"Name":"CVE-2016-1000110","NamespaceName":"debian:8","Link":"https://security-tracker.debian.org/tracker/CVE-2016-1000110","Severity":"Negligible"},{"Name":"CVE-2013-7040","NamespaceName":"debian:8","Description":"Python
+        2.7 before 3.4 only uses the last eight bits of the prefix to randomize hash
+        values, which causes it to compute hash values without restricting the ability
+        to trigger hash collisions predictably and makes it easier for context-dependent
+        attackers to cause a denial of service (CPU consumption) via crafted input
+        to an application that maintains a hash table.  NOTE: this vulnerability exists
+        because of an incomplete fix for CVE-2012-1150.","Link":"https://security-tracker.debian.org/tracker/CVE-2013-7040","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2018-1000030","NamespaceName":"debian:8","Description":"Python
+        2.7.14 is vulnerable to a Heap-Buffer-Overflow as well as a Heap-Use-After-Free.
+        Python versions prior to 2.7.14 may also be vulnerable and it appears that
+        Python 2.7.17 and prior may also be vulnerable however this has not been confirmed.
+        The vulnerability lies when multiply threads are handling large amounts of
+        data. In both cases there is essentially a race condition that occurs. For
+        the Heap-Buffer-Overflow, Thread 2 is creating the size for a buffer, but
+        Thread1 is already writing to the buffer without knowing how much to write.
+        So when a large amount of data is being processed, it is very easy to cause
+        memory corruption using a Heap-Buffer-Overflow. As for the Use-After-Free,
+        Thread3-\u003eMalloc-\u003eThread1-\u003eFree''s-\u003eThread2-Re-uses-Free''d
+        Memory. The PSRT has stated that this is not a security vulnerability due
+        to the fact that the attacker must be able to run code, however in some situations,
+        such as function as a service, this vulnerability can potentially be used
+        by an attacker to violate a trust boundary, as such the DWF feels this issue
+        deserves a CVE.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-1000030","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2018-1061","NamespaceName":"debian:8","Link":"https://security-tracker.debian.org/tracker/CVE-2018-1061","Severity":"Low"},{"Name":"CVE-2017-1000158","NamespaceName":"debian:8","Description":"CPython
+        (aka Python) up to 2.7.13 is vulnerable to an integer overflow in the PyString_DecodeEscape
+        function in stringobject.c, resulting in heap-based buffer overflow (and possible
+        arbitrary code execution)","Link":"https://security-tracker.debian.org/tracker/CVE-2017-1000158","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}},{"Name":"CVE-2018-1060","NamespaceName":"debian:8","Link":"https://security-tracker.debian.org/tracker/CVE-2018-1060","Severity":"Low"},{"Name":"CVE-2017-17522","NamespaceName":"debian:8","Description":"**
+        DISPUTED ** Lib/webbrowser.py in Python through 3.6.3 does not validate strings
+        before launching the program specified by the BROWSER environment variable,
+        which might allow remote attackers to conduct argument-injection attacks via
+        a crafted URL. NOTE: a software maintainer indicates that exploitation is
+        impossible because the code relies on subprocess.Popen and the default shell=False
+        setting.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-17522","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}}],"AddedBy":"sha256:b313b08bab3b8bbcf0de4171a2a80a01e67fab094f272819b76a58705d21ab28"},{"Name":"mpfr4","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"3.1.2-2","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"x11proto-input","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2.3.1-1","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"openexr","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.6.1-8","Vulnerabilities":[{"Name":"CVE-2017-9115","NamespaceName":"debian:8","Description":"In
+        OpenEXR 2.2.0, an invalid write of size 2 in the = operator function in half.h
+        could cause the application to crash or execute arbitrary code.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-9115","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-12596","NamespaceName":"debian:8","Description":"In
+        OpenEXR 2.2.0, a crafted image causes a heap-based buffer over-read in the
+        hufDecode function in IlmImf/ImfHuf.cpp during exrmaketiled execution; it
+        may result in denial of service or possibly unspecified other impact.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12596","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-14988","NamespaceName":"debian:8","Description":"Header::readfrom
+        in IlmImf/ImfHeader.cpp in OpenEXR 2.2.0 allows remote attackers to cause
+        a denial of service (excessive memory allocation) via a crafted file that
+        is accessed with the ImfOpenInputFile function in IlmImf/ImfCRgbaFile.cpp.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-14988","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-9111","NamespaceName":"debian:8","Description":"In
+        OpenEXR 2.2.0, an invalid write of size 8 in the storeSSE function in ImfOptimizedPixelReading.h
+        could cause the application to crash or execute arbitrary code.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-9111","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-9114","NamespaceName":"debian:8","Description":"In
+        OpenEXR 2.2.0, an invalid read of size 1 in the refill function in ImfFastHuf.cpp
+        could cause the application to crash.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-9114","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-9116","NamespaceName":"debian:8","Description":"In
+        OpenEXR 2.2.0, an invalid read of size 1 in the uncompress function in ImfZip.cpp
+        could cause the application to crash.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-9116","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-9113","NamespaceName":"debian:8","Description":"In
+        OpenEXR 2.2.0, an invalid write of size 1 in the bufferedReadPixels function
+        in ImfInputFile.cpp could cause the application to crash or execute arbitrary
+        code.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-9113","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-9112","NamespaceName":"debian:8","Description":"In
+        OpenEXR 2.2.0, an invalid read of size 1 in the getBits function in ImfHuf.cpp
+        could cause the application to crash.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-9112","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-9110","NamespaceName":"debian:8","Description":"In
+        OpenEXR 2.2.0, an invalid read of size 2 in the hufDecode function in ImfHuf.cpp
+        could cause the application to crash.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-9110","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}}],"AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"tar","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.27.1-2+deb8u1","Vulnerabilities":[{"Name":"CVE-2005-2541","NamespaceName":"debian:8","Description":"Tar
+        1.15.1 does not properly warn the user when extracting setuid or setgid files,
+        which may allow local users or remote attackers to gain privileges.","Link":"https://security-tracker.debian.org/tracker/CVE-2005-2541","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":10,"Vectors":"AV:N/AC:L/Au:N/C:C/I:C"}}}}],"AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"cryptsetup","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2:1.6.6-5","Vulnerabilities":[{"Name":"CVE-2016-4484","NamespaceName":"debian:8","Description":"The
+        Debian initrd script for the cryptsetup package 2:1.7.3-2 and earlier allows
+        physically proximate attackers to gain shell access via many log in attempts
+        with an invalid password.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-4484","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":7.2,"Vectors":"AV:L/AC:L/Au:N/C:C/I:C"}}}}],"AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"libcap2","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1:2.24-8","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"icu","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"52.1-8+deb8u6","Vulnerabilities":[{"Name":"CVE-2017-15422","NamespaceName":"debian:8","Link":"https://security-tracker.debian.org/tracker/CVE-2017-15422","Severity":"Negligible","FixedBy":"52.1-8+deb8u7"}],"AddedBy":"sha256:7b491c575b06601bb07a2d88bfc3ace6c6005edc1b4d8da3ba6e37e04e9592d6"},{"Name":"hicolor-icon-theme","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"0.13-1","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"gobject-introspection","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.42.0-2.2","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"geoip","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.6.2-4","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"file","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1:5.22+15-2+deb8u3","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"sed","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"4.2.2-4+deb8u1","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"base-files","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"8+deb8u10","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"libtimedate-perl","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2.3000-2","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"x11proto-xext","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"7.3.0-1","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"tiff","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"4.0.3-12.3+deb8u4","Vulnerabilities":[{"Name":"CVE-2018-8905","NamespaceName":"debian:8","Description":"In
+        LibTIFF 4.0.9, a heap-based buffer overflow occurs in the function LZWDecodeCompat
+        in tif_lzw.c via a crafted TIFF file, as demonstrated by tiff2ps.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-8905","Severity":"Unknown"},{"Name":"CVE-2016-10268","NamespaceName":"debian:8","Description":"tools/tiffcp.c
+        in LibTIFF 4.0.7 allows remote attackers to cause a denial of service (integer
+        underflow and heap-based buffer under-read) or possibly have unspecified other
+        impact via a crafted TIFF image, related to \"READ of size 78490\" and libtiff/tif_unix.c:115:23.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-10268","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-11613","NamespaceName":"debian:8","Description":"In
+        LibTIFF 4.0.8, there is a denial of service vulnerability in the TIFFOpen
+        function. A crafted input will lead to a denial of service attack. During
+        the TIFFOpen process, td_imagelength is not checked. The value of td_imagelength
+        can be directly controlled by an input file. In the ChopUpSingleUncompressedStrip
+        function, the _TIFFCheckMalloc function is called based on td_imagelength.
+        If we set the value of td_imagelength close to the amount of system memory,
+        it will hang the system or trigger the OOM killer.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-11613","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-13727","NamespaceName":"debian:8","Description":"There
+        is a reachable assertion abort in the function TIFFWriteDirectoryTagSubifd()
+        in LibTIFF 4.0.8, related to tif_dirwrite.c and a SubIFD tag. A crafted input
+        will lead to a remote denial of service attack.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-13727","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}},"FixedBy":"4.0.3-12.3+deb8u5"},{"Name":"CVE-2017-17942","NamespaceName":"debian:8","Description":"In
+        LibTIFF 4.0.9, there is a heap-based buffer over-read in the function PackBitsEncode
+        in tif_packbits.c.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-17942","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-17095","NamespaceName":"debian:8","Description":"tools/pal2rgb.c
+        in pal2rgb in LibTIFF 4.0.9 allows remote attackers to cause a denial of service
+        (TIFFSetupStrips heap-based buffer overflow and application crash) or possibly
+        have unspecified other impact via a crafted TIFF file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-17095","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-13726","NamespaceName":"debian:8","Description":"There
+        is a reachable assertion abort in the function TIFFWriteDirectorySec() in
+        LibTIFF 4.0.8, related to tif_dirwrite.c and a SubIFD tag. A crafted input
+        will lead to a remote denial of service attack.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-13726","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}},"FixedBy":"4.0.3-12.3+deb8u5"},{"Name":"CVE-2017-11335","NamespaceName":"debian:8","Description":"There
+        is a heap based buffer overflow in tools/tiff2pdf.c of LibTIFF 4.0.8 via a
+        PlanarConfig=Contig image, which causes a more than one hundred bytes out-of-bounds
+        write (related to the ZIPDecode function in tif_zip.c). A crafted input may
+        lead to a remote denial of service attack or an arbitrary code execution attack.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-11335","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}},"FixedBy":"4.0.3-12.3+deb8u5"},{"Name":"CVE-2016-10371","NamespaceName":"debian:8","Description":"The
+        TIFFWriteDirectoryTagCheckedRational function in tif_dirwrite.c in LibTIFF
+        4.0.6 allows remote attackers to cause a denial of service (assertion failure
+        and application exit) via a crafted TIFF file.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-10371","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}},"FixedBy":"4.0.3-12.3+deb8u5"},{"Name":"CVE-2014-8130","NamespaceName":"debian:8","Description":"The
+        _TIFFmalloc function in tif_unix.c in LibTIFF 4.0.3 does not reject a zero
+        size, which allows remote attackers to cause a denial of service (divide-by-zero
+        error and application crash) via a crafted TIFF image that is mishandled by
+        the TIFFWriteScanline function in tif_write.c, as demonstrated by tiffdither.","Link":"https://security-tracker.debian.org/tracker/CVE-2014-8130","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2018-7456","NamespaceName":"debian:8","Description":"A
+        NULL Pointer Dereference occurs in the function TIFFPrintDirectory in tif_print.c
+        in LibTIFF 4.0.9 when using the tiffinfo tool to print crafted TIFF information,
+        a different vulnerability than CVE-2017-18013. (This affects an earlier part
+        of the TIFFPrintDirectory function that was not addressed by the CVE-2017-18013
+        patch.)","Link":"https://security-tracker.debian.org/tracker/CVE-2018-7456","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-9935","NamespaceName":"debian:8","Description":"In
+        LibTIFF 4.0.8, there is a heap-based buffer overflow in the t2p_write_pdf
+        function in tools/tiff2pdf.c. This heap overflow could lead to different damages.
+        For example, a crafted TIFF document can lead to an out-of-bounds read in
+        TIFFCleanup, an invalid free in TIFFClose or t2p_free, memory corruption in
+        t2p_readwrite_pdf_image, or a double free in t2p_free. Given these possibilities,
+        it probably could cause arbitrary code execution.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-9935","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}},"FixedBy":"4.0.3-12.3+deb8u5"},{"Name":"CVE-2014-8127","NamespaceName":"debian:8","Description":"LibTIFF
+        4.0.3 allows remote attackers to cause a denial of service (out-of-bounds
+        read and crash) via a crafted TIFF image to the (1) checkInkNamesString function
+        in tif_dir.c in the thumbnail tool, (2) compresscontig function in tiff2bw.c
+        in the tiff2bw tool, (3) putcontig8bitCIELab function in tif_getimage.c in
+        the tiff2rgba tool, LZWPreDecode function in tif_lzw.c in the (4) tiff2ps
+        or (5) tiffdither tool, (6) NeXTDecode function in tif_next.c in the tiffmedian
+        tool, or (7) TIFFWriteDirectoryTagLongLong8Array function in tif_dirwrite.c
+        in the tiffset tool.","Link":"https://security-tracker.debian.org/tracker/CVE-2014-8127","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-9815","NamespaceName":"debian:8","Description":"In
+        LibTIFF 4.0.7, the TIFFReadDirEntryLong8Array function in libtiff/tif_dirread.c
+        mishandles a malloc operation, which allows attackers to cause a denial of
+        service (memory leak within the function _TIFFmalloc in tif_unix.c) via a
+        crafted file.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-9815","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-9117","NamespaceName":"debian:8","Description":"In
+        LibTIFF 4.0.7, the program processes BMP images without verifying that biWidth
+        and biHeight in the bitmap-information header match the actual input, leading
+        to a heap-based buffer over-read in bmp2tiff.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-9117","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}},{"Name":"CVE-2015-7313","NamespaceName":"debian:8","Description":"LibTIFF
+        allows remote attackers to cause a denial of service (memory consumption and
+        crash) via a crafted tiff file.","Link":"https://security-tracker.debian.org/tracker/CVE-2015-7313","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2018-5360","NamespaceName":"debian:8","Description":"LibTIFF
+        before 4.0.6 mishandles the reading of TIFF files, as demonstrated by a heap-based
+        buffer over-read in the ReadTIFFImage function in coders/tiff.c in GraphicsMagick
+        1.3.27.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-5360","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2016-9539","NamespaceName":"debian:8","Description":"tools/tiffcrop.c
+        in libtiff 4.0.6 has an out-of-bounds read in readContigTilesIntoBuffer().
+        Reported as MSVR 35092.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-9539","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}},{"Name":"CVE-2018-5784","NamespaceName":"debian:8","Description":"In
+        LibTIFF 4.0.9, there is an uncontrolled resource consumption in the TIFFSetDirectory
+        function of tif_dir.c. Remote attackers could leverage this vulnerability
+        to cause a denial of service via a crafted tif file. This occurs because the
+        declared number of directory entries is not validated against the actual number
+        of directory entries.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-5784","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-5563","NamespaceName":"debian:8","Description":"LibTIFF
+        version 4.0.7 is vulnerable to a heap-based buffer over-read in tif_lzw.c
+        resulting in DoS or code execution via a crafted bmp image to tools/bmp2tiff.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-5563","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":6.8,"Vectors":"AV:N/AC:M/Au:N/C:P/I:P"}}}},{"Name":"CVE-2010-2596","NamespaceName":"debian:8","Description":"The
+        OJPEGPostDecode function in tif_ojpeg.c in LibTIFF 3.9.0 and 3.9.2, as used
+        in tiff2ps, allows remote attackers to cause a denial of service (assertion
+        failure and application exit) via a crafted TIFF image, related to \"downsampled
+        OJPEG input.\"","Link":"https://security-tracker.debian.org/tracker/CVE-2010-2596","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-18013","NamespaceName":"debian:8","Description":"In
+        LibTIFF 4.0.9, there is a Null-Pointer Dereference in the tif_print.c TIFFPrintDirectory
+        function, as demonstrated by a tiffinfo crash.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-18013","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}},"FixedBy":"4.0.3-12.3+deb8u5"},{"Name":"CVE-2017-16232","NamespaceName":"debian:8","Link":"https://security-tracker.debian.org/tracker/CVE-2017-16232","Severity":"Negligible"},{"Name":"CVE-2017-12944","NamespaceName":"debian:8","Description":"The
+        TIFFReadDirEntryArray function in tif_read.c in LibTIFF 4.0.8 mishandles memory
+        allocation for short files, which allows remote attackers to cause a denial
+        of service (allocation failure and application crash) in the TIFFFetchStripThing
+        function in tif_dirread.c during a tiff2pdf invocation.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12944","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}},"FixedBy":"4.0.3-12.3+deb8u5"}],"AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"libice","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2:1.0.9-1","Vulnerabilities":[{"Name":"CVE-2017-2626","NamespaceName":"debian:8","Link":"https://security-tracker.debian.org/tracker/CVE-2017-2626","Severity":"Unknown"}],"AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"libxt","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1:1.1.4-1","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"graphviz","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2.38.0-7","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"libthai","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"0.1.21-1","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"glibc","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2.19-18+deb8u10","Vulnerabilities":[{"Name":"CVE-2017-12132","NamespaceName":"debian:8","Description":"The
+        DNS stub resolver in the GNU C Library (aka glibc or libc6) before version
+        2.26, when EDNS support is enabled, will solicit large UDP responses from
+        name servers, potentially simplifying off-path DNS spoofing attacks due to
+        IP fragmentation.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12132","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:P"}}}},{"Name":"CVE-2010-4051","NamespaceName":"debian:8","Description":"The
+        regcomp implementation in the GNU C Library (aka glibc or libc6) through 2.11.3,
+        and 2.12.x through 2.12.2, allows context-dependent attackers to cause a denial
+        of service (application crash) via a regular expression containing adjacent
+        bounded repetitions that bypass the intended RE_DUP_MAX limitation, as demonstrated
+        by a {10,}{10,}{10,}{10,}{10,} sequence in the proftpd.gnu.c exploit for ProFTPD,
+        related to a \"RE_DUP_MAX overflow.\"","Link":"https://security-tracker.debian.org/tracker/CVE-2010-4051","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-15671","NamespaceName":"debian:8","Description":"The
+        glob function in glob.c in the GNU C Library (aka glibc or libc6) before 2.27,
+        when invoked with GLOB_TILDE, could skip freeing allocated memory when processing
+        the ~ operator with a long user name, potentially leading to a denial of service
+        (memory leak).","Link":"https://security-tracker.debian.org/tracker/CVE-2017-15671","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2014-9761","NamespaceName":"debian:8","Description":"Multiple
+        stack-based buffer overflows in the GNU C Library (aka glibc or libc6) before
+        2.23 allow context-dependent attackers to cause a denial of service (application
+        crash) or possibly execute arbitrary code via a long argument to the (1) nan,
+        (2) nanf, or (3) nanl function.","Link":"https://security-tracker.debian.org/tracker/CVE-2014-9761","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}},{"Name":"CVE-2016-10228","NamespaceName":"debian:8","Description":"The
+        iconv program in the GNU C Library (aka glibc or libc6) 2.25 and earlier,
+        when invoked with the -c option, enters an infinite loop when processing invalid
+        multi-byte input sequences, leading to a denial of service.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-10228","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2018-1000001","NamespaceName":"debian:8","Description":"In
+        glibc 2.26 and earlier there is confusion in the usage of getcwd() by realpath()
+        which can be used to write before the destination buffer leading to a buffer
+        underflow and potential code execution.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-1000001","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.2,"Vectors":"AV:L/AC:L/Au:N/C:C/I:C"}}}},{"Name":"CVE-2017-1000409","NamespaceName":"debian:8","Description":"A
+        buffer overflow in glibc 2.5 (released on September 29, 2006) and can be triggered
+        through the LD_LIBRARY_PATH environment variable. Please note that many versions
+        of glibc are not vulnerable to this issue if patched for CVE-2017-1000366.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-1000409","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":6.9,"Vectors":"AV:L/AC:M/Au:N/C:C/I:C"}}}},{"Name":"CVE-2017-15670","NamespaceName":"debian:8","Description":"The
+        GNU C Library (aka glibc or libc6) before 2.27 contains an off-by-one error
+        leading to a heap-based buffer overflow in the glob function in glob.c, related
+        to the processing of home directories using the ~ operator followed by a long
+        string.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-15670","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-15804","NamespaceName":"debian:8","Description":"The
+        glob function in glob.c in the GNU C Library (aka glibc or libc6) before 2.27
+        contains a buffer overflow during unescaping of user names with the ~ operator.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-15804","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}},{"Name":"CVE-2015-8985","NamespaceName":"debian:8","Description":"The
+        pop_fail_stack function in the GNU C Library (aka glibc or libc6) allows context-dependent
+        attackers to cause a denial of service (assertion failure and application
+        crash) via vectors related to extended regular expression processing.","Link":"https://security-tracker.debian.org/tracker/CVE-2015-8985","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}},{"Name":"CVE-2018-6485","NamespaceName":"debian:8","Description":"An
+        integer overflow in the implementation of the posix_memalign in memalign functions
+        in the GNU C Library (aka glibc or libc6) 2.26 and earlier could cause these
+        functions to return a pointer to a heap area that is too small, potentially
+        leading to heap corruption.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-6485","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}},{"Name":"CVE-2017-12133","NamespaceName":"debian:8","Description":"The
+        DNS stub resolver in the GNU C Library (glibc) before version 2.26, when EDNS
+        support is enabled, will solicit large UDP responses from name servers, potentially
+        simplifying off-path DNS spoofing attackers due to IP fragmentation.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12133","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:P"}}}},{"Name":"CVE-2015-5180","NamespaceName":"debian:8","Description":"res_query
+        in libresolv in glibc before 2.25 allows remote attackers to cause a denial
+        of service (NULL pointer dereference and process crash).","Link":"https://security-tracker.debian.org/tracker/CVE-2015-5180","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2017-1000408","NamespaceName":"debian:8","Description":"A
+        memory leak in glibc 2.1.1 (released on May 24, 1999) can be reached and amplified
+        through the LD_HWCAP_MASK environment variable. Please note that many versions
+        of glibc are not vulnerable to this issue if patched for CVE-2017-1000366.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-1000408","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.2,"Vectors":"AV:L/AC:L/Au:N/C:C/I:C"}}}},{"Name":"CVE-2017-16997","NamespaceName":"debian:8","Description":"elf/dl-load.c
+        in the GNU C Library (aka glibc or libc6) 2.19 through 2.26 mishandles RPATH
+        and RUNPATH containing $ORIGIN for a privileged (setuid or AT_SECURE) program,
+        which allows local users to gain privileges via a Trojan horse library in
+        the current working directory, related to the fillin_rpath and decompose_rpath
+        functions. This is associated with misinterpretion of an empty RPATH/RUNPATH
+        token as the \"./\" directory. NOTE: this configuration of RPATH/RUNPATH for
+        a privileged program is apparently very uncommon; most likely, no such program
+        is shipped with any common Linux distribution.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-16997","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":9.3,"Vectors":"AV:N/AC:M/Au:N/C:C/I:C"}}}},{"Name":"CVE-2017-8804","NamespaceName":"debian:8","Description":"The
+        xdr_bytes and xdr_string functions in the GNU C Library (aka glibc or libc6)
+        2.25 mishandle failures of buffer deserialization, which allows remote attackers
+        to cause a denial of service (virtual memory allocation, or memory consumption
+        if an overcommit setting is not used) via a crafted UDP packet to port 111,
+        a related issue to CVE-2017-8779.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-8804","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.8,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2010-4052","NamespaceName":"debian:8","Description":"Stack
+        consumption vulnerability in the regcomp implementation in the GNU C Library
+        (aka glibc or libc6) through 2.11.3, and 2.12.x through 2.12.2, allows context-dependent
+        attackers to cause a denial of service (resource exhaustion) via a regular
+        expression containing adjacent repetition operators, as demonstrated by a
+        {10,}{10,}{10,}{10,} sequence in the proftpd.gnu.c exploit for ProFTPD.","Link":"https://security-tracker.debian.org/tracker/CVE-2010-4052","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:N/I:N"}}}},{"Name":"CVE-2010-4756","NamespaceName":"debian:8","Description":"The
+        glob implementation in the GNU C Library (aka glibc or libc6) allows remote
+        authenticated users to cause a denial of service (CPU and memory consumption)
+        via crafted glob expressions that do not match any pathnames, as demonstrated
+        by glob expressions in STAT commands to an FTP daemon, a different vulnerability
+        than CVE-2010-2632.","Link":"https://security-tracker.debian.org/tracker/CVE-2010-4756","Severity":"Negligible","Metadata":{"NVD":{"CVSSv2":{"Score":4,"Vectors":"AV:N/AC:L/Au:S/C:N/I:N"}}}}],"AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"libgd2","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2.1.0-5+deb8u11","Vulnerabilities":[{"Name":"CVE-2018-5711","NamespaceName":"debian:8","Description":"gd_gif_in.c
+        in the GD Graphics Library (aka libgd), as used in PHP before 5.6.33, 7.0.x
+        before 7.0.27, 7.1.x before 7.1.13, and 7.2.x before 7.2.1, has an integer
+        signedness error that leads to an infinite loop via a crafted GIF file, as
+        demonstrated by a call to the imagecreatefromgif or imagecreatefromstring
+        PHP function. This is related to GetCode_ and gdImageCreateFromGifCtx.","Link":"https://security-tracker.debian.org/tracker/CVE-2018-5711","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}}],"AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"gzip","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.6-4","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"readline6","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"6.3-8","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"autoconf","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2.69-8","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"harfbuzz","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"0.9.35-2","Vulnerabilities":[{"Name":"CVE-2015-8947","NamespaceName":"debian:8","Description":"hb-ot-layout-gpos-table.hh
+        in HarfBuzz before 1.0.5 allows remote attackers to cause a denial of service
+        (buffer over-read) or possibly have unspecified other impact via crafted data,
+        a different vulnerability than CVE-2016-2052.","Link":"https://security-tracker.debian.org/tracker/CVE-2015-8947","Severity":"High","Metadata":{"NVD":{"CVSSv2":{"Score":7.5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:P"}}}}],"AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"libelf","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"0.8.13-5","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"xorg-sgml-doctools","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1:1.11-1","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"attr","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1:2.4.47-2","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"inetutils","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2:1.9.2.39.3a460-3","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"bzr","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2.6.0+bzr6595-6+deb8u1","AddedBy":"sha256:b313b08bab3b8bbcf0de4171a2a80a01e67fab094f272819b76a58705d21ab28"},{"Name":"autotools-dev","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"20140911.1","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"lcms2","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2.6-3+deb8u1","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"startpar","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"0.59-3","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"gcc-4.8","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"4.8.4-1","Vulnerabilities":[{"Name":"CVE-2017-11671","NamespaceName":"debian:8","Description":"Under
+        certain circumstances, the ix86_expand_builtin function in i386.c in GNU Compiler
+        Collection (GCC) version 4.6, 4.7, 4.8, 4.9, 5 before 5.5, and 6 before 6.4
+        will generate instruction sequences that clobber the status flag of the RDRAND
+        and RDSEED intrinsics before it can be read, potentially causing failures
+        of these instructions to go unreported. This could potentially lead to less
+        randomness in random number generation.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-11671","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":2.1,"Vectors":"AV:L/AC:L/Au:N/C:P/I:N"}}}}],"AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"iproute2","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"3.16.0-2","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"bzip2","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.0.6-7","Vulnerabilities":[{"Name":"CVE-2016-3189","NamespaceName":"debian:8","Description":"Use-after-free
+        vulnerability in bzip2recover in bzip2 1.0.6 allows remote attackers to cause
+        a denial of service (crash) via a crafted bzip2 file, related to block ends
+        set to before the start of the block.","Link":"https://security-tracker.debian.org/tracker/CVE-2016-3189","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":4.3,"Vectors":"AV:N/AC:M/Au:N/C:N/I:N"}}}}],"AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"gcc-4.9","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"4.9.2-10","Vulnerabilities":[{"Name":"CVE-2015-5276","NamespaceName":"debian:8","Description":"The
+        std::random_device class in libstdc++ in the GNU Compiler Collection (aka
+        GCC) before 4.9.4 does not properly handle short reads from blocking sources,
+        which makes it easier for context-dependent attackers to predict the random
+        values via unspecified vectors.","Link":"https://security-tracker.debian.org/tracker/CVE-2015-5276","Severity":"Medium","Metadata":{"NVD":{"CVSSv2":{"Score":5,"Vectors":"AV:N/AC:L/Au:N/C:P/I:N"}}}},{"Name":"CVE-2017-11671","NamespaceName":"debian:8","Description":"Under
+        certain circumstances, the ix86_expand_builtin function in i386.c in GNU Compiler
+        Collection (GCC) version 4.6, 4.7, 4.8, 4.9, 5 before 5.5, and 6 before 6.4
+        will generate instruction sequences that clobber the status flag of the RDRAND
+        and RDSEED intrinsics before it can be read, potentially causing failures
+        of these instructions to go unreported. This could potentially lead to less
+        randomness in random number generation.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-11671","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":2.1,"Vectors":"AV:L/AC:L/Au:N/C:P/I:N"}}}}],"AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"apr","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1.5.1-3","Vulnerabilities":[{"Name":"CVE-2017-12613","NamespaceName":"debian:8","Description":"When
+        apr_time_exp*() or apr_os_exp_time*() functions are invoked with an invalid
+        month field value in Apache Portable Runtime APR 1.6.2 and prior, out of bounds
+        memory may be accessed in converting this value to an apr_time_exp_t value,
+        potentially revealing the contents of a different static heap value or resulting
+        in program termination, and may represent an information disclosure or denial
+        of service vulnerability to applications which call these APR functions with
+        unvalidated external input.","Link":"https://security-tracker.debian.org/tracker/CVE-2017-12613","Severity":"Low","Metadata":{"NVD":{"CVSSv2":{"Score":3.6,"Vectors":"AV:L/AC:L/Au:N/C:P/I:N"}}}}],"AddedBy":"sha256:b313b08bab3b8bbcf0de4171a2a80a01e67fab094f272819b76a58705d21ab28"},{"Name":"fftw3","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"3.3.4-2","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"libx11","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2:1.6.2-3+deb8u1","AddedBy":"sha256:51d6678c3f0e0c6e2b58b51ad100912b7c0e4dfedf98a1808417216fd5d948e5"},{"Name":"diffutils","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"1:3.3-1","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"},{"Name":"slang2","NamespaceName":"debian:8","VersionFormat":"dpkg","Version":"2.3.0-2","AddedBy":"sha256:f49cf87b52c10aa83b4f4405800527a74400fb19ea1821d209293bc4d53966aa"}]}}
+
+'
+    http_version:
+  recorded_at: Thu, 12 Apr 2018 10:34:11 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
Before this we were storing vulnerabilities as a serialized column,
which, despite being convenient, had some problems. For example, when
the response from scanners was too large, the insert would fail on this
column.

Fixes #1669

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>