### PR TITLE
ui(comments): fixed regression of user's avatar

### DIFF
--- a/app/assets/javascripts/modules/repositories/components/comments/list-item.vue
+++ b/app/assets/javascripts/modules/repositories/components/comments/list-item.vue
@@ -2,7 +2,8 @@
   <div class="comment-row" :id="commentId">
     <div class="comment-thumbnail">
       <div class="user-image">
-        <img :src="comment.author.avatar" />
+        <img :src="comment.author.avatar_url" v-if="comment.author.avatar_url" />
+        <i class="fa fa-user user-picture" v-else></i>
       </div>
     </div>
     <div class="comment-content">

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -32,11 +32,9 @@ module ApplicationHelper
   end
 
   # Render the user profile picture depending on the gravatar configuration.
-  def user_image_tag(owner)
-    email = owner.nil? ? nil : owner.email
-
-    if APP_CONFIG.enabled?("gravatar") && !email.nil? && !email.empty?
-      gravatar_image_tag(email)
+  def user_image_tag(user)
+    if user&.avatar_url.present?
+      content_tag :img, nil, src: user.avatar_url
     else
       content_tag :i, nil, class: "fa fa-user user-picture"
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -95,6 +95,11 @@ class User < ActiveRecord::Base
     username == "portus"
   end
 
+  # Returns avatar url if gravatar is enabled and email not blank
+  def avatar_url
+    GravatarImageTag.gravatar_url(email) if APP_CONFIG.enabled?("gravatar") && email.present?
+  end
+
   # Returns the username to be displayed.
   def display_username
     return username unless APP_CONFIG.enabled?("display_name")

--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -168,7 +168,7 @@ module API
       expose :author, documentation: {
         desc: "The ID and the username of the comment author"
       } do |c|
-        c.author&.slice("id", "username")
+        c.author&.slice("id", "username", "avatar_url")
       end
       expose :destroyable, documentation: {
         desc: "Boolean that tells if the current user can destroy or not the comment"

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -6,28 +6,21 @@ RSpec.describe ApplicationHelper, type: :helper do
   describe "#user_image_tag" do
     let(:user) { create(:user, email: "user@example.com") }
 
-    # Mocking the gravatar_image_tag
-    def gravatar_image_tag(email)
-      email
-    end
-
-    it "uses the gravatar image tag if enabled" do
-      APP_CONFIG["gravatar"] = { "enabled" => true }
-      expect(user_image_tag(user)).to eq "user@example.com"
-    end
-
     it "uses the fa icon if gravatar support is disabled" do
-      APP_CONFIG["gravatar"] = { "enabled" => false }
       expect(user_image_tag(user)).to eq(
         '<i class="fa fa-user user-picture"></i>'
       )
     end
 
     it "uses the fa icon if the user had no email set" do
-      APP_CONFIG["gravatar"] = { "enabled" => false }
       expect(user_image_tag(nil)).to eq(
         '<i class="fa fa-user user-picture"></i>'
       )
+    end
+
+    it "uses the gravatar image tag if enabled" do
+      APP_CONFIG["gravatar"] = { "enabled" => true }
+      expect(user_image_tag(user)).to start_with("<img src=\"http")
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -273,6 +273,24 @@ describe User do
     end
   end
 
+  describe "#avatar_url" do
+    let(:user) { build(:user, username: "user") }
+    let(:user2) { build(:user, username: "user", email: "") }
+
+    it "returns nil if the feature is disabled" do
+      expect(user.avatar_url).to be_nil
+    end
+
+    it "returns nil if email is blank" do
+      expect(user2.avatar_url).to be_nil
+    end
+
+    it "returns the avatar url if the feature is enabled" do
+      APP_CONFIG["gravatar"] = { "enabled" => true }
+      expect(user.avatar_url).to start_with("http")
+    end
+  end
+
   describe "#destroy" do
     let!(:registry)   { create(:registry, hostname: "registry.test.lan") }
     let!(:user)       { create(:admin, username: "admin") }


### PR DESCRIPTION
During the refactoring of comments to vue components the user's avatar
was not implemented properly.

Signed-off-by: Vítor Avelino <vavelino@suse.com>

![screenshot-20180613102616-211x185](https://user-images.githubusercontent.com/188554/41354014-46e9c7c4-6ef4-11e8-923a-26ae850fd8ea.png)
![screenshot-20180613102741-220x179](https://user-images.githubusercontent.com/188554/41354073-6e2f37ce-6ef4-11e8-82a6-5ad43c98f937.png)
![screenshot-20180613102453-223x186](https://user-images.githubusercontent.com/188554/41354013-46ce5778-6ef4-11e8-8d2b-a37f807eaa6e.png)