### PR TITLE
webhooks: added permissions on webhooks

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -259,6 +259,18 @@ user_permission:
   manage_namespace:
     enabled: true
 
+  # Allow users to create webhooks if they are an owner of the namespace
+  # containing it. If this is disabled, only an admin will be able to do
+  # this. This defaults to true.
+  create_webhook:
+    enabled: true
+
+  # Allow users to manage webhooks if they are an owner of the namespace
+  # containing it. If this is disabled, only an admin will be able to do
+  # this. This defaults to true.
+  manage_webhook:
+    enabled: true
+
   # Define a push policy. There are three possible values:
   #   1. allow-teams (default): leaves push policy at the team level: owners and
   #      contributors can push. Portus administrators will also be able to push.

--- a/spec/policies/webhook_policy_spec.rb
+++ b/spec/policies/webhook_policy_spec.rb
@@ -30,6 +30,55 @@ describe WebhookPolicy do
     @registry = create(:registry)
   end
 
+  context "owners can also create or update" do
+    permissions :create? do
+      it "allows an admin to create a webook" do
+        expect(subject).to permit(@admin, webhook)
+      end
+
+      it "allows an admin to create a webhook" do
+        expect(subject).to permit(owner, webhook)
+      end
+    end
+
+    permissions :update? do
+      it "allows an admin to update a webook" do
+        expect(subject).to permit(@admin, webhook)
+      end
+
+      it "allows an admin to update a webhook" do
+        expect(subject).to permit(owner, webhook)
+      end
+    end
+  end
+
+  context "only admins can create or update" do
+    before do
+      APP_CONFIG["user_permission"]["create_webhook"] = false
+      APP_CONFIG["user_permission"]["manage_webhook"] = false
+    end
+
+    permissions :create? do
+      it "allows an admin to create a webook" do
+        expect(subject).to permit(@admin, webhook)
+      end
+
+      it "does not allow an admin to create a webhook" do
+        expect(subject).not_to permit(owner, webhook)
+      end
+    end
+
+    permissions :update? do
+      it "allows an admin to update a webook" do
+        expect(subject).to permit(@admin, webhook)
+      end
+
+      it "does not allow an admin to update a webhook" do
+        expect(subject).not_to permit(owner, webhook)
+      end
+    end
+  end
+
   permissions :toggle_enabled? do
     it "allows admin to change it" do
       expect(subject).to permit(@admin, webhook)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -68,6 +68,10 @@ RSpec.configure do |config|
       "manage_namespace"  => { "enabled" => true },
       # This allows non-admins to create namespaces
       "create_namespace"  => { "enabled" => true },
+      # This allows non-admins to modify webhooks
+      "manage_webhook"    => { "enabled" => true },
+      # This allows non-admins to create webhooks
+      "create_webhook"    => { "enabled" => true },
       # This allows non-admins to modify teams
       "manage_team"       => { "enabled" => true },
       # This allows non-admins to create teams


### PR DESCRIPTION
Before this commit, permissions on webhooks were coupled with
namespaces, which was not desirable for some users.

Fixes #1109

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>