### PR TITLE
Improve detection of containerized environments - fix issue #1732

### DIFF
--- a/packaging/suse/portusctl/lib/constants.rb
+++ b/packaging/suse/portusctl/lib/constants.rb
@@ -4,7 +4,8 @@
 
 # Checks whether it's running inside of a Docker container or not
 def dockerized?
-  File.read("/proc/1/cgroup").include?("docker")
+  cgroup = File.read("/proc/1/cgroup")
+  cgroup.include?("docker") || cgroup.include?("kubepod")
 end
 
 # This one is set by the bash wrapper we deliver with our RPM


### PR DESCRIPTION
The code determining if Portus is running containerized is broken on Kubernetes because in this case PID 1 doesn't belong to the `docker` cgroup slice.

That causes the code to invoke `hostnamectl`, that tries to access kdbus from within a container. That causes Rails to fail immediately.

fixes #1732 