### PR TITLE
Adding the possibility to create bots

### DIFF
--- a/app/assets/javascripts/modules/users/index.js
+++ b/app/assets/javascripts/modules/users/index.js
@@ -6,7 +6,8 @@ import UsersEditPage from './pages/edit';
 import UsersSignUpPage from './pages/sign-up';
 import UsersSignInPage from './pages/sign-in';
 
-const USERS_EDIT_ROUTE = 'auth/registrations/edit';
+const USERS_SELF_EDIT_ROUTE = 'auth/registrations/edit';
+const USERS_EDIT_ROUTE = 'admin/users/edit';
 const USERS_SIGN_IN_ROUTE = 'auth/sessions/new';
 const USERS_SIGN_UP_ROUTE = 'auth/registrations/new';
 
@@ -24,7 +25,7 @@ $(() => {
       new UsersSignInPage($body);
   }
 
-  if (route === USERS_EDIT_ROUTE) {
+  if (route === USERS_SELF_EDIT_ROUTE || route === USERS_EDIT_ROUTE) {
     // eslint-disable-next-line no-new
     new Vue({
       el: '.vue-root',

--- a/app/models/application_token.rb
+++ b/app/models/application_token.rb
@@ -42,7 +42,7 @@ class ApplicationToken < ActiveRecord::Base
 
   class << self
     # Create new application token and generate plain token, salt, nash.
-    # If usre_id passed then created token belongs to the user.
+    # If user_id passed then created token belongs to the user.
     #
     # Return array with application_token and plain_token.
     def create_token(current_user:, user_id: nil, params:)

--- a/app/policies/application_token_policy.rb
+++ b/app/policies/application_token_policy.rb
@@ -10,6 +10,7 @@ class ApplicationTokenPolicy
   end
 
   def destroy?
-    user.id == application_token.user_id
+    user.id == application_token.user_id ||
+      user.admin? && application_token.user.bot
   end
 end

--- a/app/views/admin/users/edit.html.slim
+++ b/app/views/admin/users/edit.html.slim
@@ -1,6 +1,6 @@
 .panel.panel-default
   .panel-heading
-    h5 <b>Edit</b> #{@user.display_username}
+    h5 <b>Edit</b> #{@user.display_username} #{@user.bot ? "(bot)" : ""}
   .panel-body
     = form_for [:admin, @user], html: {class: 'form-horizontal', role: 'form'} do |f|
       .form-group
@@ -18,6 +18,9 @@
         .col-md-offset-2.col-md-7
           = f.submit('Update', class: 'btn btn-primary')
 
+- if @user.bot
+  <app-tokens-wrapper :user-id="#{@user.id}" :app-tokens-ref="#{@app_tokens_serialized}" :max-tokens="#{User::APPLICATION_TOKENS_MAX}"></app-tokens-wrapper>
+
 .panel.panel-default
   .panel-heading
     h5 <b>Remove</b> #{@user.display_username}
@@ -25,15 +28,19 @@
     = form_for @user, url: admin_user_path(@user), method: :delete, html: {id: "delete_user_#{@user.id}", class: 'form-horizontal', role: "form"} do |f|
       .form-group
         .col-md-offset-2.col-md-7
-          p
-            | As an administrator, you can remove this user. That being said, be aware that doing this has its consequences:
-          ul
-            li
-              | The namespace and the repositories of this user won't be removed. You will still be able to access them and manage them.
-            li
-              | The user will be lost forever, so you won't be able to recover the data.
-          p
-            | With this in mind, if you want to remove this user, just click the button below.
+          - if @user.bot
+            p
+              | As an administrator, you can remove this bot. Just click the button below.
+          - else
+            p
+              | As an administrator, you can remove this user. That being said, be aware that doing this has its consequences:
+            ul
+              li
+                | The namespace and the repositories of this user won't be removed. You will still be able to access them and manage them.
+              li
+                | The user will be lost forever, so you won't be able to recover the data.
+            p
+              | With this in mind, if you want to remove this user, just click the button below.
       .form-group
         .col-md-offset-2.col-md-7
           = f.submit('Remove', class: 'btn btn-danger')

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -12,7 +12,8 @@
     .table-responsive
       table.table.table-stripped.table-hover
         col.col-20
-        col.col-30
+        col.col-20
+        col.col-10
         col.col-10
         col.col-10
         col.col-10
@@ -26,6 +27,7 @@
             th Namespaces
             th Teams
             th Enabled
+            th Bot
             th Remove
         tbody
           - @users.each do |user|
@@ -59,6 +61,7 @@
                     rel="nofollow"
                     href=url_for(toggle_enabled_path(user))]
                       i.fa.fa-lg[class="fa-toggle-#{user.enabled? ? 'on': 'off'}"]
+              td= user.bot
               td.remove-btn
                 - if current_user == user
                     a[class="btn btn-default" disabled=true]

--- a/app/views/admin/users/new.html.slim
+++ b/app/views/admin/users/new.html.slim
@@ -19,8 +19,10 @@
         = f.label :password_confirmation, {class: 'control-label col-md-2'}
         .col-md-7
           = f.password_field(:password_confirmation, class: 'form-control', required: true)
-
+      .form-group
+        = f.label :bot, {class: 'control-label col-md-2'}
+        .col-md-7
+          = f.check_box(:bot)
       .form-group
         .col-md-offset-2.col-md-7
           = f.submit('Create', class: 'btn btn-primary')
-

--- a/app/views/shared/_notification.html.slim
+++ b/app/views/shared/_notification.html.slim
@@ -8,7 +8,7 @@ div [id="#{float == true ? 'float' : 'fixed'}-alert" class="#{messages && messag
         i.fa.fa-3x class=(alert == 'alert' ? 'fa-exclamation-circle' : 'fa-info-circle')
       p
         - if messages.is_a?(String)
-          = messages
+          = messages.html_safe
         - elsif messages.is_a?(Array)
           - if messages.size == 1
             = messages[0]

--- a/db/migrate/20180612145708_add_bot_to_user.rb
+++ b/db/migrate/20180612145708_add_bot_to_user.rb
@@ -1,0 +1,5 @@
+class AddBotToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :bot, :bool, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180412140442) do
+ActiveRecord::Schema.define(version: 20180612145708) do
 
   create_table "activities", force: :cascade do |t|
     t.integer  "trackable_id",   limit: 4
@@ -175,6 +175,7 @@ ActiveRecord::Schema.define(version: 20180412140442) do
     t.string   "display_name",           limit: 255
     t.string   "provider",               limit: 255
     t.string   "uid",                    limit: 255
+    t.boolean  "bot",                                default: false
   end
 
   add_index "users", ["display_name"], name: "index_users_on_display_name", unique: true, using: :btree

--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -48,10 +48,14 @@ module API
       expose :current_sign_in_at, documentation: { type: DateTime }
       expose :last_sign_in_at, documentation: { type: DateTime }
       expose :created_at, :updated_at, documentation: { type: DateTime }
-      expose :admin, :enabled, documentation: { type: "boolean" }
+      expose :admin, :enabled, documentation: { type: ::Grape::API::Boolean }
       expose :locked_at, documentation: { type: DateTime }
       expose :namespace_id, documentation: { type: Integer }
       expose :display_name, documentation: { type: String, desc: "Display name" }
+      expose :bot, documentation: {
+        type: ::Grape::API::Boolean,
+        desc: "Whether this is a bot or not"
+      }
     end
 
     class ApplicationTokens < Grape::Entity

--- a/lib/api/v1/users.rb
+++ b/lib/api/v1/users.rb
@@ -33,8 +33,8 @@ module API
                        using: API::Entities::Users.documentation.slice(:username, :email)
               requires :password, type: String, documentation: { desc: "Password" }
               optional :all,
-                       only:  [:display_name],
-                       using: API::Entities::Users.documentation.slice(:display_name)
+                       only:  %i[display_name bot],
+                       using: API::Entities::Users.documentation.slice(:display_name, :bot)
             end
           end
 

--- a/lib/portus/ldap/configuration.rb
+++ b/lib/portus/ldap/configuration.rb
@@ -39,9 +39,11 @@ module Portus
       # something about the current accounts telling us to not go through LDAP
       # (e.g. portus user). Otherwise it returns true.
       def check_account(account)
-        # NOTE: this method will get expanded with #1856
         if account == "portus"
           @reason = "Portus user does not go through LDAP"
+          false
+        elsif @username.present? && User.find_by(username: @username)&.bot
+          @reason = "Bot user is not expected to be present on LDAP"
           false
         else
           true

--- a/lib/portus/ldap/login.rb
+++ b/lib/portus/ldap/login.rb
@@ -37,7 +37,7 @@ module Portus
             username: cfg.username,
             email:    em,
             password: cfg.password,
-            admin:    User.not_portus.none?
+            admin:    User.not_portus.where(bot: false).none?
           )
           created = user.persisted?
         end

--- a/spec/api/grape_api/v1/application_tokens_spec.rb
+++ b/spec/api/grape_api/v1/application_tokens_spec.rb
@@ -79,6 +79,15 @@ describe API::V1::Users do
         raise_exception(ActiveRecord::RecordNotFound)
     end
 
+    it "deletes bot application token if admin" do
+      bot = create(:user, bot: true)
+      token = create(:application_token, user: bot)
+      delete "/api/v1/users/application_tokens/#{token.id}", nil, @header
+      expect(response).to have_http_status(:no_content)
+      expect { ApplicationToken.find(token.id) }.to \
+        raise_exception(ActiveRecord::RecordNotFound)
+    end
+
     it "returns status 404" do
       token_id = ApplicationToken.maximum(:id) + 1
       delete "/api/v1/users/application_tokens/#{token_id}", nil, @header

--- a/spec/api/grape_api/v1/users_spec.rb
+++ b/spec/api/grape_api/v1/users_spec.rb
@@ -82,6 +82,12 @@ describe API::V1::Users do
         expect(response).to have_http_status(:created)
         expect(User.find_by(email: user_data[:email])).not_to be_nil
       end
+
+      it "creates a new bot" do
+        data = user_data.merge(bot: true)
+        post "/api/v1/users", { user: data }, @header
+        expect(User.find_by(email: data[:email]).bot).to be_truthy
+      end
     end
 
     context "with invalid params" do

--- a/spec/factories/users_factory.rb
+++ b/spec/factories/users_factory.rb
@@ -5,6 +5,7 @@ FactoryGirl.define do
     sequence(:email) { |n| "test#{n}@localhost.test.lan" }
     password "test-password"
     sequence(:username) { |n| "username#{n}" }
+    bot false
 
     factory :admin do
       admin(true)

--- a/spec/integration/helpers/ldap.rb
+++ b/spec/integration/helpers/ldap.rb
@@ -14,11 +14,14 @@ class IntegrationLDAP < Portus::LDAP::Authenticatable
     @session = {}
   end
 
-  def fail(_obj)
-    exit 1
+  def fail(obj)
+    puts "Soft fail: #{obj}"
+    exit 0
   end
 
-  alias fail! fail
+  def fail!(_obj)
+    exit 1
+  end
 
   def success!(user)
     puts "name: #{user.username}, email: #{user.email}, " \

--- a/spec/integration/ldap/login.bats
+++ b/spec/integration/ldap/login.bats
@@ -58,3 +58,9 @@ function setup() {
     ruby_puts "Registry.get.client.catalog.inspect"
     [ $status -eq 0 ]
 }
+
+@test "LDAP: portus user is skipped" {
+    helper_runner ldap.rb pfabra giecftw1918
+    [ $status -eq 0 ]
+    [[ "${lines[-1]}" =~ "Soft fail: Bot user is not expected to be present on LDAP" ]]
+}

--- a/spec/integration/profiles/ldap.rb
+++ b/spec/integration/profiles/ldap.rb
@@ -5,6 +5,12 @@ require_relative "shared"
 
 clean_db!
 create_registry!
+User.create!(
+  username: "pfabra",
+  password: "giecftw1918",
+  email:    "pfabra@iec.cat",
+  bot:      true
+)
 
 ##
 # Set parameters and initialize LDAP object.

--- a/spec/lib/portus/ldap/authenticatable_spec.rb
+++ b/spec/lib/portus/ldap/authenticatable_spec.rb
@@ -360,12 +360,22 @@ describe ::Portus::LDAP::Authenticatable do
       expect(lm.fail_message).to eq "error message"
     end
 
-    it "returns fails 'softly' for the portus user" do
+    it "fails 'softly' for the portus user" do
       params = { account: "portus", user: { username: "portus", password: "1234" } }
 
       lm = AuthenticatableMock.new(params)
       lm.authenticate!
       expect(lm.fail_message).to eq "Portus user does not go through LDAP"
+      expect(lm.soft).to be_truthy
+    end
+
+    it "fails 'softly' for bots" do
+      create(:user, username: "bot", bot: true)
+      params = { user: { username: "bot", password: "1234" } }
+
+      lm = AuthenticatableMock.new(params)
+      lm.authenticate!
+      expect(lm.fail_message).to eq "Bot user is not expected to be present on LDAP"
       expect(lm.soft).to be_truthy
     end
 

--- a/spec/lib/portus/ldap/configuration_spec.rb
+++ b/spec/lib/portus/ldap/configuration_spec.rb
@@ -22,6 +22,14 @@ describe ::Portus::LDAP::Configuration do
       expect(cfg.reason_message).to eq "Portus user does not go through LDAP"
     end
 
+    it "returns false if the user is a bot" do
+      create(:user, username: "bot", bot: true)
+      params = { user: { username: "bot", password: "" } }
+      cfg = ::Portus::LDAP::Configuration.new(params)
+      expect(cfg.enabled?).to be_falsey
+      expect(cfg.reason_message).to eq "Bot user is not expected to be present on LDAP"
+    end
+
     it "returns true otherwise" do
       params = { user: { username: "name", password: "" } }
       cfg = ::Portus::LDAP::Configuration.new(params)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -27,6 +27,7 @@
 #  display_name           :string(255)
 #  provider               :string(255)
 #  uid                    :string(255)
+#  bot                    :boolean          default(FALSE)
 #
 # Indexes
 #
@@ -64,6 +65,17 @@ describe User do
       user = build(:user, username: name)
       expect(user.save).to be_truthy
       expect(user.errors).to be_empty
+    end
+  end
+
+  describe "after creation" do
+    it "does not create a namespace if it's a bot" do
+      create(:registry)
+
+      user = create(:user)
+      expect(user.namespace).to_not be_nil
+      bot = create(:user, bot: true)
+      expect(bot.namespace).to be_nil
     end
   end
 


### PR DESCRIPTION
This commit introduces a new concept: bots. Bots are regular users that
are created by administrators, but with some subtelties:

1. A bot doesn't own a personal namespace.
2. A bot cannot login via web.
3. A bot can only log in with application tokens (a token is generated
    automatically when creating a bot).

This should cover the needs from #517 and #801, except for a couple of
small features that should be added in the near future:

- Bots should be able to be created by mere team owners. These team bots
  should be attached to a specific team, but an administrator might be
  able to upgrade it to a global bot.
- Team owners should be able to be more granular on repository access
  (instead of granting access to all repositories from a given
   namespace).

See #517
See #801

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>