### PR TITLE
spec: added chrome headless as default js runner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,18 +8,7 @@ matrix:
   allow_failures:
     - rvm: ruby-head
 
-cache:
-  directories:
-    - $PWD/travis_phantomjs
-
 before_install:
-  - phantomjs --version
-  - export PATH=$PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH
-  - if [ $(phantomjs --version) != '2.1.1' ]; then rm -rf $PWD/travis_phantomjs; mkdir -p $PWD/travis_phantomjs; fi
-  - if [ $(phantomjs --version) != '2.1.1' ]; then wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2; fi
-  - if [ $(phantomjs --version) != '2.1.1' ]; then tar -xvf $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis_phantomjs; fi
-  - phantomjs --version
-
   # Use the latest stable Node.js
   - nvm install stable
   - nvm use stable
@@ -44,6 +33,9 @@ before_install:
 before_script:
   - mysql -e 'create database portus_test;'
   - psql -c 'create database portus_test' -U postgres
+
+  # fix for chrome headless
+  - export DISPLAY=:99.0 && sh -e /etc/init.d/xvfb start && sleep 3
 
 script:
   - chmod +x bin/ci.sh && ./bin/ci.sh
@@ -73,3 +65,4 @@ addons:
     repo_token: 18a0cf6c35e0c801678f12f444051c33e0390ce0efa91ec06a2aa5068b10c19e
   mariadb: '10.2'
   postgresql: '9.6'
+  chrome: stable

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ RUN zypper addrepo https://download.opensuse.org/repositories/devel:languages:go
     zypper --gpg-auto-import-keys ref && \
     zypper -n in --no-recommends ruby2.5-devel \
            libmysqlclient-devel postgresql-devel \
-           nodejs libxml2-devel libxslt1 git-core go1.10 && \
+           nodejs libxml2-devel libxslt1 git-core \
+           go1.10 phantomjs && \
     zypper -n in --no-recommends -t pattern devel_basis && \
     gem install bundler --no-ri --no-rdoc -v 1.16.0 && \
     update-alternatives --install /usr/bin/bundle bundle /usr/bin/bundle.ruby2.5 3 && \

--- a/Gemfile
+++ b/Gemfile
@@ -100,10 +100,13 @@ end
 
 group :test do
   gem "capybara", "~> 2.14.3"
-  gem "codeclimate-test-reporter", group: :test, require: nil
+  gem "capybara-screenshot", "~> 1.0.0"
+  gem "chromedriver-helper"
+  gem "codeclimate-test-reporter", require: false
   gem "docker-api", "~> 1.28.0"
   gem "json-schema"
-  gem "poltergeist", "~> 1.15.0", require: false
+  gem "poltergeist", "~> 1.18.0", require: false
+  gem "selenium-webdriver", "~> 3.12"
   gem "shoulda"
   gem "simplecov", "0.15.1", require: false
   gem "timecop"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,8 @@ GEM
     annotate (2.7.2)
       activerecord (>= 3.2, < 6.0)
       rake (>= 10.4, < 13.0)
+    archive-zip (0.11.0)
+      io-like (~> 0.3.0)
     arel (6.0.4)
     ast (2.4.0)
     autoprefixer-rails (7.2.3)
@@ -69,9 +71,17 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    capybara-screenshot (1.0.21)
+      capybara (>= 1.0, < 4)
+      launchy
     cconfig (1.2.0)
       safe_yaml (~> 1.0.0, >= 1.0.0)
+    childprocess (0.9.0)
+      ffi (~> 1.0, >= 1.0.11)
     choice (0.2.0)
+    chromedriver-helper (1.2.0)
+      archive-zip (~> 0.10)
+      nokogiri (~> 1.8)
     cliver (0.3.2)
     codeclimate-test-reporter (0.4.7)
       simplecov (>= 0.7.1, < 1.0.0)
@@ -166,6 +176,7 @@ GEM
     hirb (0.7.3)
     i18n (0.8.0)
     ice_nine (0.11.2)
+    io-like (0.3.0)
     json (2.1.0)
     json-schema (2.5.1)
       addressable (~> 2.3.7)
@@ -240,8 +251,8 @@ GEM
     parser (2.5.0.3)
       ast (~> 2.4.0)
     pg (0.20.0)
-    poltergeist (1.15.0)
-      capybara (~> 2.1)
+    poltergeist (1.18.1)
+      capybara (>= 2.1, < 4)
       cliver (~> 0.3.1)
       websocket-driver (>= 0.2.0)
     polyglot (0.3.5)
@@ -343,6 +354,7 @@ GEM
     ruby-openid (2.7.0)
     ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
+    rubyzip (1.2.1)
     safe_yaml (1.0.4)
     sass (3.4.25)
     sass-rails (5.0.7)
@@ -356,6 +368,9 @@ GEM
       uri_template (~> 0.5.0)
     search_cop (1.0.6)
       treetop
+    selenium-webdriver (3.12.0)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.2)
     shellany (0.0.1)
     shoulda (3.5.0)
       shoulda-context (~> 1.0, >= 1.0.1)
@@ -413,9 +428,9 @@ GEM
     webpack-rails (0.9.10)
       hashdiff
       railties (>= 3.2.0)
-    websocket-driver (0.6.5)
+    websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.2)
+    websocket-extensions (0.1.3)
     wirb (2.0.0)
       paint (>= 0.9, < 2.0)
     wirble (0.1.3)
@@ -437,7 +452,9 @@ DEPENDENCIES
   brakeman
   byebug
   capybara (~> 2.14.3)
+  capybara-screenshot (~> 1.0.0)
   cconfig (~> 1.2.0)
+  chromedriver-helper
   codeclimate-test-reporter
   database_cleaner
   devise
@@ -472,7 +489,7 @@ DEPENDENCIES
   omniauth-google-oauth2
   omniauth-openid
   pg (~> 0.20.0)
-  poltergeist (~> 1.15.0)
+  poltergeist (~> 1.18.0)
   pry-rails
   public_activity
   puma (~> 3.10.0)
@@ -491,6 +508,7 @@ DEPENDENCIES
   sass (~> 3.4.23)
   sass-rails (~> 5.0.6)
   search_cop
+  selenium-webdriver (~> 3.12)
   shoulda
   simplecov (= 0.15.1)
   slim (~> 3.0.8)

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -38,6 +38,9 @@ $(function () {
 
   refreshFloatAlertPosition();
 
+  // disable effects during tests
+  $.fx.off = $('body').data('disable-effects');
+
   // necessary to be compatible with the js rendered
   // on the server-side via jquery-ujs
   window.setTimeOutAlertDelay = setTimeOutAlertDelay;

--- a/app/assets/javascripts/modules/repositories/components/comments/wrapper.vue
+++ b/app/assets/javascripts/modules/repositories/components/comments/wrapper.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="comments-wrapper">
     <comments-form :state="state" form-state="commentFormVisible" :repository="repository"></comments-form>
     <comments-panel :comments="comments" :state="state"></comments-panel>
   </div>

--- a/app/assets/javascripts/modules/teams/components/panel.vue
+++ b/app/assets/javascripts/modules/teams/components/panel.vue
@@ -2,9 +2,7 @@
   <panel>
     <h5 slot="heading-left">{{ title }}</h5>
 
-    <div slot="heading-right" v-if="canCreate">
-      <toggle-link text="Create new team" :state="state" state-key="newFormVisible" class="toggle-link-new-team"></toggle-link>
-    </div>
+    <toggle-link slot="heading-right" text="Create new team" :state="state" state-key="newFormVisible" class="toggle-link-new-team" v-if="canCreate"></toggle-link>
 
     <div slot="body">
       <teams-table :teams="teams" :sortable="true" sort-by="name" :teams-path="teamsPath"></teams-table>

--- a/app/assets/javascripts/shared/components/toggle-link.vue
+++ b/app/assets/javascripts/shared/components/toggle-link.vue
@@ -1,5 +1,5 @@
 <template>
-  <a type="button" class="btn btn-xs btn-link toggle-link" @click="toggle">
+  <a type="button" class="btn btn-xs btn-link toggle-link" @click.prevent="toggle">
     <i class="fa" :class="icon"></i> {{ text }}
   </a>
 </template>

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -32,7 +32,7 @@ html
     = javascript_include_tag(*webpack_asset_paths("application"))
     = yield :js_header
 
-  body data-controller="#{js_controller}" data-route="#{js_route}" class="#{'is-admin' if current_user.admin?}"
+  body data-controller="#{js_controller}" data-route="#{js_route}" class="#{'is-admin' if current_user.admin?}" data-disable-effects="#{Rails.env.test?}"
     .vue-root
       header
         = render 'shared/header'

--- a/spec/features/admin/registries_spec.rb
+++ b/spec/features/admin/registries_spec.rb
@@ -21,7 +21,7 @@ describe "Admin - Registries panel" do
       visit new_admin_registry_path
 
       fill_in "registry_name", with: "registry"
-      fill_in "registry_name", with: ""
+      clear_field("#registry_name")
 
       expect(page).to have_content("Name can't be blank")
       expect(page).to have_button("Create", disabled: true)
@@ -31,7 +31,7 @@ describe "Admin - Registries panel" do
       visit new_admin_registry_path
 
       fill_in "registry_hostname", with: "registry"
-      fill_in "registry_hostname", with: ""
+      clear_field("#registry_hostname")
 
       expect(page).to have_content("Hostname can't be blank")
       expect(page).to have_button("Create", disabled: true)
@@ -86,7 +86,6 @@ describe "Admin - Registries panel" do
       expect(page).not_to have_css("#advanced.collapse.in")
 
       click_button "Show Advanced"
-      wait_for_effect_on("#advanced")
 
       expect(page).to have_content("External Registry Name")
       expect(page).to have_css("#advanced.collapse.in")
@@ -96,13 +95,11 @@ describe "Admin - Registries panel" do
       visit new_admin_registry_path
 
       click_button "Show Advanced"
-      wait_for_effect_on("#advanced")
 
       expect(page).to have_content("External Registry Name")
       expect(page).to have_css("#advanced.collapse.in")
 
       click_button "Hide Advanced"
-      wait_for_effect_on("#advanced")
 
       expect(page).not_to have_css("#advanced.collapse.in")
       expect(page).not_to have_content("External Registry Name")
@@ -140,7 +137,6 @@ describe "Admin - Registries panel" do
       expect(page).not_to have_css("#advanced")
 
       click_button "Show Advanced"
-      wait_for_effect_on("#advanced")
 
       expect(page).to have_content("External Registry Name")
       expect(page).to have_css("#advanced.collapse.in")
@@ -148,13 +144,11 @@ describe "Admin - Registries panel" do
 
     it "hides advanced options when clicking on Hide Advanced" do
       click_button "Show Advanced"
-      wait_for_effect_on("#advanced")
 
       expect(page).to have_content("External Registry Name")
       expect(page).to have_css("#advanced.collapse.in")
 
       click_button "Hide Advanced"
-      wait_for_effect_on("#advanced")
 
       expect(page).not_to have_css("#advanced.collapse.in")
       expect(page).not_to have_content("External Registry Name")

--- a/spec/features/admin/users_spec.rb
+++ b/spec/features/admin/users_spec.rb
@@ -164,14 +164,12 @@ describe "Admin - Users panel" do
       visit edit_admin_user_path(bot)
 
       find(".toggle-link-new-app-token").click
-      wait_for_effect_on("#new-app-token-form")
 
       expect(focused_element_id).to eq "application_token_application"
       fill_in "Application", with: "awesome-application"
 
       click_button "Create"
       wait_for_ajax
-      wait_for_effect_on("#float-alert")
 
       expect(page).to have_css("#float-alert")
       expect(page).to have_content("was created successfully")
@@ -186,7 +184,6 @@ describe "Admin - Users panel" do
       find(".application_token_#{token.id} button").click
       find(".popover-content .yes").click
       wait_for_ajax
-      wait_for_effect_on("#float-alert")
 
       expect(page).to have_css("#float-alert")
       expect(page).to have_content("was removed successfully")

--- a/spec/features/application_tokens_spec.rb
+++ b/spec/features/application_tokens_spec.rb
@@ -13,14 +13,12 @@ describe "Application tokens" do
     it "As an user I can create a new token", js: true do
       visit edit_user_registration_path
       find(".toggle-link-new-app-token").click
-      wait_for_effect_on("#new-app-token-form")
 
       expect(focused_element_id).to eq "application_token_application"
       fill_in "Application", with: "awesome-application"
 
       click_button "Create"
       wait_for_ajax
-      wait_for_effect_on("#float-alert")
 
       expect(page).to have_css("#float-alert")
       expect(page).to have_content("was created successfully")
@@ -32,14 +30,12 @@ describe "Application tokens" do
 
       visit edit_user_registration_path
       find(".toggle-link-new-app-token").click
-      wait_for_effect_on("#new-app-token-form")
 
       expect(focused_element_id).to eq "application_token_application"
       fill_in "Application", with: "awesome-application"
 
       click_button "Create"
       wait_for_ajax
-      wait_for_effect_on("#float-alert")
 
       expect(page).to have_css("#float-alert")
       expect(page).to have_content("Application has already been taken")
@@ -50,14 +46,12 @@ describe "Application tokens" do
 
       visit edit_user_registration_path
       find(".toggle-link-new-app-token").click
-      wait_for_effect_on("#new-app-token-form")
 
       expect(focused_element_id).to eq "application_token_application"
       fill_in "Application", with: "awesome-application"
 
       click_button "Create"
       wait_for_ajax
-      wait_for_effect_on("#float-alert")
 
       expect(page).to have_css("#float-alert")
       expect(page).to have_content("was created successfully")
@@ -82,7 +76,6 @@ describe "Application tokens" do
       find(".application_token_#{token.id} button").click
       find(".popover-content .yes").click
       wait_for_ajax
-      wait_for_effect_on("#float-alert")
 
       expect(page).to have_css("#float-alert")
       expect(page).to have_content("was removed successfully")

--- a/spec/features/auth/profile_feature_spec.rb
+++ b/spec/features/auth/profile_feature_spec.rb
@@ -72,8 +72,7 @@ describe "Update password feature" do
 
       expect(page).to have_content("Profile updated successfully!")
       expect(page).to have_button("Update", disabled: true)
-      # fill_in does not trigger keyUp event, so using clear_field instead
-      clear_field("Display name")
+      clear_field("#user_display_name")
       expect(page).to have_button("Update")
     end
   end

--- a/spec/features/help_spec.rb
+++ b/spec/features/help_spec.rb
@@ -11,11 +11,11 @@ describe "Help page" do
       login_as user, scope: :user
     end
 
-    it "A user can go to the API documentation", js: true do
+    it "A user can go to the API documentation" do
       visit help_index_path
       click_link("API Documentation")
 
-      expect(page).to have_http_status(200)
+      expect(page).to have_content("Swagger")
       expect(page).to have_current_path("/documentation")
     end
   end

--- a/spec/features/namespaces_spec.rb
+++ b/spec/features/namespaces_spec.rb
@@ -19,7 +19,6 @@ describe "Namespaces support" do
       visit namespaces_path
 
       find(".toggle-link-new-namespace").click
-      wait_for_effect_on("#new-namespace-form")
 
       expect(page).to have_button("Create", disabled: true)
     end
@@ -28,10 +27,9 @@ describe "Namespaces support" do
       visit namespaces_path
 
       find(".toggle-link-new-namespace").click
-      wait_for_effect_on("#new-namespace-form")
 
-      fill_in "Name", with: Namespace.first.name
-      fill_in "Name", with: ""
+      fill_in "Name", with: "something"
+      clear_field("#namespace_name")
 
       expect(page).to have_content("Name can't be blank")
       expect(page).to have_button("Create", disabled: true)
@@ -41,7 +39,6 @@ describe "Namespaces support" do
       visit namespaces_path
 
       find(".toggle-link-new-namespace").click
-      wait_for_effect_on("#new-namespace-form")
 
       fill_in "Name", with: "!@#!@#"
 
@@ -55,7 +52,6 @@ describe "Namespaces support" do
       visit namespaces_path
 
       find(".toggle-link-new-namespace").click
-      wait_for_effect_on("#new-namespace-form")
 
       expect(page).to have_css(".namespace_team")
     end
@@ -64,7 +60,6 @@ describe "Namespaces support" do
       visit namespaces_path
 
       find(".toggle-link-new-namespace").click
-      wait_for_effect_on("#new-namespace-form")
 
       fill_in "Name", with: Namespace.first.name
       wait_for_ajax
@@ -77,7 +72,6 @@ describe "Namespaces support" do
       visit namespaces_path
 
       find(".toggle-link-new-namespace").click
-      wait_for_effect_on("#new-namespace-form")
 
       fill_in "Name", with: Namespace.first.name
       fill_vue_multiselect(".namespace_team", Team.where(hidden: true).first.name)
@@ -92,14 +86,12 @@ describe "Namespaces support" do
 
       visit namespaces_path
       find(".toggle-link-new-namespace").click
-      wait_for_effect_on("#new-namespace-form")
 
       fill_in "Name", with: "valid-namespace"
       select_vue_multiselect(".namespace_team", namespace.team.name)
       click_button "Create"
 
       wait_for_ajax
-      wait_for_effect_on("#float-alert")
 
       expect(page).to have_css("#float-alert")
       expect(page).to have_content("Namespace 'valid-namespace' was created successfully")
@@ -107,50 +99,10 @@ describe "Namespaces support" do
       # Check that it created a link to it and that it's accessible.
       expect(Namespace.count).to eql namespaces_count + 1
       expect(page).to have_link("valid-namespace")
-      find(:link, "valid-namespace").trigger(:click)
+      find(:link, "valid-namespace").click
 
       namespace = Namespace.find_by(name: "valid-namespace")
       expect(page).to have_current_path(namespace_path(namespace))
-    end
-
-    it 'The "Create new namespace" link has a toggle effect', js: true do
-      visit namespaces_path
-      expect(page).to have_css(".toggle-link-new-namespace i.fa-plus-circle")
-      expect(page).not_to have_css(".toggle-link-new-namespace i.fa-minus-circle")
-
-      find(".toggle-link-new-namespace").click
-      wait_for_effect_on("#new-namespace-form")
-
-      expect(page).not_to have_css(".toggle-link-new-namespace i.fa-plus-circle")
-      expect(page).to have_css(".toggle-link-new-namespace i.fa-minus-circle")
-
-      find(".toggle-link-new-namespace").click
-      wait_for_effect_on("#new-namespace-form")
-
-      expect(page).to have_css(".toggle-link-new-namespace i.fa-plus-circle")
-      expect(page).not_to have_css(".toggle-link-new-namespace i.fa-minus-circle")
-    end
-
-    it 'The "Create new namespace" keeps icon after add new namespace', js: true do
-      visit namespaces_path
-      expect(page).to have_css(".toggle-link-new-namespace i.fa-plus-circle")
-      expect(page).not_to have_css(".toggle-link-new-namespace i.fa-minus-circle")
-
-      find(".toggle-link-new-namespace").click
-      wait_for_effect_on("#new-namespace-form")
-
-      fill_in "Name", with: "valid-namespace"
-      select_vue_multiselect(".namespace_team", namespace.team.name)
-
-      expect(page).not_to have_css(".toggle-link-new-namespace i.fa-plus-circle")
-      expect(page).to have_css(".toggle-link-new-namespace i.fa-minus-circle")
-
-      click_button "Create"
-      wait_for_ajax
-      wait_for_effect_on("#new-namespace-form")
-
-      expect(page).to have_css(".toggle-link-new-namespace i.fa-plus-circle")
-      expect(page).not_to have_css(".toggle-link-new-namespace i.fa-minus-circle")
     end
 
     it "The namespace visibility can be changed", js: true do
@@ -285,7 +237,6 @@ describe "Namespaces support" do
       click_button "Save"
 
       wait_for_ajax
-      wait_for_effect_on("#float-alert")
 
       expect(page).to have_css("#float-alert")
       expect(page).to have_content("Namespace '#{namespace.name}' was updated successfully")
@@ -301,7 +252,6 @@ describe "Namespaces support" do
       click_button "Save"
 
       wait_for_ajax
-      wait_for_effect_on("#float-alert")
 
       expect(page).to have_css("#float-alert")
       expect(page).to have_content("Cool description")

--- a/spec/features/repositories_comments_spec.rb
+++ b/spec/features/repositories_comments_spec.rb
@@ -93,7 +93,8 @@ describe "Repositories comments support" do
 
       find(".toggle-link-new-comment").click
 
-      fill_in "comment_body", with: ""
+      fill_in "comment_body", with: "comment"
+      clear_field("#comment_body")
 
       expect(page).to have_content("Comment can't be blank")
     end

--- a/spec/features/teams_spec.rb
+++ b/spec/features/teams_spec.rb
@@ -20,10 +20,9 @@ describe "Teams support" do
 
     it "A user cannot create an empty team" do
       find(".toggle-link-new-team").click
-      wait_for_effect_on("#new-team-form")
 
-      fill_in "Name", with: Team.first.name
-      fill_in "Name", with: ""
+      fill_in "Name", with: "name"
+      clear_field("#team_name")
 
       expect(page).to have_content("Name can't be blank")
       expect(page).to have_button("Add", disabled: true)
@@ -31,7 +30,6 @@ describe "Teams support" do
 
     it "A team cannot be created if the name has already been picked" do
       find(".toggle-link-new-team").click
-      wait_for_effect_on("#new-team-form")
 
       fill_in "Name", with: Team.last.name
       wait_for_ajax
@@ -44,7 +42,6 @@ describe "Teams support" do
       teams_count = Team.count
 
       find(".toggle-link-new-team").click
-      wait_for_effect_on("#new-team-form")
 
       fill_in "Name", with: "valid-team"
       select admin.username, from: "team_owner_id"
@@ -52,30 +49,12 @@ describe "Teams support" do
 
       click_button "Add"
       wait_for_ajax
-      wait_for_effect_on("#float-alert")
 
       expect(page).to have_css("#float-alert")
       expect(page).to have_content("Team 'valid-team' was created successfully")
       expect(page).to have_link("valid-team")
       expect(page).to have_current_path(teams_path)
       expect(Team.count).to eql(teams_count + 1)
-    end
-
-    it 'The "Create new team" link has a toggle effect' do
-      expect(page).to have_css(".toggle-link-new-team i.fa-plus-circle")
-      expect(page).not_to have_css(".toggle-link-new-team i.fa-minus-circle")
-
-      find(".toggle-link-new-team").click
-      wait_for_effect_on("#new-team-form")
-
-      expect(page).not_to have_css(".toggle-link-new-team i.fa-plus-circle")
-      expect(page).to have_css(".toggle-link-new-team i.fa-minus-circle")
-
-      find(".toggle-link-new-team").click
-      wait_for_effect_on("#new-team-form")
-
-      expect(page).to have_css(".toggle-link-new-team i.fa-plus-circle")
-      expect(page).not_to have_css(".toggle-link-new-team i.fa-minus-circle")
     end
 
     it "The name of each team is a link" do
@@ -106,7 +85,6 @@ describe "Teams support" do
 
     it "shows owner select" do
       find(".toggle-link-new-team").click
-      wait_for_effect_on("#new-team-form")
 
       expect(page).to have_css("#team_name")
       expect(page).to have_css("#team_owner_id")
@@ -114,14 +92,12 @@ describe "Teams support" do
 
     it "creates a team with a different owner" do
       find(".toggle-link-new-team").click
-      wait_for_effect_on("#new-team-form")
 
       fill_in "Name", with: "another"
       select another_user.username, from: "team_owner_id"
 
       click_button "Add"
       wait_for_ajax
-      wait_for_effect_on("#float-alert")
 
       expect(page).to have_css("#float-alert")
       expect(page).to have_content("Team 'another' was created successfully")
@@ -140,7 +116,6 @@ describe "Teams support" do
 
       it "doesn't show owner select" do
         find(".toggle-link-new-team").click
-        wait_for_effect_on("#new-team-form")
 
         expect(page).to have_css("#team_name")
         expect(page).not_to have_css("#team_owner_id")
@@ -188,7 +163,6 @@ describe "Teams support" do
       expect(page).to have_css("#new-namespace-form", visible: false)
 
       find(".toggle-link-new-namespace").click
-      wait_for_effect_on("#new-namespace-form")
 
       expect(page).to have_css("#new-namespace-form")
 
@@ -197,14 +171,13 @@ describe "Teams support" do
       click_button "Create"
 
       wait_for_ajax
-      wait_for_effect_on("#float-alert")
 
       expect(page).to have_css("#float-alert")
       expect(page).to have_content("Namespace 'new-namespace' was created successfully")
 
       expect(Namespace.count).to eql namespaces_count + 1
       expect(page).to have_link("new-namespace")
-      find(:link, "new-namespace").trigger(:click)
+      find(:link, "new-namespace").click
 
       namespace = Namespace.find_by(name: "new-namespace")
       expect(page).to have_current_path(namespace_path(namespace))
@@ -292,7 +265,6 @@ describe "Teams support" do
       click_button "Add"
 
       wait_for_ajax
-      wait_for_effect_on("#float-alert")
 
       expect(page).to have_css("#float-alert")
       expect(page).to have_content("'#{another.username}' was successfully added to the team")
@@ -309,7 +281,6 @@ describe "Teams support" do
       click_button "Add"
 
       wait_for_ajax
-      wait_for_effect_on("#float-alert")
 
       expect(page).to have_css("#float-alert")
       expect(page).to have_content(
@@ -339,7 +310,6 @@ describe "Teams support" do
       find(".team_member_#{tu.id} .btn-primary").click
 
       wait_for_ajax
-      wait_for_effect_on("#float-alert")
 
       expect(page).to have_css("#float-alert")
       expect(page).to have_content("User '#{another.username}' was
@@ -355,7 +325,6 @@ describe "Teams support" do
       find(".popover-content .yes").click
 
       wait_for_ajax
-      wait_for_effect_on("#float-alert")
 
       expect(page).to have_css("#float-alert")
       expect(page).to have_content("User '#{another.username}' was
@@ -367,7 +336,6 @@ describe "Teams support" do
       find(".popover-content .yes").click
 
       wait_for_ajax
-      wait_for_effect_on("#float-alert")
 
       expect(page).to have_css("#float-alert")
       expect(page).to have_content("Cannot remove the only owner of the team")

--- a/spec/features/webhooks_spec.rb
+++ b/spec/features/webhooks_spec.rb
@@ -36,14 +36,12 @@ describe "Webhooks support", js: true do
       webhooks_count = namespace.webhooks.count
 
       find(".toggle-link-new-webhook").click
-      wait_for_effect_on("#new-webhook-form")
 
       fill_in "Name", with: "webhook name"
       fill_in "URL", with: "http://url-here"
       click_button "Add"
 
       wait_for_ajax
-      wait_for_effect_on("#float-alert")
 
       expect(page).to have_css("#float-alert")
       expect(page).to have_content("Webhook 'webhook name' was created successfully")
@@ -51,25 +49,10 @@ describe "Webhooks support", js: true do
       # Check that it created a link to it and that it's accessible.
       expect(namespace.webhooks.count).to eql webhooks_count + 1
       expect(page).to have_link("webhook name")
-      find(:link, "webhook name").trigger(:click)
+      find(:link, "webhook name").click
 
       webhook = namespace.webhooks.find_by(url: "http://url-here")
       expect(page).to have_current_path(namespace_webhook_path(namespace, webhook))
-    end
-
-    it 'The "Create new webhook" link has a toggle effect' do
-      expect(page).to have_css(".toggle-link-new-webhook i.fa-plus-circle")
-      expect(page).not_to have_css(".toggle-link-new-webhook i.fa-minus-circle")
-
-      find(".toggle-link-new-webhook").click
-
-      expect(page).not_to have_css(".toggle-link-new-webhook i.fa-plus-circle")
-      expect(page).to have_css(".toggle-link-new-webhook i.fa-minus-circle")
-
-      find(".toggle-link-new-webhook").click
-
-      expect(page).to have_css(".toggle-link-new-webhook i.fa-plus-circle")
-      expect(page).not_to have_css(".toggle-link-new-webhook i.fa-minus-circle")
     end
 
     it "A user enables/disables webhook" do
@@ -108,7 +91,7 @@ describe "Webhooks support", js: true do
 
     it "cannot update webhook if form is invalid" do
       find(".toggle-link-edit-webhook").click
-      fill_in "Name", with: ""
+      clear_field("#webhook_name")
 
       expect(page).to have_content("Name can't be blank")
       expect(page).to have_button("Save", disabled: true)
@@ -150,14 +133,12 @@ describe "Webhooks support", js: true do
         webhook_headers_count = webhook.headers.count
 
         find(".toggle-link-new-webhook-header").click
-        wait_for_effect_on("#new-webhook-header-form")
 
         fill_in "Name", with: "cool-header"
         fill_in "Value", with: "cool-value"
         click_button "Add"
 
         wait_for_ajax
-        wait_for_effect_on("#float-alert")
 
         expect(page).to have_css("#float-alert")
         expect(page).to have_content("cool-header")
@@ -170,7 +151,6 @@ describe "Webhooks support", js: true do
         webhook_headers_count = webhook.headers.count
 
         find(".toggle-link-new-webhook-header").click
-        wait_for_effect_on("#new-webhook-header-form")
 
         expect(focused_element_id).to eq "header_name"
         fill_in "Name", with: webhook_header.name
@@ -178,7 +158,6 @@ describe "Webhooks support", js: true do
         click_button "Add"
 
         wait_for_ajax
-        wait_for_effect_on("#float-alert")
 
         expect(page).to have_css("#float-alert")
         expect(page).to have_content("Name has already been taken")
@@ -196,21 +175,6 @@ describe "Webhooks support", js: true do
         expect(page).to have_content("Header '#{webhook_header.name}' was removed successfully")
         expect(page).not_to have_content(webhook_header.name)
         expect(page).not_to have_content(webhook_header.value)
-      end
-
-      it 'The "Create new header" link has a toggle effect' do
-        expect(page).to have_css(".toggle-link-new-webhook-header i.fa-plus-circle")
-        expect(page).not_to have_css(".toggle-link-new-webhook-header i.fa-minus-circle")
-
-        find(".toggle-link-new-webhook-header").click
-
-        expect(page).not_to have_css(".toggle-link-new-webhook-header i.fa-plus-circle")
-        expect(page).to have_css(".toggle-link-new-webhook-header i.fa-minus-circle")
-
-        find(".toggle-link-new-webhook-header").click
-
-        expect(page).to have_css(".toggle-link-new-webhook-header i.fa-plus-circle")
-        expect(page).not_to have_css(".toggle-link-new-webhook-header i.fa-minus-circle")
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,9 +7,6 @@ ENV["NODE_ENV"]  ||= "test"
 require "spec_helper"
 require File.expand_path("../config/environment", __dir__)
 require "rspec/rails"
-require "devise"
-require "ffaker"
-require "factory_girl_rails"
 require "pundit/rspec"
 
 # Raise exception for pending migrations after reading the schema.
@@ -42,6 +39,7 @@ RSpec.configure do |config|
   # If we want Capybara + DatabaseCleaner + Poltergeist to work correctly, we
   # have to just set this to false.
   config.use_transactional_fixtures = false
+  config.use_instantiated_fixtures  = false
 
   config.infer_spec_type_from_file_location!
   config.include FactoryGirl::Syntax::Methods

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,11 +1,85 @@
 # frozen_string_literal: true
 
+require "selenium-webdriver"
 require "capybara/rails"
 require "capybara/rspec"
 require "capybara/poltergeist"
 
-WAIT_TIME = 3.minutes
+require_relative "containers"
 
+WAIT_TIME = ENV["TRAVIS"] ? 30 : 10
+
+# HACK: when running tests inside of a container we should use poltergeist
+# This is unfortunately necessary due to an instability of capybara and chromedriver
+# raising Net::ReadTimeout exception
+JAVASCRIPT_DRIVER = Containers.dockerized? ? :poltergeist : :chrome
+
+# Most of below was extracted from
+# https://gitlab.com/gitlab-org/gitlab-ce/blob/master/spec/support/capybara.rb
+
+# Define an error class for JS console messages
+JSConsoleError = Class.new(StandardError)
+
+# Filter out innocuous JS console messages
+JS_CONSOLE_FILTER = Regexp.union(
+  [
+    "Download the Vue Devtools extension",
+    "You are running Vue in development mode"
+  ]
+)
+
+unless ENV["TRAVIS"]
+  require "capybara-screenshot/rspec"
+
+  Capybara::Screenshot.prune_strategy = :keep_last_run
+  # From https://github.com/mattheworiordan/capybara-screenshot/issues/84#issuecomment-41219326
+  Capybara::Screenshot.register_driver(:chrome) do |driver, path|
+    driver.browser.save_screenshot(path)
+  end
+end
+
+# Chrome driver
+Capybara.register_driver :chrome do |app|
+  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
+    # This enables access to logs with `page.driver.manage.get_log(:browser)`
+    loggingPrefs: {
+      browser: "ALL",
+      client:  "ALL",
+      driver:  "ALL",
+      server:  "ALL"
+    }
+  )
+
+  options = Selenium::WebDriver::Chrome::Options.new
+  options.add_argument("window-size=1280,720")
+  options.add_argument("no-sandbox")
+  options.add_argument("headless")
+  options.add_argument("disable-gpu")
+
+  Capybara::Selenium::Driver.new(
+    app,
+    browser:              :chrome,
+    desired_capabilities: capabilities,
+    options:              options
+  )
+end
+
+# RSpec hooks
+unless Containers.dockerized?
+  RSpec.configure do |config|
+    config.after(:example, :js) do |example|
+      next unless ENV["DEBUG_JS"] || example.exception
+
+      console = page.driver.browser.manage.logs.get(:browser)&.reject do |log|
+        log.message =~ JS_CONSOLE_FILTER
+      end
+
+      p console.map(&:message).join("\n") if console.present?
+    end
+  end
+end
+
+# Poltergeist driver
 Capybara.register_driver :poltergeist do |app|
   options = {
     timeout:           WAIT_TIME,
@@ -19,13 +93,11 @@ Capybara.register_driver :poltergeist do |app|
   Capybara::Poltergeist::Driver.new(app, options)
 end
 
-Capybara.javascript_driver = :poltergeist
-
+# Capybara configuration
 Capybara.configure do |config|
-  config.javascript_driver = :poltergeist
+  config.javascript_driver = JAVASCRIPT_DRIVER
   config.default_max_wait_time = WAIT_TIME
   config.match = :one
-  config.exact_options = true
   config.ignore_hidden_elements = true
   config.visible_text_only = true
   config.default_selector = :css

--- a/spec/support/containers.rb
+++ b/spec/support/containers.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Module related to container's helpers stuff
+module Containers
+  # Checks whether it's running inside of a Docker container or not
+  def self.dockerized?
+    @dockerized ||= File.read("/proc/1/cgroup").include?("docker")
+  end
+end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -29,7 +29,7 @@ module Helpers
   # Clears a field value. `fill_in` also does the job but
   # it doesn't trigger keyUp event, for example
   def clear_field(field)
-    find_field(field).send_keys([:control, "a"], :backspace)
+    find(field).native.send_keys([:control, "a"], :backspace)
   end
 
   # Creates the Portus user. The Portus user cannot be created with neither the

--- a/spec/support/wait_for_events.rb
+++ b/spec/support/wait_for_events.rb
@@ -15,11 +15,6 @@ module WaitForEvents
     wait_until_zero("$.active")
   end
 
-  # Wait for all the effects on the given selector to have concluded.
-  def wait_for_effect_on(selector)
-    wait_until_zero("$('#{selector}').queue().length")
-  end
-
   # This method will loop until the given block evaluates to true. It will
   # respect to default timeout as specifyied by Capybara.
   def wait_until


### PR DESCRIPTION
So far the feature tests with js enabled were running through
poltergeist driver. As we know, PhantomJS was discontinued and
that's bad. PhantomJS was far from perfect and we've had a lot
of flaky issues with it.

Even knowing that most of those flaky issues were our fault, it's
always good to improve our workflow whenever possible. Based on this we
are adding chrome headless as our default js runner for our feature
tests.

Unfortunately we had to keep poltergeist for one scenario that we
couldn't make chrome headless work properly. That scenario is when the
dev runs the feature tests inside of the container. For bare metal and
travis, chrome headless works like a charm.

Signed-off-by: Vítor Avelino <vavelino@suse.com>
