### PR TITLE
api: explicitly set 204 status instead of nothing

### DIFF
--- a/lib/api/v1/repositories.rb
+++ b/lib/api/v1/repositories.rb
@@ -111,7 +111,8 @@ module API
                failure: [
                  [401, "Authentication fails"],
                  [403, "Authorization fails"],
-                 [404, "Not found"]
+                 [404, "Not found"],
+                 [422, "Unprocessable Entity", API::Entities::ApiErrors]
                ]
 
           delete do
@@ -121,7 +122,11 @@ module API
             destroy_service = ::Repositories::DestroyService.new(current_user)
             destroyed = destroy_service.execute(repository)
 
-            error!(destroy_service.error, 422, header) unless destroyed
+            if destroyed
+              status 204
+            else
+              unprocessable_entity!(destroy_service.error)
+            end
           end
         end
       end

--- a/lib/api/v1/tags.rb
+++ b/lib/api/v1/tags.rb
@@ -51,7 +51,8 @@ module API
                failure: [
                  [401, "Authentication fails"],
                  [403, "Authorization fails"],
-                 [404, "Not found"]
+                 [404, "Not found"],
+                 [422, "Unprocessable Entity", API::Entities::ApiErrors]
                ]
 
           delete do
@@ -61,7 +62,11 @@ module API
             service = ::Tags::DestroyService.new(current_user)
             destroyed = service.execute(tag)
 
-            error!({ "errors" => service.error }, 422, header) unless destroyed
+            if destroyed
+              status 204
+            else
+              unprocessable_entity!(service.error)
+            end
           end
         end
       end


### PR DESCRIPTION
If we don't specify what Grape should do/return when we have an empty
response, an exception is thrown because it's expected something and
it's actually nil.

This was fixed in latest implemented features but there were still
legacy code with this problem.

Signed-off-by: Vítor Avelino <vavelino@suse.com>