### PR TITLE
ui: fixed team field on namespaces#index

### DIFF
--- a/app/views/namespaces/components/_form.html.slim
+++ b/app/views/namespaces/components/_form.html.slim
@@ -13,7 +13,7 @@ div ref="form" class="collapse"
             span.error-message v-for="(error, index) in errors.name" :key="index"
               | Name {{ error }}
 
-    .form-group.has-feedback :class=="{ 'has-error': $v.namespace.team.$error }" v-if="!namespace.team"
+    .form-group.has-feedback :class=="{ 'has-error': $v.namespace.team.$error }" v-if="!teamName"
       = f.label :team, { class: "control-label col-md-2" }
       .col-md-7
         vue-multiselect{

--- a/spec/features/namespaces_spec.rb
+++ b/spec/features/namespaces_spec.rb
@@ -49,6 +49,17 @@ describe "Namespaces support" do
       expect(page).to have_button("Create", disabled: true)
     end
 
+    # TODO: move this test to a component level one instead of feature once
+    # form component is migrated to a vue file
+    it "shows team field if no team", js: true do
+      visit namespaces_path
+
+      find(".toggle-link-new-namespace").click
+      wait_for_effect_on("#new-namespace-form")
+
+      expect(page).to have_css(".namespace_team")
+    end
+
     it "An user cannot create a namespace that already exists", js: true do
       visit namespaces_path
 

--- a/spec/features/teams_spec.rb
+++ b/spec/features/teams_spec.rb
@@ -172,6 +172,15 @@ describe "Teams support" do
       visit team_path(team)
     end
 
+    # TODO: move this test to a component level one instead of feature once
+    # form component is migrated to a vue file
+    it "hides team field if team is defined", js: true do
+      find(".toggle-link-new-namespace").click
+
+      expect(page).to have_css("#namespace_name")
+      expect(page).not_to have_css(".namespace_team")
+    end
+
     it "A namespace can be created from the team page", js: true do
       namespaces_count = Namespace.count
 


### PR DESCRIPTION
When user was selecting a team, the field was disappearing from the
screen. Minor regression introduced during the replacement of typeahead
by vue-multiselect.

Signed-off-by: Vítor Avelino <vavelino@suse.com>