### PR TITLE
tasks: remove 2.3 from the integration matrix

### DIFF
--- a/lib/tasks/test/integration.rake
+++ b/lib/tasks/test/integration.rake
@@ -19,13 +19,6 @@ SUPPORTED_REGISTRIES = [
 ].freeze
 
 PRODUCTION = [
-  # Stable release: 2.3
-  {
-    background: "opensuse/portus:2.3",
-    portus:     "opensuse/portus:2.3"
-  },
-
-  # Master.
   {
     background: "opensuse/portus:head",
     portus:     "opensuse/portus:head"


### PR DESCRIPTION
We've introduced the new `bin/health.rb` file, and that makes
integration tests fail under 2.3. I think that it is not worth
it to test 2.3 in the master branch, since integration tests for
2.3 are available anyways on the v2.3 branch.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>