### PR TITLE
ldap: fixed a couple of bugs around SSL support

### DIFF
--- a/bin/check_services.rb
+++ b/bin/check_services.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+##
+# TODO: this should be re-purposed once we support health for LDAP
+
+require "net/ldap"
+
+puts case Portus::DB.ping
+     when :ready
+       "DB_READY"
+     when :empty
+       "DB_EMPTY"
+     when :missing
+       "DB_MISSING"
+     when :down
+       "DB_DOWN"
+     else
+       "DB_UNKNOWN"
+     end
+
+params = { host: APP_CONFIG["ldap"]["hostname"], port: APP_CONFIG["ldap"]["port"] }
+
+# Fill authentication details.
+if APP_CONFIG.enabled?("ldap.authentication")
+  params[:auth] = {
+    method:   :simple,
+    username: APP_CONFIG["ldap"]["authentication"]["bind_dn"],
+    password: APP_CONFIG["ldap"]["authentication"]["password"]
+  }
+end
+
+# Fill TLS options with the given env. variables or assume defaults.
+if APP_CONFIG["ldap"]["encryption"]["method"].present?
+  params[:encryption] = { method: APP_CONFIG["ldap"]["encryption"]["method"].to_sym }
+
+  if APP_CONFIG["ldap"]["encryption"]["options"]["ca_file"].present?
+    params[:encryption][:tls_options] = {
+      ca_file:     APP_CONFIG["ldap"]["encryption"]["options"]["ca_file"],
+      ssl_version: APP_CONFIG["ldap"]["encryption"]["options"]["ssl_version"]
+    }
+  else
+    params[:encryption][:tls_options] = OpenSSL::SSL::SSLContext::DEFAULT_PARAMS
+  end
+end
+
+if APP_CONFIG.disabled?("ldap")
+  puts "LDAP_DISABLED"
+else
+  ldap = Net::LDAP.new(params)
+  begin
+    if ldap.bind
+      puts "LDAP_OK"
+    else
+      puts "LDAP_FAIL"
+    end
+  rescue Net::LDAP::Error
+    puts "LDAP_FAIL"
+  end
+end

--- a/bin/test-integration.sh
+++ b/bin/test-integration.sh
@@ -22,85 +22,145 @@ if [ ! -f "$ROOT_DIR/bin/integration/init" ]; then
 fi
 chmod +x $ROOT_DIR/bin/integration/init
 
-# Generate the build directory.
-bundle exec rails runner $ROOT_DIR/bin/integration/integration.rb
-
 ##
-# Start containers.
+# Functions for starting/cleaning containers and running tests.
 
 # It will kill and remove all containers related to integration testing.
 cleanup_containers() {
     pushd "$ROOT_DIR/build"
-    docker-compose kill
-    docker-compose rm -f
+    docker-compose -f $1 kill
+    docker-compose -f $1 rm -f
     popd
 }
 
-if [[ ! "$SKIP_ENV_TESTS" ]]; then
-    cleanup_containers
-    pushd "$ROOT_DIR/build"
-    docker-compose up -d
-    popd
+# Start the containers depending on the profile to be picked.
+start_containers() {
+    if [[ ! "$SKIP_ENV_TESTS" ]]; then
+        cleanup_containers $1
+        pushd "$ROOT_DIR/build"
+        docker-compose -f $1 up -d
+        popd
 
-    # We will wait 10 minutes until everything is properly set up.
-    TIMEOUT=600
-    COUNT=0
-    RETRY=1
+        # We will wait 10 minutes until everything is properly set up.
+        TIMEOUT=600
+        COUNT=0
+        RETRY=1
 
-    while [ $RETRY -ne 0 ]; do
-        msg=$(SKIP_MIGRATION=1 docker exec $CNAME portusctl exec rails r /srv/Portus/bin/check_db.rb)
-        case $(echo "$msg" | grep DB) in
-            "DB_READY")
-                echo "Database ready"
+        DB=0
+        LDAP=0
+
+        while [ $RETRY -ne 0 ]; do
+            msg=$(SKIP_MIGRATION=1 docker exec $CNAME portusctl exec rails r /srv/Portus/bin/check_services.rb)
+            case $(echo "$msg" | grep DB) in
+                "DB_READY")
+                    DB=1
+                    ;;
+                *)
+                    echo "Database is not ready yet:"
+                    echo $msg
+                    ;;
+            esac
+
+            case $(echo "$msg" | grep LDAP) in
+                "LDAP_DISABLED"|"LDAP_OK")
+                    LDAP=1
+                    ;;
+                *)
+                    echo "LDAP is not ready yet"
+                    ;;
+            esac
+
+            if (( "$DB" == "1" )) && (( "$LDAP" == "1" )); then
+                echo "Let's go!"
                 break
-                ;;
-            *)
-                echo "Database is not ready yet:"
-                echo $msg
-                ;;
-        esac
+            fi
 
-        if [ "$COUNT" -ge "$TIMEOUT" ]; then
-            echo "[integration] Timeout  reached, exiting with error"
-            cleanup_containers
-            exit 1
+            if [ "$COUNT" -ge "$TIMEOUT" ]; then
+                echo "[integration] Timeout  reached, exiting with error"
+                cleanup_containers $1
+                exit 1
+            fi
+
+            sleep 5
+            COUNT=$((COUNT+5))
+        done
+
+        echo "You may want to set the 'SKIP_ENV_TESTS' env. variable for successive runs..."
+
+        # Travis oddities...
+        if [ ! -z "$CI" ]; then
+            sleep 10
         fi
-
-        sleep 5
-        COUNT=$((COUNT+5))
-    done
-
-    echo "You may want to set the 'SKIP_ENV_TESTS' env. variable for successive runs..."
-
-    # Travis oddities...
-    if [ ! -z "$CI" ]; then
-        sleep 10
     fi
-fi
+}
+
+# Run tests.
+run_tests() {
+    tests=()
+    if [[ -z "$TESTS" ]]; then
+        tests=($ROOT_DIR/spec/integration/$1*.bats)
+    else
+        for f in $TESTS; do
+            tests+=("$ROOT_DIR/spec/integration/$1$f.bats")
+        done
+    fi
+    echo "Running: ${tests[*]}"
+    bats -t ${tests[*]}
+}
+
+##
+# Setup environment
+
+# We build the development image only once.
+export PORTUS_INTEGRATION_BUILD_IMAGE=false
+pushd $ROOT_DIR
+docker rmi -f opensuse/portus:development
+docker build -t opensuse/portus:development .
+popd
 
 # Integration tests will play with the following images
 export DEVEL_NAME="busybox"
 export DEVEL_IMAGE="$DEVEL_NAME:latest"
 docker pull $DEVEL_IMAGE
 
-# Run tests.
-tests=()
-if [[ -z "$TESTS" ]]; then
-    tests=($ROOT_DIR/spec/integration/*.bats)
+# Remove current build directory
+rm -rf "$ROOT_DIR/build"
+
+##
+# Profiles
+
+profiles=()
+if [[ -z "$PROFILES" ]]; then
+    profiles=("clair" "ldap")
 else
-    for f in $TESTS; do
-        tests+=("$ROOT_DIR/spec/integration/$f.bats")
+    for p in $PROFILES; do
+        profiles+=("$p")
     done
 fi
-set +e
-echo "Running: ${tests[*]}"
-bats -t ${tests[*]}
-status=$?
-set -e
 
-# Tear down
-if [[ "$TEARDOWN_TESTS" ]]; then
-    cleanup_containers
-fi
+##
+# Actual run.
 
-exit $status
+for p in ${profiles[*]}; do
+    export PORTUS_INTEGRATION_PROFILE="$p"
+    bundle exec rails runner $ROOT_DIR/bin/integration/integration.rb
+    start_containers "docker-compose.$p.yml"
+
+    prefix=""
+    if [ "$p" != "clair" ]; then
+        prefix="$p/"
+    fi
+
+    set +e
+    run_tests $prefix
+    status=$?
+    set -e
+
+    cleanup_containers "docker-compose.$p.yml"
+
+    if [ $status -ne 0 ]; then
+        exit $status
+    fi
+done
+
+exit 0

--- a/config/config.yml
+++ b/config/config.yml
@@ -51,9 +51,21 @@ ldap:
   hostname: "ldap_hostname"
   port: 389
 
-  # Available options: "plain", "simple_tls" and "starttls". The default is
-  # "plain", the recommended is "starttls".
+  # Available options: "plain", "simple_tls" and "start_tls".
+  # TODO: deprecated in favor of `encryption.method`.
   method: "plain"
+
+  # Encryption options
+  encryption:
+    # Available methods: "plain", "simple_tls" and "start_tls".
+    method: ""
+    options:
+      # The CA file to be accepted by the LDAP server. If none is provided, then
+      # the default parameters from the host will be sent.
+      ca_file: ""
+
+      # Protocol version.
+      ssl_version: "TLSv1_2"
 
   # The base where users are located (e.g. "ou=users,dc=example,dc=com").
   base: ""

--- a/examples/compose/docker-compose.ldap.yml
+++ b/examples/compose/docker-compose.ldap.yml
@@ -1,0 +1,127 @@
+version: "2"
+
+services:
+  portus:
+    image: opensuse/portus:head
+    environment:
+      - PORTUS_MACHINE_FQDN_VALUE=${MACHINE_FQDN}
+      - PORTUS_CHECK_SSL_USAGE_ENABLED=false
+
+      - CCONFIG_PREFIX=PORTUS
+
+      - PORTUS_DB_HOST=db
+      - PORTUS_DB_DATABASE=portus_production
+      - PORTUS_DB_PASSWORD=${DATABASE_PASSWORD}
+      - PORTUS_DB_POOL=5
+
+      # Secrets. It can possibly be handled better with Swarm's secrets.
+      - PORTUS_SECRET_KEY_BASE=${SECRET_KEY_BASE}
+      - PORTUS_KEY_PATH=/certificates/portus.key
+      - PORTUS_PASSWORD=${PORTUS_PASSWORD}
+
+      # Since we have no nginx in insecure mode, portus have to
+      # serve the static files
+      - RAILS_SERVE_STATIC_FILES=true
+
+      # LDAP
+      - PORTUS_LDAP_ENABLED=true
+      - PORTUS_LDAP_HOSTNAME=ldap
+      - PORTUS_LDAP_PORT=389
+      - PORTUS_LDAP_UID=uid
+      - PORTUS_LDAP_BASE=dc=example,dc=org
+      - PORTUS_LDAP_FILTER=
+      - PORTUS_LDAP_AUTHENTICATION_ENABLED=true
+      - PORTUS_LDAP_AUTHENTICATION_BIND_DN=cn=admin,dc=example,dc=org
+      - PORTUS_LDAP_AUTHENTICATION_PASSWORD=admin
+      - PORTUS_LDAP_ENCRYPTION_METHOD=start_tls
+      - PORTUS_LDAP_ENCRYPTION_OPTIONS_CA_FILE=/ldap-certificates/ca.pem
+      - PORTUS_LDAP_ENCRYPTION_OPTIONS_SSL_VERSION=TLSv1_2
+    ports:
+      - 3000:3000
+    depends_on:
+      - db
+      - ldap
+    links:
+      - db
+      - ldap
+    volumes:
+      - ./secrets:/certificates:ro
+      - ./secrets/ldap:/ldap-certificates:ro
+
+  background:
+    image: opensuse/portus:head
+    depends_on:
+      - portus
+      - db
+    environment:
+      # Theoretically not needed, but cconfig's been buggy on this...
+      - CCONFIG_PREFIX=PORTUS
+      - PORTUS_MACHINE_FQDN_VALUE=${MACHINE_FQDN}
+
+      # DB. The password for the database should definitely not be here. You are
+      # probably better off with Docker Swarm secrets.
+      - PORTUS_DB_HOST=db
+      - PORTUS_DB_DATABASE=portus_production
+      - PORTUS_DB_PASSWORD=${DATABASE_PASSWORD}
+      - PORTUS_DB_POOL=5
+
+      # Secrets. It can possibly be handled better with Swarm's secrets.
+      - PORTUS_SECRET_KEY_BASE=${SECRET_KEY_BASE}
+      - PORTUS_KEY_PATH=/certificates/portus.key
+      - PORTUS_PASSWORD=${PORTUS_PASSWORD}
+
+      - PORTUS_BACKGROUND=true
+    links:
+      - db
+    volumes:
+      - ./secrets:/certificates:ro
+
+  db:
+    image: library/mariadb:10.0.23
+    command: mysqld --character-set-server=utf8 --collation-server=utf8_unicode_ci --init-connect='SET NAMES UTF8;' --innodb-flush-log-at-trx-commit=0
+    environment:
+      - MYSQL_DATABASE=portus_production
+
+      # Again, the password shouldn't be handled like this.
+      - MYSQL_ROOT_PASSWORD=${DATABASE_PASSWORD}
+    volumes:
+      - /var/lib/portus/mariadb:/var/lib/mysql
+
+  registry:
+    image: library/registry:2.6
+    environment:
+      # Authentication
+      REGISTRY_AUTH_TOKEN_REALM: http://${MACHINE_FQDN}:3000/v2/token
+      REGISTRY_AUTH_TOKEN_SERVICE: ${MACHINE_FQDN}:5000
+      REGISTRY_AUTH_TOKEN_ISSUER: ${MACHINE_FQDN}
+      REGISTRY_AUTH_TOKEN_ROOTCERTBUNDLE: /secrets/portus.crt
+
+      # Portus endpoint
+      REGISTRY_NOTIFICATIONS_ENDPOINTS: >
+        - name: portus
+          url: http://${MACHINE_FQDN}:3000/v2/webhooks/events
+          timeout: 2000ms
+          threshold: 5
+          backoff: 1s
+    volumes:
+      - /var/lib/portus/registry:/var/lib/registry
+      - ./secrets:/secrets:ro
+      - ./registry/config.yml:/etc/docker/registry/config.yml:ro
+    ports:
+      - 5000:5000
+      - 5001:5001 # required to access debug service
+    links:
+      - portus:portus
+
+  ldap:
+    image: osixia/openldap:1.2.0
+    command: --copy-service
+    hostname: ldap
+    environment:
+      - LDAP_TLS_ENFORCE=true
+      - LDAP_TLS_CRT_FILENAME=ldap.crt
+      - LDAP_TLS_KEY_FILENAME=ldap.key
+      - LDAP_TLS_CA_CRT_FILENAME=ca.crt
+      - LDAP_TLS_VERIFY_CLIENT=try
+    volumes:
+      - ./secrets/ldap:/container/service/slapd/assets/certs:ro

--- a/lib/portus/test.rb
+++ b/lib/portus/test.rb
@@ -12,6 +12,7 @@ module ::Portus
       background: LOCAL_IMAGE,
       db:         "library/mariadb:10.0.23",
       clair:      "quay.io/coreos/clair:v2.0.1",
+      ldap:       "osixia/openldap:1.2.0",
       portus:     LOCAL_IMAGE,
       postgres:   "library/postgres:10-alpine",
       registry:   "library/registry:2.6"

--- a/spec/integration/helpers/ldap.rb
+++ b/spec/integration/helpers/ldap.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "portus/ldap"
+
+##
+# Define a class that mocks stuff like `params` and exit methods.
+
+class IntegrationLDAP < Portus::LDAP
+  attr_reader :params
+  attr_accessor :session
+
+  def initialize(params)
+    @params  = params
+    @session = {}
+  end
+
+  def fail(_obj)
+    exit 1
+  end
+
+  alias fail! fail
+
+  def success!(user)
+    puts "name: #{user.username}, email: #{user.email}, " \
+         "admin: #{user.admin}, display_name: #{user.display_name}"
+    exit 0
+  end
+end
+
+##
+# Setup APP_CONFIG according to some possible modifications.
+
+originals = {}
+
+ARGV[2].to_s.split(",").each do |env|
+  k, val = env.split("=")
+
+  *key, last = k.split(":")
+  hsh = APP_CONFIG["ldap"]
+  key.each { |ke| hsh = hsh[ke] }
+
+  originals[k] = hsh[last].dup
+  hsh[last] = val
+end
+
+# Regardless of what happens in the end, set the APP_CONFIG to the original
+# values.
+at_exit do
+  originals.each do |k, v|
+    *key, last = k.split(":")
+    hsh = APP_CONFIG["ldap"]
+    key.each { |ke| hsh = hsh[ke] }
+    hsh[last] = v
+  end
+end
+
+##
+# Try to authenticate!
+
+ldap = IntegrationLDAP.new(user: { username: ARGV.first.dup, password: ARGV[1].dup })
+ldap.authenticate!

--- a/spec/integration/ldap/login.bats
+++ b/spec/integration/ldap/login.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats -t
+
+load ../helpers
+
+function setup() {
+    __setup ldap
+}
+
+@test "LDAP: proper user can login" {
+    helper_runner ldap.rb jverdaguer folgueroles
+    [ $status -eq 0 ]
+    [[ "${lines[-1]}" =~ "name: jverdaguer, email: , admin: true, display_name:" ]]
+}
+
+@test "LDAP: bad password" {
+    helper_runner ldap.rb jverdaguer vic
+    [ $status -eq 1 ]
+    [[ "${lines[-2]}" =~ "Invalid Credentials (code 49)" ]]
+}
+
+@test "LDAP: unknown user" {
+    helper_runner ldap.rb jcarner arbres
+    [ $status -eq 1 ]
+    [[ "${lines[-2]}" =~ "Could not find user 'jcarner'" ]]
+}
+
+@test "LDAP: certificate signed by unknown CA" {
+    helper_runner ldap.rb jverdaguer folgueroles encryption:options:ca_file=""
+    [ $status -eq 1 ]
+    [[ "${lines[-2]}" =~ "certificate verify failed" ]]
+}
+
+@test "LDAP: no certificate was provided" {
+    helper_runner ldap.rb jverdaguer folgueroles encryption:method=""
+    [ $status -eq 1 ]
+    [[ "${lines[-2]}" =~ "Confidentiality Required (code 13)" ]]
+}
+
+@test "LDAP: wrong SSL version" {
+    helper_runner ldap.rb jverdaguer folgueroles encryption:options:ssl_version="TLSv1_1"
+    [ $status -eq 1 ]
+    [[ "${lines[-2]}" =~ "SSL_connect SYSCALL" ]]
+}
+
+@test "LDAP: could not connect to server" {
+    helper_runner ldap.rb jverdaguer folgueroles hostname="unknown"
+    [ $status -eq 1 ]
+    [[ "${lines[-2]}" =~ "getaddrinfo: Name or service not known" ]]
+}
+
+@test "LDAP: wrong authentication" {
+    helper_runner ldap.rb jverdaguer folgueroles authentication:password="wrong"
+    [ $status -eq 1 ]
+    [[ "${lines[-2]}" =~ "No Such Object (code 32)" ]]
+}

--- a/spec/integration/profiles/ldap.rb
+++ b/spec/integration/profiles/ldap.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "net/ldap"
+require_relative "shared"
+
+clean_db!
+
+##
+# Set parameters and initialize LDAP object.
+
+params = { host: APP_CONFIG["ldap"]["hostname"], port: APP_CONFIG["ldap"]["port"] }
+
+# Fill authentication details.
+if APP_CONFIG.enabled?("ldap.authentication")
+  params[:auth] = {
+    method:   :simple,
+    username: APP_CONFIG["ldap"]["authentication"]["bind_dn"],
+    password: APP_CONFIG["ldap"]["authentication"]["password"]
+  }
+end
+
+# Fill TLS options with the given env. variables or assume defaults.
+if APP_CONFIG["ldap"]["encryption"]["method"].present?
+  params[:encryption] = { method: APP_CONFIG["ldap"]["encryption"]["method"].to_sym }
+
+  if APP_CONFIG["ldap"]["encryption"]["options"]["ca_file"].present?
+    params[:encryption][:tls_options] = {
+      ca_file:     APP_CONFIG["ldap"]["encryption"]["options"]["ca_file"],
+      ssl_version: APP_CONFIG["ldap"]["encryption"]["options"]["ssl_version"]
+    }
+  else
+    params[:encryption][:tls_options] = OpenSSL::SSL::SSLContext::DEFAULT_PARAMS
+  end
+end
+
+ldap = Net::LDAP.new(params)
+
+##
+# Add a test user.
+
+ldap.add(
+  dn:         "uid=jverdaguer,dc=example,dc=org",
+  attributes: {
+    cn:           "Jacint Verdaguer",
+    givenName:    "Jacint",
+    sn:           "Verdaguer",
+    displayName:  "Jacint Verdaguer",
+    objectclass:  %w[top inetorgperson],
+    userPassword: Net::LDAP::Password.generate(:md5, "folgueroles"),
+    mail:         "jverdaguer@renaixenca.cat"
+  }
+)
+
+puts "#{ldap.get_operation_result.message} (code #{ldap.get_operation_result.code})."
+puts "Parameters used: #{params}" if ldap.get_operation_result.code != 0


### PR DESCRIPTION
This commit fixes a couple of bugs present in both master and 2.3:

1. We didn't implement some options that needed to be passed to the LDAP
   backend to fully support SSL connections. This has been addressed
   also in the configuration, but without breaking existing
   installations (e.g. the `method` attribute from 2.3 has been left
   untouched). This will be addressed in later commits of the master
   branch (so in 2.4 users should adapt to this change).
2. We were relying on Devise's translations for failures, but some of
   them were not available. This has been addressed and improved: the
   error message will be more on point and more informative to end
   users.

There is still room for improvement, but we can do it in later commits:
let's keep this commit to the point so it can be cherry-picked into the
2.3 branch.

Fixes #1746
Fixes #1774

bsc#1073232

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>