### PR TITLE
Fixed hostname copied to clipboard on tags

### DIFF
--- a/app/models/registry.rb
+++ b/app/models/registry.rb
@@ -130,6 +130,13 @@ class Registry < ActiveRecord::Base
     e.message
   end
 
+  # Returns the hostname value that should be priotized and used by the user.
+  # In other words, whenever external hostname is present, that would be returned.
+  # Otherwise the internal hostname is returned.1
+  def reachable_hostname
+    external_hostname.presence || hostname
+  end
+
   protected
 
   # Fetch the tag being pushed through the given target object.

--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -120,9 +120,10 @@ module API
       end
       expose :registry_hostname, documentation: {
         type: Integer,
-        desc: "The repository's registry hostname"
+        desc: "The repository's registry hostname. Prioritizes external hostname value" \
+              "if present, otherwise internal hostname is shown"
       }, if: { type: :internal } do |repository|
-        repository.registry.hostname
+        repository.registry.reachable_hostname
       end
       expose :stars, documentation: {
         type: Integer,

--- a/spec/models/registry_spec.rb
+++ b/spec/models/registry_spec.rb
@@ -107,6 +107,19 @@ describe Registry, type: :model do
     end
   end
 
+  describe "#reachable_hostname" do
+    let!(:registry) { create(:registry, use_ssl: true) }
+    let!(:registry_external) { create(:registry, external_hostname: "external", use_ssl: true) }
+
+    it "returns internal hostname when external not present" do
+      expect(registry.reachable_hostname).to eq registry.hostname
+    end
+
+    it "returns external hostname whenever is present" do
+      expect(registry_external.reachable_hostname).to eq registry_external.external_hostname
+    end
+  end
+
   describe "#reachable" do
     after :each do
       allow_any_instance_of(::Portus::RegistryClient).to receive(:perform_request).and_call_original


### PR DESCRIPTION
The internal hostname was being referring as the hostname to be copied
to the clipboard when the user clicked on the labeled tags. This patch
fixes that by checking if external hostname is set or not. If set,
external hostname will be used instead of internal hostname.

This change affects the API directly because the repository entity is
now using the #reacheable_hostname method that tried to prioritize the
external hostname if set.

Signed-off-by: Vítor Avelino <vavelino@suse.com>

Fixes #1719 