### PR TITLE
Make containerized deployment more configurable

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -31,6 +31,9 @@ default: &default
   <% if ENV["PORTUS_DB_TIMEOUT"] %>
   timeout: <%= ENV['PORTUS_DB_TIMEOUT'] %>
   <% end %>
+  <% if ENV['PORTUS_DB_SOCKET'] %>
+  socket:  <%= ENV['PORTUS_DB_SOCKET'] %>
+  <% end %>
 
 <%= Rails.env.downcase %>:
   <<: *default

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -16,7 +16,7 @@ workers ENV.fetch("PORTUS_PUMA_WORKERS") { 2 }.to_i
 #     purposes inside of a container.
 #  3. UNIX socket. This is the default and it's good for development purposes if
 #     you are not using a container setup.
-if ENV["PORTUS_PUMA_HOST"]
+if ENV["PORTUS_PUMA_HOST"] && ENV["PORTUS_PUMA_USE_UNIX_SOCKET"] != "true"
   if ENV["PORTUS_PUMA_TLS_KEY"]
     host, port = ENV["PORTUS_PUMA_HOST"].split(":")
     port ||= "3000"


### PR DESCRIPTION
A bunch of changes required to be more flexible when deploying Portus into a containerized environment.

### TODO

* [ ] Extend the documentation to mention the new environment variable added.