### PR TITLE
docker: moved production images into this repo

### DIFF
--- a/bin/check_db.rb
+++ b/bin/check_db.rb
@@ -8,9 +8,6 @@
 #   * `DB_MISSING`: the database has not been created.
 #   * `DB_DOWN`: cannot connect to the database.
 #   * `DB_UNKNOWN`: unknown error.
-#
-# Originally included in the https://github.com/openSUSE/docker-containers
-# repository under the same license.
 
 require "portus/db"
 

--- a/bin/test-integration.sh
+++ b/bin/test-integration.sh
@@ -17,8 +17,8 @@ export RNAME="integration_registry"
 
 # Download the `init` script if possible.
 if [ ! -f "$ROOT_DIR/bin/integration/init" ]; then
-    echo "[integration] Init file does not exist, downloading into '$ROOT_DIR/bin/integration/init'"
-    wget -O $ROOT_DIR/bin/integration/init https://raw.githubusercontent.com/openSUSE/docker-containers/master/derived_images/portus/init
+    echo "[integration] Init file does not exist, creating '$ROOT_DIR/bin/integration/init'"
+    cp $ROOT_DIR/docker/init $ROOT_DIR/bin/integration/init
 fi
 chmod +x $ROOT_DIR/bin/integration/init
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,27 @@
+FROM opensuse/amd64:42.3
+MAINTAINER SUSE Containers Team <containers@suse.com>
+
+# Install the entrypoint of this image.
+COPY init /
+
+# Install Portus and prepare the /certificates directory.
+RUN chmod +x /init && \
+    # Fetch the key from the obs://Virtualization:containers:Portus project.
+    mkdir -m 0600 /tmp/build && \
+    gpg --homedir /tmp/build --keyserver ha.pool.sks-keyservers.net --recv-keys 55A0B34D49501BB7CA474F5AA193FBB572174FC2 && \
+    gpg --homedir /tmp/build --export --armor 55A0B34D49501BB7CA474F5AA193FBB572174FC2 > /tmp/build/repo.key && \
+    rpm --import /tmp/build/repo.key && \
+    rm -rf /tmp/build && \
+    # Now add the repository and installa portus.
+    zypper ar -f obs://Virtualization:containers:Portus/openSUSE_Leap_42.3 portus && \
+    zypper ref && \
+    zypper -n in --from portus ruby-common portus && \
+    # Remove unneeded packages and clean stuff.
+    zypper -n rm kbd-legacy && \
+    zypper clean -a && \
+    # Prepare the certificates directory.
+    rm -rf /etc/pki/trust/anchors && \
+    ln -sf /certificates /etc/pki/trust/anchors
+
+EXPOSE 3000
+ENTRYPOINT ["/init"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,176 @@
+# Portus Official Docker image
+
+This directory contains all the resources needed to create a production-ready
+Docker image for Portus.
+
+The master branch of this repository is going to include the files needed
+to build Portus from the `master` branch, which is tagged as `head`. Other
+branches are available to build Portus out of more stable branches. These
+branches are going to be named using the following scheme: `portus-<release>`.
+
+Moreover, note that the deployment method has changed quite a lot:
+
+- From 2.0 to 2.2, Portus uses Apache.
+- From 2.3 onwards (including `head`), Portus uses Puma.
+
+This file contains instructions on the Puma deployment. If you want to know more
+about how to deploy other versions of Portus, please refer to this file on their
+respective branches.
+
+## Security
+
+SUSE's containers team cares about security, hence we made the following
+decisions:
+
+  * This image is running in the `production` environment, and because of that
+    SSL is enabled by default. You can disable this by setting the
+    `PORTUS_CHECK_SSL_USAGE_ENABLED` environment variable to false, but we don't
+    recommend this.
+  * Portus is installed from an RPM package, this ensures the final image will
+    have only the runtime dependency; no build time dependency is ever installed.
+
+SUSE's containers team is constantly working to automate the release process
+of Portus and of this image to ensure it stays up-to-date and secure.
+
+When deploying this image make sure to add all the required keys and
+certificates at runtime instead of adding them to a Docker image.
+
+## Anatomy of the image
+
+The image is based on openSUSE 42.3 and installs Portus using the RPM package
+built by SUSE's containers team inside of the [Open Build Service](https://build.opensuse.org/project/subprojects/Virtualization:containers:Portus)
+top level project and subprojects (one subproject per portus branch).
+
+### Exposed ports
+
+This image is using Puma as the web server and it only binds to the `3000`
+port.
+
+### The init script
+
+This Docker image has a init script which takes care of the following actions:
+
+  1. Setup the database required by Portus
+  2. Import all the `.crt` located under `/certificates`
+  3. Start Puma
+
+The next sections will provide more details about these steps.
+
+### Volumes
+
+Portus' state is stored inside of a MariaDB database. This makes this Docker
+image stateless.
+
+### External database
+
+This image has a custom `init` script that takes care of configuring the external
+database.
+
+The script will keep trying to reach the database for 90 seconds. A 5 seconds
+pause is done after each failed attempt. The container will exit with an error
+message if the database is not reachable.
+
+The script will take care of the creation of the Portus database and its initial
+population via the usual Rails procedures.
+
+The database is automatically migrated whenever a new migration is introduced
+by the upstream project.
+
+### Secrets and certificates
+
+Portus requires both a SSL key and a certificate to serve its contents over
+HTTPS. These files must be located in the `/certificates` directory of the
+container. Moreover, it's up to the deployer to set the `PORTUS_PUMA_TLS_KEY`
+and `PORTUS_PUMA_TLS_CERT` environment variables. Note that the key is also
+used to sign the JWT tokens issued to authenticate all the docker clients
+against the Registry.
+
+It's also required to add the certificate of the Registry when the latter one
+uses TLS to secure itself. The Registry certificate must be placed inside
+of `/certificates`, the `init` script of this image will automatically import
+it if it ends with the `.crt` extension.
+
+This image also supports [Docker
+secrets](https://docs.docker.com/engine/swarm/secrets/) for some environment
+variables. In particular, setting `PORTUS_DB_PASSWORD_FILE`,
+`PORTUS_PASSWORD_FILE`, `PORTUS_SECRET_KEY_BASE_FILE`,
+`PORTUS_EMAIL_SMTP_PASSWORD_FILE` and `PORTUS_LDAP_AUTHENTICATION_PASSWORD_FILE`
+with the path for the secrets will automatically set `PORTUS_DB_PASSWORD`,
+`PORTUS_PASSWORD`, `PORTUS_SECRET_KEY_BASE`, `PORTUS_EMAIL_SMTP_PASSWORD` and
+`PORTUS_LDAP_AUTHENTICATION_PASSWORD` respectively with the contents of these
+files.
+
+### Logging
+
+All logging is done to `stdout` and `stderr`. This makes it possible to handle
+the logs of this image in the usual ways.
+
+## Deployment
+
+It's possible to deploy this image using one of the existing orchestration
+solutions for Docker images. You can read some examples in the `examples`
+directory of Portus' source code.
+
+### Executing the crono script
+
+Portus uses [crono](https://github.com/plashchynski/crono) to handle some
+background jobs. You can also execute this piece with this image. In order to do
+this, you need to set the `PORTUS_INIT_COMMAND` environment variable to
+"bin/crono".
+
+### Environment variables
+
+Here's the full list of environment variables:
+
+Security related settings:
+
+  * `PORTUS_SECRET_KEY_BASE`: you can generate it using `openssl rand -hex 64`,
+    or provide it as a Docker secret with `PORTUS_SECRET_KEY_BASE_FILE`.
+  * `PORTUS_KEY_PATH`: the path of the certificate key. This is the key that
+    Portus will use for the authentication with your Docker registry.
+  * `PORTUS_PASSWORD`: the password of the hidden `portus` user. You can
+    generate it using `openssl rand -hex 64`. You can provide a Docker secret by
+    setting `PORTUS_PASSWORD_FILE`.
+  * `PORTUS_PUMA_TLS_KEY`: The TLS key to be picked by Puma.
+  * `PORTUS_PUMA_TLS_CERT`: The TLS certificate to be picked by Puma.
+  * `PORTUS_CHECK_SSL_USAGE_ENABLED`: Set this to `false` if you want to disable
+    SSL altogether.
+
+Database releated settings (see [configuring the database](http://port.us.org/docs/database.html) for details):
+
+  * `PORTUS_DB_ADAPTER`: database type. Supported values are `postgresql` and `mysql2`. Default is `mysql2`.
+  * `PORTUS_DB_HOST`: the host running the MariaDB (or Postgres) database.
+  * `PORTUS_DB_USERNAME`: the database user to be used.
+  * `PORTUS_DB_PASSWORD`: the password of the database user. You can provide a
+    Docker secret by setting `PORTUS_DB_PASSWORD_FILE`.
+  * `PORTUS_DB_DATABASE`: the name of the Portus database.
+  * `PORTUS_DB_PORT`: alternative database port number.
+  * `PORTUS_DB_POOL`: the number of pool connections.
+  * `PORTUS_DB_TIMEOUT`: timeout value for requests.
+
+Deployment related settings:
+
+  * `PORTUS_MACHINE_FQDN_VALUE`: this is the fully qualified domain name of your
+    Portus instance (eg: `portus.example.com`).
+
+Some fine tuning for Puma:
+
+  * `PORTUS_PUMA_WORKERS`: the amount of Puma workers to be spawned. Defaults to 1.
+  * `PORTUS_PUMA_MAX_THREADS`: the maximum amount of Puma threads to be
+    created. Defaults to 1.
+  * `RAILS_SERVE_STATIC_FILES`: set this to `true` if you want Puma to serve the
+    static files. Defaults to false, in which case you'd need for example NGinx
+    in front of this container.
+
+Executing other commands:
+
+  * `PORTUS_INIT_COMMAND`: you can set this environment variable with the
+    command that you'd like to run. For example, if you want to run crono, you
+    can set it to "bin/crono".
+  * `PORTUS_BACKGROUND`: you can set this environment to true in order to
+    indicate that the process to be executed is the rails runner
+    `bin/background.rb` (that is, the background process). This is a shortcut
+    for `PORTUS_INIT_COMMAND=rails r /srv/Portus/bin/background.rb`.
+
+You can also pass further environment variables to configure Portus as
+described [here](http://port.us.org/docs/Configuring-Portus.html#override-specific-configuration-options).

--- a/docker/init
+++ b/docker/init
@@ -1,0 +1,108 @@
+#!/bin/bash
+
+# This script will ensure Portus' database is ready to be used. It will keep
+# waiting for the db to be usable, but the script will exit with an error
+# after a certain amount of failed attempts.
+#
+# The script will automatically import all the SSL certificates from
+# `/certificates` into the final system. This is needed to talk with the
+# registry API when this one is protected by TLS.
+#
+# Finally the script will start apache running Portus via mod_rails.
+
+set -e
+
+setup_database() {
+  set +e
+
+  TIMEOUT=90
+  COUNT=0
+  RETRY=1
+
+  while [ $RETRY -ne 0 ]; do
+    case $(portusctl exec rails r /srv/Portus/bin/check_db.rb | grep DB) in
+      "DB_DOWN")
+        if [ "$COUNT" -ge "$TIMEOUT" ]; then
+          printf " [FAIL]\n"
+          echo "Timeout reached, exiting with error"
+          exit 1
+        fi
+        echo "Waiting for mariadb to be ready in 5 seconds"
+        sleep 5
+        COUNT=$((COUNT+5))
+        ;;
+      "DB_EMPTY"|"DB_MISSING")
+        # create db, apply schema and seed
+        echo "Initializing database"
+        portusctl exec rake db:setup
+        if [ $? -ne 0 ]; then
+            echo "Error at setup time"
+            exit 1
+        fi
+        ;;
+      "DB_READY")
+        echo "Database ready"
+        break
+        ;;
+    esac
+  done
+  set -e
+}
+
+# Usage: file_env 'XYZ_DB_PASSWORD' 'example'. This code is taken from:
+# https://github.com/docker-library/postgres/blob/master/docker-entrypoint.sh
+file_env() {
+    local var="$1"
+    local fileVar="${var}_FILE"
+    local def="${2:-}"
+    if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+        echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+        exit 1
+    fi
+    local val="$def"
+    if [ "${!var:-}" ]; then
+        val="${!var}"
+    elif [ "${!fileVar:-}" ]; then
+        val="$(< "${!fileVar}")"
+    fi
+    export "$var"="$val"
+    unset "$fileVar"
+}
+
+# Setup environment variables from secrets.
+secrets=( PORTUS_DB_PASSWORD PORTUS_PASSWORD PORTUS_SECRET_KEY_BASE
+          PORTUS_EMAIL_SMTP_PASSWORD PORTUS_LDAP_AUTHENTICATION_PASSWORD )
+for s in "${secrets[@]}"; do
+    if [[ -z "${!s}" ]]; then
+        file_env "$s"
+    fi
+done
+
+# Ensure additional certificates (e.g. docker registry) are known.
+update-ca-certificates
+
+# Further settings
+export PORTUS_PUMA_HOST="0.0.0.0:3000"
+export RACK_ENV="production"
+export RAILS_ENV="production"
+export CCONFIG_PREFIX="PORTUS"
+
+if [ -z "$PORTUS_GEM_GLOBAL" ]; then
+    export GEM_PATH="/srv/Portus/vendor/bundle/ruby/2.5.0"
+fi
+
+# On debug, print the environment in which we'll call Portus.
+if [ "$PORTUS_LOG_LEVEL" == "debug" ]; then
+    printenv
+fi
+
+# Go to the Portus directory and execute the proper command.
+cd /srv/Portus
+if [ ! -z "$PORTUS_BACKGROUND" ]; then
+    portusctl exec rails r /srv/Portus/bin/background.rb
+elif [ -z "$PORTUS_INIT_COMMAND" ]; then
+    setup_database
+    portusctl exec "pumactl -F /srv/Portus/config/puma.rb start"
+else
+    portusctl exec "$PORTUS_INIT_COMMAND"
+fi

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,12 +2,9 @@
 
 In this directory we've compiled the files of different deployment
 strategies. All these examples are based on the [official Portus
-image](https://github.com/openSUSE/docker-containers/tree/master/derived_images/portus),
-and they only work for Portus 2.3 and later. Support for older versions is not
-possible without creating new directories and configuration files. For more info
-on older releases, check this [README.md
-file](https://github.com/openSUSE/docker-containers/tree/portus-2.2/derived_images/portus)
-from the 2.2 branch.
+image](https://hub.docker.com/r/opensuse/portus/), and they only work for Portus
+2.3 and later. Support for older versions is not possible without creating new
+directories and configuration files.
 
 For now we have:
 

--- a/examples/compose/README.md
+++ b/examples/compose/README.md
@@ -6,11 +6,10 @@ ways:
 - A production-ready setup where all communication is encrypted.
 - A version which doesn't use encryption for simplicity.
 
-As explained in the [README file](../README.md) above, this example uses
-the
-[official Portus image](https://github.com/openSUSE/docker-containers/tree/master/derived_images/portus),
-so it has nothing to do with the docker-compose setup used for development in
-the root directory.
+As explained in the [README file](../README.md) above, this example uses the
+[official Portus image](https://hub.docker.com/r/opensuse/portus/), so it has
+nothing to do with the docker-compose setup used for development in the root
+directory.
 
 ## The hostname
 

--- a/examples/development/postgresql/README.md
+++ b/examples/development/postgresql/README.md
@@ -19,5 +19,6 @@ $ docker-compose -f docker-compose.postgres.yml up
 
 If you want to run PostgreSQL and Portus in production, having to call `bundle`
 when bringing up the containers is a bad idea. Instead, create a new Docker
-image that derives from the [official Portus image](https://github.com/openSUSE/docker-containers/tree/master/derived_images/portus) and install the `pg` gem
+image that derives from the [official Portus
+image](https://hub.docker.com/r/opensuse/portus/) and install the `pg` gem
 there.


### PR DESCRIPTION
Having Docker images into another repository disallowed us from having
Docker images from different sources. This is something we needed
because the `development` tag has to be created from this repository.

Fixes #1544

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>