### PR TITLE
registries: show external hostname for registries

### DIFF
--- a/app/views/admin/registries/index.html.slim
+++ b/app/views/admin/registries/index.html.slim
@@ -15,14 +15,16 @@
     .panel-body
       .table-responsive
         table.table.table-stripped.table-hover
-          col.col-40
-          col.col-40
+          col.col-20
+          col.col-30
+          col.col-30
           col.col-10
           col.col-10
           thead
             tr
               th Name
               th Hostname
+              th External hostname
               th SSL
               th.text-center Reachable
               th
@@ -31,6 +33,7 @@
               tr id="registry_#{registry.id}"
                 td= registry.name
                 td= registry.hostname
+                td= registry.external_hostname
                 td
                   i.fa.fa-lg class="fa-toggle-#{registry.use_ssl? ? 'on': 'off'}" title="SSL in the comunication between Portus and this registry is #{registry.use_ssl? ? "enabled" : "disabled"}"
                 td.text-center.registry-status


### PR DESCRIPTION
External hostname was not being shown in the registries table. This is a
simple patch that adds a column for the external hostname and show it
whenever present.

Signed-off-by: Vítor Avelino <vavelino@suse.com>

Fixes #1711 

![screenshot-20180419063718-1653x197](https://user-images.githubusercontent.com/188554/38984338-c9597624-439c-11e8-883d-0ab16afa35cc.png)
