### PR TITLE
lib: be explicit on the exceptions to be rescued

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -89,13 +89,11 @@ class Repository < ActiveRecord::Base
 
   # Handle a delete event.
   def self.handle_delete_event(event)
+    # Fetch the repo.
     registry = Registry.find_from_event(event)
     return if registry.nil?
-
-    # Fetch the repo.
-    ns, repo_name, = registry.get_namespace_from_event(event, false)
-    repo = ns.repositories.find_by(name: repo_name)
-    return if repo.nil? || repo.marked?
+    repo = registry.get_repository_from_event(event, false)
+    return if repo.nil?
 
     # Destroy tags and the repository if it's empty now.
     user = User.find_from_event(event)
@@ -144,8 +142,9 @@ class Repository < ActiveRecord::Base
     if digest.present?
       begin
         id, = Registry.get.client.manifest(repo, digest)
-      rescue StandardError => e
-        logger.warn "Could not fetch manifest for '#{repo}' with digest '#{digest}': " + e.message
+      rescue ::Portus::RequestError, ::Portus::Errors::NotFoundError,
+             ::Portus::RegistryClient::ManifestError => e
+        logger.warn "Could not fetch manifest for '#{repo}' with digest '#{digest}': " + e.to_s
       end
     end
 
@@ -196,10 +195,11 @@ class Repository < ActiveRecord::Base
       # Try to fetch the manifest digest of the tag.
       begin
         _, digest, = client.manifest(repository.full_name, tag)
-      rescue StandardError => e
+      rescue ::Portus::RequestError, ::Portus::Errors::NotFoundError,
+             ::Portus::RegistryClient::ManifestError => e
         logger.tagged("catalog") do
           logger.warn "Could not fetch manifest for '#{repository.full_name}' " \
-            "with tag '#{tag}': " + e.message
+            "with tag '#{tag}': " + e.to_s
         end
         next
       end
@@ -221,7 +221,8 @@ class Repository < ActiveRecord::Base
       # Try to fetch the manifest digest of the tag.
       begin
         id, digest, = client.manifest(repository.full_name, tag)
-      rescue ::Portus::RegistryClient::ManifestError, ::Portus::RequestError => e
+      rescue ::Portus::RequestError, ::Portus::Errors::NotFoundError,
+             ::Portus::RegistryClient::ManifestError => e
         Rails.logger.info e.to_s
         id = ""
         digest = ""

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -69,7 +69,8 @@ class Tag < ActiveRecord::Base
 
     begin
       Registry.get.client.delete(repository.full_name, dig, "manifests")
-    rescue StandardError => e
+    rescue ::Portus::RequestError, ::Portus::Errors::NotFoundError,
+           ::Portus::RegistryClient::RegistryError => e
       Rails.logger.error "Could not delete tag on the registry: #{e.message}"
       return false
     end
@@ -136,8 +137,9 @@ class Tag < ActiveRecord::Base
         _, dig, = client.manifest(repository.full_name, name)
         update_column(:digest, dig)
         dig
-      rescue StandardError => e
-        Rails.logger.error "Could not fetch manifest digest: #{e.message}"
+      rescue ::Portus::RequestError, ::Portus::Errors::NotFoundError,
+             ::Portus::RegistryClient::ManifestError => e
+        Rails.logger.error "Could not fetch manifest digest: #{e}"
         nil
       end
     else

--- a/lib/portus/background/sync.rb
+++ b/lib/portus/background/sync.rb
@@ -59,9 +59,10 @@ module Portus
           # the DB in an unknown state because of an update failure.
           ActiveRecord::Base.transaction { update_registry!(cat) }
           @executed = true
-        rescue EOFError, *::Portus::Errors::NET,
+        rescue ::Portus::RequestError, ::Portus::Errors::NotFoundError,
+               ::Portus::RegistryClient::ManifestError,
                ::Portus::Errors::NoBearerRealmException, ::Portus::Errors::AuthorizationError,
-               ::Portus::Errors::NotFoundError, ::Portus::Errors::CredentialsMissingError => e
+               ::Portus::Errors::CredentialsMissingError => e
           Rails.logger.warn "Exception: #{e.message}"
         end
       end

--- a/lib/portus/errors.rb
+++ b/lib/portus/errors.rb
@@ -6,7 +6,7 @@ module Portus
     # Networking errors given usually on this application. This is useful to
     # catch a set of common networking issues on a single rescue statement.
     NET = [SocketError, OpenSSL::SSL::SSLError, Net::HTTPBadResponse,
-           Errno::ECONNRESET, Errno::ECONNREFUSED, Errno::EHOSTUNREACH,
+           Errno::ECONNRESET, Errno::ECONNREFUSED, Errno::EHOSTUNREACH, EOFError,
            Errno::ETIMEDOUT, Net::OpenTimeout, Net::ReadTimeout].freeze
 
     # Returns a string with a message representing the given exception.

--- a/lib/tasks/portus/tags.rake
+++ b/lib/tasks/portus/tags.rake
@@ -43,7 +43,7 @@ namespace :portus do
   task :update_tags, [:update] => [:environment] do |_, args|
     warn_user!
 
-    tags = tags_tp_update(args[:update])
+    tags = tags_to_update(args[:update])
 
     # And for each tag fetch its digest and update the DB.
     client = Registry.get.client
@@ -54,8 +54,9 @@ namespace :portus do
       begin
         id, digest, = client.manifest(t.repository.full_name, t.name)
         t.update(digest: digest, image_id: id)
-      rescue StandardError => e
-        puts "Could not get the manifest for #{repo_name}: #{e.message}"
+      rescue ::Portus::RequestError, ::Portus::Errors::NotFoundError,
+             ::Portus::RegistryClient::ManifestError => e
+        puts "Could not get the manifest for #{repo_name}: #{e}"
       end
     end
     puts

--- a/spec/api/grape_api/v1/repositories_spec.rb
+++ b/spec/api/grape_api/v1/repositories_spec.rb
@@ -125,7 +125,7 @@ describe API::V1::Repositories do
 
     it "returns 422 if unable to remove dependent tag" do
       allow_any_instance_of(Portus::RegistryClient).to receive(:delete) do
-        raise "I AM ERROR."
+        raise ::Portus::RegistryClient::RegistryError, "I AM ERROR."
       end
 
       repository = create(:repository, namespace: public_namespace)

--- a/spec/api/grape_api/v1/tags_spec.rb
+++ b/spec/api/grape_api/v1/tags_spec.rb
@@ -75,7 +75,7 @@ describe API::V1::Tags do
     it "returns 422 if unable to remove tag" do
       APP_CONFIG["delete"]["enabled"] = true
       allow_any_instance_of(Portus::RegistryClient).to receive(:delete) do
-        raise "I AM ERROR."
+        raise ::Portus::RegistryClient::RegistryError, "I AM ERROR."
       end
 
       tag = create(:tag, name: "taggg", repository: repository, digest: "1", author: admin)

--- a/spec/models/registry_spec.rb
+++ b/spec/models/registry_spec.rb
@@ -36,11 +36,11 @@ class RegistryMock < Registry
     o = nil
     if @should_fail
       def o.manifest(*_)
-        raise StandardError, "Some message"
+        raise ::Portus::RegistryClient::ManifestError, "Some message"
       end
 
       def o.tags(*_)
-        raise StandardError, "Some message"
+        raise ::Portus::RegistryClient::ManifestError, "Some message"
       end
     else
       def o.manifest(*_)

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -78,7 +78,7 @@ describe Tag do
 
     it "returns false if the registry client could not delete the tag" do
       allow_any_instance_of(Portus::RegistryClient).to receive(:delete) do
-        raise "I AM ERROR."
+        raise ::Portus::RegistryClient::RegistryError, "I AM ERROR."
       end
 
       # That being said, the tag should be "marked".
@@ -185,7 +185,7 @@ describe Tag do
 
     it "returns nil if the client could not fetch the digest" do
       allow_any_instance_of(Portus::RegistryClient).to receive(:manifest) do
-        raise "I AM ERROR."
+        raise ::Portus::RegistryClient::ManifestError, "I AM ERROR."
       end
 
       tag = TagMock.create(name: "tag", repository: repository)

--- a/spec/services/repositories/destroy_service_spec.rb
+++ b/spec/services/repositories/destroy_service_spec.rb
@@ -37,7 +37,7 @@ describe "Repositories::DestroyService" do
         create(:tag, name: "tag1", repository: repository, digest: "1")
 
         allow_any_instance_of(Portus::RegistryClient).to receive(:delete) do
-          raise "I AM ERROR."
+          raise ::Portus::RegistryClient::RegistryError, "I AM ERROR."
         end
 
         expect { service.execute(repository) }.to change(Repository, :count).by(0)
@@ -47,7 +47,7 @@ describe "Repositories::DestroyService" do
         create(:tag, name: "tag1", repository: repository, digest: "1")
 
         allow_any_instance_of(Portus::RegistryClient).to receive(:delete) do
-          raise "I AM ERROR."
+          raise ::Portus::RegistryClient::RegistryError, "I AM ERROR."
         end
 
         service.execute(repository)

--- a/spec/services/tags/destroy_service_spec.rb
+++ b/spec/services/tags/destroy_service_spec.rb
@@ -38,7 +38,7 @@ describe "Tags::DestroyService" do
 
       it "stores error in attribute" do
         allow_any_instance_of(Portus::RegistryClient).to receive(:delete) do
-          raise "I AM ERROR."
+          raise ::Portus::RegistryClient::RegistryError, "I AM ERROR."
         end
 
         service.execute(tag)


### PR DESCRIPTION
In the past we have had some problems when it comes to unhandled
exceptions. This commit fixes the opposite problem: having too broad
exceptions. That is, this commit clarifies which exact exceptions might
be raised from the different registry methods and updates the places
where these methods are used.

Some tests had to be corrected because they were abusing some code
paths that were rescuing StandardError.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>