### PR TITLE
ldap: properly skip the portus user

### DIFF
--- a/lib/portus/ldap/authenticatable.rb
+++ b/lib/portus/ldap/authenticatable.rb
@@ -40,10 +40,17 @@ module Portus
       def authenticate!
         fill_user_params!
 
-        cfg        = ::Portus::LDAP::Configuration.new(params)
-        connection = initialized_adapter
-
-        portus_login!(connection, cfg) if bind_as(connection, cfg)
+        cfg = ::Portus::LDAP::Configuration.new(params)
+        # rubocop:disable Style/GuardClause
+        if cfg.enabled?
+          connection = initialized_adapter
+          portus_login!(connection, cfg) if bind_as(connection, cfg)
+        else
+          # rubocop:disable Style/SignalException
+          fail cfg.reason_message
+          # rubocop:enable Style/SignalException
+        end
+        # rubocop:enable Style/GuardClause
       rescue ::Portus::LDAP::Error, Net::LDAP::Error => e
         logged_failure!(e.message)
       end

--- a/spec/integration/ldap/login.bats
+++ b/spec/integration/ldap/login.bats
@@ -53,3 +53,8 @@ function setup() {
     [ $status -eq 1 ]
     [[ "${lines[-2]}" =~ "No Such Object (code 32)" ]]
 }
+
+@test "LDAP: portus user is skipped" {
+    ruby_puts "Registry.get.client.catalog.inspect"
+    [ $status -eq 0 ]
+}

--- a/spec/integration/profiles/ldap.rb
+++ b/spec/integration/profiles/ldap.rb
@@ -4,6 +4,7 @@ require "net/ldap"
 require_relative "shared"
 
 clean_db!
+create_registry!
 
 ##
 # Set parameters and initialize LDAP object.

--- a/spec/lib/portus/ldap/configuration_spec.rb
+++ b/spec/lib/portus/ldap/configuration_spec.rb
@@ -13,17 +13,20 @@ describe ::Portus::LDAP::Configuration do
       params = { user: { username: "name", password: "1234" } }
       cfg = ::Portus::LDAP::Configuration.new(params)
       expect(cfg.enabled?).to be_falsey
+      expect(cfg.reason_message).to eq "LDAP is not enabled"
     end
 
     it "returns false if we are talking about the portus user" do
       cfg = ::Portus::LDAP::Configuration.new(account: "portus", password: "1234")
       expect(cfg.enabled?).to be_falsey
+      expect(cfg.reason_message).to eq "Portus user does not go through LDAP"
     end
 
     it "returns true otherwise" do
       params = { user: { username: "name", password: "" } }
       cfg = ::Portus::LDAP::Configuration.new(params)
       expect(cfg.enabled?).to be_truthy
+      expect(cfg.reason_message).to eq ""
     end
   end
 


### PR DESCRIPTION
This is a regression that happened after merging #1828.

Fixes #1850

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>