### PR TITLE
sidebar: added users and registries

### DIFF
--- a/app/views/shared/_aside.html.slim
+++ b/app/views/shared/_aside.html.slim
@@ -31,6 +31,18 @@ aside
           | Admin
         - if current_page?(url_for controller: 'admin/dashboard', action: 'index')
           .list-selected
+      li.active
+        = link_to admin_users_path
+          i[class="fa fa-user"]
+          | Users
+        - if current_page?(url_for controller: 'admin/users', action: 'index')
+          .list-selected
+      li.active
+        = link_to admin_registries_path
+          i[class="fa fa-server"]
+          | Registries
+        - if current_page?(url_for controller: 'admin/registries', action: 'index')
+          .list-selected
     li.active
       = link_to help_index_path
         i[class="fa fa-life-ring"]

--- a/vendor/assets/stylesheets/lifeitup/layout.scss
+++ b/vendor/assets/stylesheets/lifeitup/layout.scss
@@ -110,6 +110,7 @@ body:not([class*="login"]) {
           .fa {
             margin-right: 10px;
             font-size: 1.4em;
+            vertical-align: middle;
           }
           position: relative;
           .list-selected {


### PR DESCRIPTION
Added 'Users' and 'Registries' items to the sidebar. So far the only
possible way to access those pages were via the admin overview page.

A minor enhancement done was the vertical alignment of the icons.

Signed-off-by: Vítor Avelino <vavelino@suse.com>

![screenshot-20180416095713-258x627](https://user-images.githubusercontent.com/188554/38810273-aaa447dc-415c-11e8-9d93-0bab6c93dd00.png)
