### PR TITLE
Fixed tags url for tags vulnerabilities

### DIFF
--- a/app/assets/javascripts/modules/repositories/components/tags-table-row.vue
+++ b/app/assets/javascripts/modules/repositories/components/tags-table-row.vue
@@ -49,6 +49,7 @@
       canDestroy: Boolean,
       securityEnabled: Boolean,
       state: Object,
+      tagsPath: String,
     },
 
     components: {
@@ -57,7 +58,6 @@
 
     data() {
       return {
-        tagsPath: '/tags',
         prefixID: 'sha256:',
         selected: false,
       };

--- a/app/assets/javascripts/modules/repositories/components/tags-table.vue
+++ b/app/assets/javascripts/modules/repositories/components/tags-table.vue
@@ -20,7 +20,7 @@
         </tr>
       </thead>
       <tbody>
-        <tag-row v-for="tag in filteredTags" :key="tag[0].digest" :tag="tag" :can-destroy="canDestroy" :security-enabled="securityEnabled" :state="state"></tag-row>
+        <tag-row v-for="tag in filteredTags" :key="tag[0].digest" :tag="tag" :can-destroy="canDestroy" :security-enabled="securityEnabled" :state="state" :tags-path="tagsPath"></tag-row>
       </tbody>
     </table>
 
@@ -39,6 +39,7 @@
       canDestroy: Boolean,
       securityEnabled: Boolean,
       state: Object,
+      tagsPath: String,
     },
 
     mixins: [TablePaginatedMixin],

--- a/app/helpers/repositories_helper.rb
+++ b/app/helpers/repositories_helper.rb
@@ -141,4 +141,10 @@ module RepositoriesHelper
   def name_and_link(tr, activity)
     tr.is_a?(Namespace) ? [repo_name(activity), nil] : [tr.name, tr]
   end
+
+  # Returns the prefix tags path. This url doesn't exist in routes because it's not needed.
+  # This is only useful for the UI.
+  def tags_path
+    "#{Rails.application.config.relative_url_root}/tags"
+  end
 end

--- a/app/views/repositories/show.html.slim
+++ b/app/views/repositories/show.html.slim
@@ -64,6 +64,6 @@
 
     .table-responsive.tags
       <tags-not-loaded v-if="notLoaded"></tags-not-loaded>
-      <tags-table v-if="!isLoading && !notLoaded" :tags="tags" :can-destroy="#{can_destroy}" :state="state" :security-enabled="#{security_vulns_enabled?}"></tags-table>
+      <tags-table v-if="!isLoading && !notLoaded" :tags="tags" :can-destroy="#{can_destroy}" :state="state" :security-enabled="#{security_vulns_enabled?}" tags-path="#{tags_path}"></tags-table>
 
 = render "repositories/partials/comments"


### PR DESCRIPTION
The tag vulnerabilities link was broken on setups that used
RAILS_RELATIVE_ROOT_URL because the url path was hardcoded.

This patch fixes that by considering the value of
RAILS_RELATIVE_ROOT_URL and concatenating with 'tags' string.

Signed-off-by: Vítor Avelino <vavelino@suse.com>

Fixes #1718 