### PR TITLE
ui: added enabled toggle to webhooks edit form

### DIFF
--- a/app/assets/javascripts/modules/webhooks/components/edit-form.vue
+++ b/app/assets/javascripts/modules/webhooks/components/edit-form.vue
@@ -1,5 +1,5 @@
 <template>
-  <form id="new-webhook-form" role="form" class="form-horizontal" ref="form" @submit.prevent="onSubmit">
+  <form id="edit-webhook-form" role="form" class="form-horizontal" ref="form" @submit.prevent="onSubmit">
     <div class="form-group has-feedback" :class="{ 'has-error': $v.webhookCopy.name.$error }">
       <label for="webhook_name" class="control-label col-md-2">Name</label>
       <div class="col-md-7">
@@ -50,6 +50,15 @@
       <label for="webhook_password" class="control-label col-md-2">Password</label>
       <div class="col-md-7">
         <input placeholder="Password for authentication" type="text" name="webhook[password]" id="webhook_password" class="form-control" v-model.trim="webhookCopy.password">
+      </div>
+    </div>
+    <div class="form-group">
+      <label for="webhook_enabled" class="control-label col-md-2">Enabled</label>
+      <div class="col-md-7">
+        <span @click.prevent="webhookCopy.enabled=!webhookCopy.enabled" >
+          <i class="fa fa-2x fa-toggle-on toggle" title="Click to disable" v-if="webhookCopy.enabled"></i>
+          <i class="fa fa-2x fa-toggle-off toggle" title="Click to enable" v-else></i>
+        </span>
       </div>
     </div>
     <div class="form-group">

--- a/app/assets/javascripts/modules/webhooks/components/info.vue
+++ b/app/assets/javascripts/modules/webhooks/components/info.vue
@@ -25,6 +25,10 @@
         <th>Password</th>
         <td>{{ password }}</td>
       </tr>
+      <tr>
+        <th>Status</th>
+        <td>{{ status }}</td>
+      </tr>
     </tbody>
   </table>
 </template>
@@ -52,6 +56,14 @@
         }
 
         return '—';
+      },
+
+      status() {
+        if (this.webhook.enabled) {
+          return 'Enabled';
+        }
+
+        return 'Disabled';
       },
     },
   };

--- a/app/assets/stylesheets/components/webhooks/edit-form.scss
+++ b/app/assets/stylesheets/components/webhooks/edit-form.scss
@@ -1,0 +1,10 @@
+#edit-webhook-form {
+  .toggle {
+    line-height: 34px;
+    cursor: pointer;
+  }
+
+  .fa-toggle-on {
+    color: $first-colour;
+  }
+}

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -135,7 +135,8 @@ class WebhooksController < ApplicationController
       :request_method,
       :content_type,
       :username,
-      :password
+      :password,
+      :enabled
     )
   end
 end


### PR DESCRIPTION
The only way of enabling a webhook was through the index page. Now user
can change that while editing other info.

Signed-off-by: Vítor Avelino <vavelino@suse.com>

![screenshot-20180523080738-501x491](https://user-images.githubusercontent.com/188554/40420984-8f8f6320-5e60-11e8-87d3-6254c1ddeb25.png)
![screenshot-20180523080801-518x301](https://user-images.githubusercontent.com/188554/40420985-8fbfccd6-5e60-11e8-928c-94dca7c4ad18.png)

