### PR TITLE
health: catch all exceptions for registries

### DIFF
--- a/lib/portus/health_checks/registry.rb
+++ b/lib/portus/health_checks/registry.rb
@@ -15,8 +15,8 @@ module Portus
 
         res = ::Registry.get.client.reachable?
         ["registry is#{res ? "" : " not"} reachable", res]
-
-        # TODO: rescue ::Portus::RequestError instead of simply bailing
+      rescue ::Portus::RequestError => e
+        [e.to_s, false]
       end
     end
   end

--- a/lib/portus/request_error.rb
+++ b/lib/portus/request_error.rb
@@ -8,7 +8,7 @@ module ::Portus
     # Given an inner exception and a message, it builds up a common error
     # message.
     def initialize(exception:, message:)
-      @msg = "#{exception.class.name}: #{message}."
+      @msg = "#{exception.class.name}: #{message}"
       Rails.logger.error @msg
     end
 

--- a/spec/integration/health.bats
+++ b/spec/integration/health.bats
@@ -1,0 +1,23 @@
+#!/usr/bin/env bats -t
+
+load helpers
+
+function setup() {
+    __setup minimal
+}
+
+@test "health runs just fine" {
+    helper_runner curl.rb /api/v1/health
+    [[ "${lines[-2]}" =~ "database is up-to-date" ]]
+    [[ "${lines[-2]}" =~ "clair is reachable" ]]
+    [[ "${lines[-2]}" =~ "registry is reachable" ]]
+}
+
+@test "health reports an invalid registry" {
+    # Modify the registry hostname to some unknown hostname.
+    ruby_puts "Registry.get.update(hostname:\"wrong.whatever\")"
+
+    helper_runner curl.rb /api/v1/health
+    [ $status -eq 1 ]
+    [[ "${lines[-2]}" =~ "SocketError: connection refused" ]]
+}

--- a/spec/lib/portus/request_error_spec.rb
+++ b/spec/lib/portus/request_error_spec.rb
@@ -6,6 +6,6 @@ describe ::Portus::RequestError do
 
     expect do
       raise ::Portus::RequestError.new(exception: e, message: "something")
-    end.to raise_error(::Portus::RequestError, "StandardError: something.")
+    end.to raise_error(::Portus::RequestError, "StandardError: something")
   end
 end


### PR DESCRIPTION
The fact that `RegistryClient.reachable?` might raise an exception is
fine in some situations on the API, but it prevents us from knowing from
other errors, and it also makes things harder in other places of the
code that rely on this check. Hence, let's rescue this exception and
return its value properly.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>