### PR TITLE
repositories: splitted repositories into different panels

### DIFF
--- a/app/assets/javascripts/modules/repositories/pages/index.js
+++ b/app/assets/javascripts/modules/repositories/pages/index.js
@@ -18,7 +18,24 @@ $(() => {
     data() {
       return {
         repositories: window.repositories,
+        teamRepositoriesNames: window.teamRepositoriesNames,
       };
+    },
+
+    computed: {
+      teamRepositories() {
+        // eslint-disable-next-line
+        return this.repositories.filter((r) => {
+          return this.teamRepositoriesNames.indexOf(r.full_name) !== -1;
+        });
+      },
+
+      otherRepositories() {
+        // eslint-disable-next-line
+        return this.repositories.filter((r) => {
+          return this.teamRepositoriesNames.indexOf(r.full_name) === -1;
+        });
+      },
     },
   });
 });

--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -6,13 +6,16 @@ class RepositoriesController < ApplicationController
   # GET /repositories
   # GET /repositories.json
   def index
-    @repositories = policy_scope(Repository).all
+    @repositories = policy_scope(Repository)
     @repositories_serialized = API::Entities::Repositories.represent(
       @repositories,
       current_user: current_user,
       type:         :internal
     ).to_json
-    respond_with(@repositories)
+    @team_repositories = Repository
+                         .joins(namespace: { team: :users })
+                         .where("users.id = :user_id", user_id: current_user.id)
+                         .map(&:full_name)
   end
 
   # GET /repositories/1

--- a/app/views/repositories/index.html.slim
+++ b/app/views/repositories/index.html.slim
@@ -1,8 +1,15 @@
 .panel.panel-default.repositories-panel
   .panel-heading
-    h5 Repositories
+    h5 Repositories via team membership
   .panel-body
-    <repositories-table :repositories="repositories" repositories-path="#{repositories_path}" namespaces-path="#{namespaces_path}" :sortable="true" sort-by="name"></repositories-table>
+    <repositories-table :repositories="teamRepositories" repositories-path="#{repositories_path}" namespaces-path="#{namespaces_path}" :sortable="true" sort-by="name"></repositories-table>
+
+- if (@repositories.count - @team_repositories.count) > 0
+  .panel.panel-default.repositories-panel
+    .panel-heading
+      h5 Other repositories
+    .panel-body
+      <repositories-table :repositories="otherRepositories" repositories-path="#{repositories_path}" namespaces-path="#{namespaces_path}" :sortable="true" sort-by="name"></repositories-table>
 
 - content_for :js_body do
   script#js-repositories-table-tmpl type="text/x-template"
@@ -14,3 +21,4 @@
 - content_for :js_header do
   javascript:
     window.repositories = #{raw @repositories_serialized};
+    window.teamRepositoriesNames = #{raw @team_repositories};

--- a/spec/features/repositories_spec.rb
+++ b/spec/features/repositories_spec.rb
@@ -100,6 +100,13 @@ describe "Feature: Repositories" do
       expect(page).to have_css(selector)
       expect(page).to have_current_path(repositories_path(page: 1))
     end
+
+    it "doesn't show 'other repositories' panel when empty" do
+      visit repositories_path
+
+      expect(page).to have_content(repository.name)
+      expect(page).not_to have_content("Other repositories")
+    end
   end
 
   describe "repository#show" do


### PR DESCRIPTION
All the repositories were mixed together without distinction from the
repositories accessible via team membership or via visibility. Of
course, if the user is an admin, all the repositories would be listed.
Anyways, a nice enhancement to have this separation and create a sense
of semantic in the UI level.

Signed-off-by: Vítor Avelino <vavelino@suse.com>

![screenshot-20180416125758-1035x412](https://user-images.githubusercontent.com/188554/38821030-d3967b2e-4175-11e8-955b-398e1cf4c2bb.png)
