### PR TITLE
devise: use a more fine-grained scope for Github

### DIFF
--- a/config/initializers/devise/oauth.rb
+++ b/config/initializers/devise/oauth.rb
@@ -30,7 +30,7 @@ def open_id_fetch_options
 end
 
 def github_fetch_options
-  { scope: "user,read:org" }
+  { scope: "read:user,user:email,read:org" }
 end
 
 def gitlab_fetch_options


### PR DESCRIPTION
We didn't need `user`, but just `read:user` and `user:email`.

Fixes #1790

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>