### PR TITLE
config: added pagination options

### DIFF
--- a/app/assets/javascripts/config.js
+++ b/app/assets/javascripts/config.js
@@ -1,0 +1,4 @@
+export default {
+  pagination: window.PAGINATION,
+  apiUrl: window.API_URL,
+};

--- a/app/assets/javascripts/plugins/config.js
+++ b/app/assets/javascripts/plugins/config.js
@@ -1,0 +1,11 @@
+import config from '~/config';
+
+export default function install(Vue) {
+  Object.defineProperties(Vue.prototype, {
+    $config: {
+      get() {
+        return config;
+      },
+    },
+  });
+}

--- a/app/assets/javascripts/shared/components/table-pagination.vue
+++ b/app/assets/javascripts/shared/components/table-pagination.vue
@@ -34,7 +34,7 @@
 
     data() {
       return {
-        showMore: 2,
+        beforeAfter: this.$config.pagination.beforeAfter,
       };
     },
 
@@ -58,8 +58,8 @@
           return [];
         }
 
-        let minRange = this.currentPage - this.showMore;
-        let maxRange = this.currentPage + this.showMore;
+        let minRange = this.currentPage - this.beforeAfter;
+        let maxRange = this.currentPage + this.beforeAfter;
 
         const distanceLeft = Math.abs(1 - minRange);
         const distanceRight = Math.abs(this.totalPages - maxRange);

--- a/app/assets/javascripts/shared/mixins/table-paginated.js
+++ b/app/assets/javascripts/shared/mixins/table-paginated.js
@@ -7,10 +7,6 @@ const { set } = Vue;
 
 export default {
   props: {
-    limit: {
-      type: Number,
-      default: 10,
-    },
     prefix: {
       type: String,
       default: '',
@@ -23,6 +19,7 @@ export default {
 
   data() {
     return {
+      limit: this.$config.pagination.limit,
       currentPage: 1,
     };
   },

--- a/app/assets/javascripts/vue-shared.js
+++ b/app/assets/javascripts/vue-shared.js
@@ -2,15 +2,19 @@ import Vue from 'vue';
 import VueResource from 'vue-resource';
 import Vuelidate from 'vuelidate';
 
-import EventBus from './plugins/eventbus';
-import Alert from './plugins/alert';
+import EventBus from '~/plugins/eventbus';
+import Alert from '~/plugins/alert';
+import Config from '~/plugins/config';
+
+import configObj from '~/config';
 
 Vue.use(Vuelidate);
 Vue.use(VueResource);
 Vue.use(EventBus);
 Vue.use(Alert);
+Vue.use(Config);
 
-Vue.http.options.root = window.API_URL;
+Vue.http.options.root = configObj.apiUrl;
 
 Vue.http.interceptors.push((_request, next) => {
   window.$.active = window.$.active || 0;

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -57,6 +57,16 @@ module ApplicationHelper
     User.not_portus.none? && APP_CONFIG.enabled?("first_user_admin") && Portus::LDAP.enabled?
   end
 
+  # Returns pagination limit config
+  def pagination_limit
+    APP_CONFIG["pagination"]["limit"]
+  end
+
+  # Returns pagination before after config
+  def pagination_before_after
+    APP_CONFIG["pagination"]["before_after"]
+  end
+
   # Render markdown to safe HTML.
   # Images, unsafe link protocols and styles are not allowed to render.
   # HTML-Tags will be filtered.

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -28,8 +28,7 @@ html
     meta content="/favicon/browserconfig.xml" name="msapplication-config"
     meta content="#205683" name="theme-color"
 
-    javascript:
-      window.API_URL = '//#{app_path}';
+    = render "shared/config"
     = javascript_include_tag("unmanaged")
     = javascript_include_tag(*webpack_asset_paths("application"))
     = yield :js_header

--- a/app/views/shared/_config.html.slim
+++ b/app/views/shared/_config.html.slim
@@ -1,0 +1,6 @@
+javascript:
+  window.API_URL = '//#{app_path}';
+  window.PAGINATION = {
+    limit: #{pagination_limit},
+    beforeAfter: #{pagination_before_after}
+  };

--- a/config/config.yml
+++ b/config/config.yml
@@ -340,3 +340,12 @@ background:
     #     empty. This is the default value since it's deemed to be the most
     #     common use-case.
     strategy: initial
+
+# Pagination configuration
+pagination:
+  # Number of entries to be listed per page
+  limit: 10
+
+  # Number of pages to be showed before and after the current one
+  # e,g.: Prev 1 2 [3] 4 5 Next
+  before_after: 2

--- a/spec/javascripts/modules/repositories/tags-table.spec.js
+++ b/spec/javascripts/modules/repositories/tags-table.spec.js
@@ -28,9 +28,15 @@ describe('tags-table', () => {
   ]);
 
   beforeEach(() => {
+    const $config = {
+      pagination: {
+        beforeAfter: 2,
+        limit: 3,
+      },
+    };
+
     wrapper = mount(TagsTable, {
       propsData: {
-        limit: 3,
         currentPage: 2,
         state: {
           selectedTags: [],
@@ -41,6 +47,7 @@ describe('tags-table', () => {
         securityEnabled: true,
       },
       mocks: {
+        $config,
         $bus: {
           $emit: sinon.spy(),
         },

--- a/spec/javascripts/shared/table-pagination.spec.js
+++ b/spec/javascripts/shared/table-pagination.spec.js
@@ -6,11 +6,16 @@ describe('table-pagination', () => {
   let wrapper;
 
   beforeEach(() => {
+    const $config = { pagination: { beforeAfter: 2 } };
+
     wrapper = mount(TablePagination, {
       propsData: {
         total: 10,
         itensPerPage: 3,
         currentPage: 1,
+      },
+      mocks: {
+        $config,
       },
     });
   });

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -100,6 +100,11 @@ RSpec.configure do |config|
       "contributors" => false
     }
 
+    APP_CONFIG["pagination"] = {
+      "limit"        => 10,
+      "before_after" => 2
+    }
+
     Rails.cache.write("portus-checks", nil)
   end
 


### PR DESCRIPTION
So far the pagination and number of shown pages before and after current
page were hard coded and not configurable.

With this the user can now choose from a configuration perspective how
he wants to show their tables.

Signed-off-by: Vítor Avelino <vavelino@suse.com>

Fixes #1375 