### PR TITLE
Prevent the update of the portus user

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -5,6 +5,8 @@
 class PasswordsController < Devise::PasswordsController
   layout "authentication"
 
+  before_action :check_portus, only: %i[create]
+
   include CheckLDAP
 
   # Re-implemented from Devise to respond with a proper message on error.
@@ -54,5 +56,15 @@ class PasswordsController < Devise::PasswordsController
   # Prevents redirect loops
   def after_resetting_password_path_for(resource)
     signed_in_root_path(resource)
+  end
+
+  # Prevents the portus user from resetting the password.
+  def check_portus
+    user = User.find_by(email: resource_params["email"])
+    return if user.nil? || !user.portus?
+
+    redirect_to new_user_session_path,
+                alert: "Action not allowed on this user",
+                float: true
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -61,6 +61,7 @@ class User < ActiveRecord::Base
   # Actions performed before/after create.
   validates :username, presence: true, uniqueness: true
   validate :private_namespace_and_team_available, on: :create
+  validate :portus_user_validation, on: :update
   after_create :create_personal_namespace!, if: :needs_namespace?
 
   # Actions performed before destroy
@@ -84,6 +85,13 @@ class User < ActiveRecord::Base
     !(APP_CONFIG.enabled?("ldap") && email.blank?)
   end
 
+  # Adds an error if the user to be updated is the portus one. This is a
+  # validation on update, so it can be skipped when strictly required.
+  def portus_user_validation
+    return unless portus? || portus?(username_was)
+    errors.add(:username, "cannot be updated")
+  end
+
   # It adds an error if the username clashes with either a namespace or a team.
   def private_namespace_and_team_available
     ns = Namespace.make_valid(username)
@@ -91,9 +99,11 @@ class User < ActiveRecord::Base
     errors.add(:username, "'#{username}' cannot be transformed into a valid namespace name")
   end
 
-  # Returns true if the current user is the Portus user.
-  def portus?
-    username == "portus"
+  # Returns true if the current user is the Portus user. You can provide a value
+  # as an alternative to the value of `username`.
+  def portus?(field = nil)
+    f = field.nil? ? username : field
+    f == "portus"
   end
 
   # Returns avatar url if gravatar is enabled and email not blank

--- a/config/initializers/portus_user.rb
+++ b/config/initializers/portus_user.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# This file updates the password of the portus hidden user if this
+# exists and the secret is given.
+
+portus_exists = false
+begin
+  portus_exists = User.exists?(username: "portus")
+rescue StandardError
+  # We will ignore any error and skip this initializer. This is done this way
+  # because it can get really tricky to catch all the myriad of exceptions that
+  # might be raised on database errors.
+  portus_exists = false
+end
+
+password = Rails.application.secrets.portus_password
+if portus_exists && password.present?
+  portus = User.find_by(username: "portus")
+  portus&.update_attribute("password", Rails.application.secrets.portus_password)
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,9 +8,4 @@ if User.any?
 end
 
 Rails.logger.info "Adding the \"portus\" user"
-User.create!(
-  username: "portus",
-  password: Rails.application.secrets.portus_password,
-  email:    "portus@portus.com",
-  admin:    true
-)
+User.create_portus_user!

--- a/spec/api/grape_api/v1/users_spec.rb
+++ b/spec/api/grape_api/v1/users_spec.rb
@@ -149,6 +149,15 @@ describe API::V1::Users do
         expect(response).to have_http_status(:not_found)
       end
     end
+
+    context "portus user" do
+      it "does not allow portus user to be updated" do
+        create :user, username: "portus", email: "portus@portus.com"
+        portus = User.find_by(username: "portus")
+        put "/api/v1/users/#{portus.id}", { user: user_data }, @header
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
   end
 
   context "DELETE /api/v1/users/:id" do

--- a/spec/api/v2/token_spec.rb
+++ b/spec/api/v2/token_spec.rb
@@ -306,14 +306,7 @@ describe "/v2/token" do
           }
         end
 
-        before do
-          User.create!(
-            username: "portus",
-            password: Rails.application.secrets.portus_password,
-            email:    "portus@portus.com",
-            admin:    true
-          )
-        end
+        before { User.create_portus_user! }
 
         it "allows portus to access the Catalog API" do
           get v2_token_url, valid_request, valid_portus_auth_header

--- a/spec/controllers/namespaces_controller_spec.rb
+++ b/spec/controllers/namespaces_controller_spec.rb
@@ -62,7 +62,9 @@ describe NamespacesController, type: :controller do
   end
 
   describe "GET #show" do
-    let!(:portus) { create(:admin, username: "portus") }
+    before { User.create_portus_user! }
+
+    let(:portus) { User.find_by(username: "portus") }
 
     it "allows team members to view the page" do
       sign_in owner

--- a/spec/features/auth/signup_feature_spec.rb
+++ b/spec/features/auth/signup_feature_spec.rb
@@ -38,7 +38,7 @@ describe "Signup feature" do
 
   it "The portus user does not interfere with regular admin creation" do
     User.delete_all
-    create_portus_user!
+    User.create_portus_user!
 
     visit new_user_registration_url
 
@@ -102,7 +102,7 @@ describe "Signup feature" do
 
   it "I am redirected to the signup page if only the portus user exists" do
     User.delete_all
-    create(:admin, username: "portus")
+    User.create_portus_user!
 
     visit new_user_session_url
     expect(current_url).to eq new_user_registration_url

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -39,7 +39,7 @@ describe "Dashboard page" do
 
   describe "Portus user" do
     it "The dashboard does not count the Portus user" do
-      create_portus_user!
+      User.create_portus_user!
       visit authenticated_root_path
 
       # 4 users: user, another_user, regular_user, and the one created by the registry.
@@ -49,7 +49,7 @@ describe "Dashboard page" do
     it "warns the admin that the portus user does not exist" do
       expect(page).to have_content("The Portus user does not exist!")
 
-      create_portus_user!
+      User.create_portus_user!
       visit authenticated_root_path
 
       expect(page).not_to have_content("The Portus user does not exist!")

--- a/spec/features/forgotten_password_spec.rb
+++ b/spec/features/forgotten_password_spec.rb
@@ -3,7 +3,8 @@
 require "rails_helper"
 
 describe "Forgotten password support" do
-  let!(:user) { create(:admin) }
+  let!(:user)   { create(:admin) }
+  let!(:portus) { create(:admin, username: "portus", email: "portus@portus.com") }
 
   before do
     APP_CONFIG["signup"] = { "enabled" => true }
@@ -19,6 +20,14 @@ describe "Forgotten password support" do
   it "gives the user a link to reset their password" do
     visit new_user_session_path
     expect(page).to have_content("I forgot my password")
+  end
+
+  it "prevents the portus user from resetting the password" do
+    visit new_user_password_path
+
+    fill_in "Email", with: "portus@portus.com"
+    click_button "Reset password"
+    expect(page).to have_content("Action not allowed on this user")
   end
 
   it "sends the reset email when appropiate" do

--- a/spec/integration/profiles/shared.rb
+++ b/spec/integration/profiles/shared.rb
@@ -20,10 +20,5 @@ def create_registry!
   Registry.create!(name: "registry", hostname: hostname, use_ssl: false)
   ENV["PORTUS_INTEGRATION_HOSTNAME"] = nil
 
-  User.create!(
-    username: "portus",
-    password: Rails.application.secrets.portus_password,
-    email:    "portus@portus.com",
-    admin:    true
-  )
+  User.create_portus_user!
 end

--- a/spec/lib/portus/background/garbage_collector_spec.rb
+++ b/spec/lib/portus/background/garbage_collector_spec.rb
@@ -99,8 +99,9 @@ describe ::Portus::Background::GarbageCollector do
 
   describe "#execute!" do
     let!(:registry)   { create(:registry, hostname: "registry.test.lan") }
-    let!(:portus)     { create(:admin, username: "portus") }
     let!(:repository) { create(:repository, namespace: registry.global_namespace, name: "repo") }
+
+    before { User.create_portus_user! }
 
     it "removes tags" do
       allow_any_instance_of(Tag).to(receive(:fetch_digest).and_return("1234"))

--- a/spec/lib/portus/registry_client_spec.rb
+++ b/spec/lib/portus/registry_client_spec.rb
@@ -242,7 +242,7 @@ describe Portus::RegistryClient do
   context "fetching Catalog from registry" do
     it "returns the available catalog" do
       create(:registry)
-      create(:admin, username: "portus")
+      User.create_portus_user!
 
       VCR.use_cassette("registry/get_registry_catalog", record: :none) do
         registry = described_class.new(
@@ -261,7 +261,7 @@ describe Portus::RegistryClient do
 
     it "returns the available catalog even if it has more than 100 repos" do
       create(:registry)
-      create(:admin, username: "portus")
+      User.create_portus_user!
 
       VCR.use_cassette("registry/catalog_lots_of_repos", record: :none) do
         WebMock.disable_net_connect!
@@ -286,7 +286,7 @@ describe Portus::RegistryClient do
 
     it "does not remove all repos just because one of them is failing" do
       create(:registry)
-      create(:admin, username: "portus")
+      User.create_portus_user!
 
       VCR.use_cassette("registry/get_registry_one_fails", record: :none) do
         registry = described_class.new(
@@ -355,7 +355,7 @@ describe Portus::RegistryClient do
 
     it "returns nil for tags when an exception happened" do
       create(:registry)
-      create(:admin, username: "portus")
+      User.create_portus_user!
 
       allow_any_instance_of(::Portus::RegistryClient).to receive(:tags) do
         raise ::Portus::Errors::NotFoundError, "I AM ERROR"
@@ -380,7 +380,7 @@ describe Portus::RegistryClient do
   context "fetching lists from the catalog" do
     it "returns the available tags even if there are more than 100 of them" do
       create(:registry)
-      create(:admin, username: "portus")
+      User.create_portus_user!
 
       VCR.use_cassette("registry/catalog_lots_of_tags", record: :none) do
         registry = described_class.new(

--- a/spec/models/namespace_spec.rb
+++ b/spec/models/namespace_spec.rb
@@ -67,9 +67,11 @@ describe Namespace do
   end
 
   context "is portus" do
-    let!(:registry)    { create(:registry) }
-    let!(:owner)       { create(:user) }
-    let!(:portus)      { create(:admin, username: "portus") }
+    let!(:registry) { create(:registry) }
+    let!(:owner)    { create(:user) }
+    let(:portus)    { User.find_by(username: "portus") }
+
+    before { User.create_portus_user! }
 
     it "returns true when the given namespace belongs to portus" do
       expect(described_class.find_by(name: portus.username)).to be_portus

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -560,7 +560,6 @@ describe Repository do
   describe "create_or_update" do
     let!(:registry)    { create(:registry) }
     let!(:owner)       { create(:user) }
-    let!(:portus)      { create(:user, username: "portus") }
     let!(:team)        { create(:team, owners: [owner]) }
     let!(:namespace)   { create(:namespace, team: team) }
     let!(:repo1)       { create(:repository, name: "repo1", namespace: namespace) }
@@ -586,6 +585,8 @@ describe Repository do
       end
 
       allow(described_class).to receive(:id_and_digest_from_event).and_return(%w[id digest])
+
+      User.create_portus_user!
     end
 
     it "adds and deletes tags accordingly" do
@@ -645,13 +646,14 @@ describe Repository do
   describe "Groupped tags" do
     let!(:registry)   { create(:registry) }
     let!(:owner)      { create(:user) }
-    let!(:portus)     { create(:user, username: "portus") }
     let!(:team)       { create(:team, owners: [owner]) }
     let!(:namespace)  { create(:namespace, team: team) }
     let!(:repo)        { create(:repository, namespace: namespace) }
     let!(:tag1)        { create(:tag, repository: repo, digest: "1234") }
     let!(:tag2)        { create(:tag, repository: repo, digest: tag1.digest) }
     let!(:tag3)        { create(:tag, repository: repo, digest: "5678", created_at: 2.hours.ago) }
+
+    before { User.create_portus_user! }
 
     it "groups tags as expected" do
       tags = repo.groupped_tags
@@ -670,13 +672,14 @@ describe Repository do
   describe "handle delete event" do
     let!(:registry)   { create(:registry) }
     let!(:owner)      { create(:user) }
-    let!(:portus)     { create(:user, username: "portus") }
     let!(:team)       { create(:team, owners: [owner]) }
     let!(:namespace)  { create(:namespace, team: team, registry: registry) }
     let!(:repo)       { create(:repository, namespace: namespace) }
     let!(:tag1)       { create(:tag, repository: repo, digest: "1234") }
     let!(:tag2)       { create(:tag, repository: repo, digest: tag1.digest) }
     let!(:tag3)       { create(:tag, repository: repo, digest: "5678") }
+
+    before { User.create_portus_user! }
 
     let!(:event) do
       {

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -109,6 +109,18 @@ describe User do
     end
   end
 
+  describe ".create_portus_user" do
+    it "creates the portus user" do
+      described_class.create_portus_user!
+      expect(User.first.username).to eq "portus"
+    end
+
+    it "sets `skip_portus_validation` back to nil" do
+      described_class.create_portus_user!
+      expect(User.skip_portus_validation).to be_nil
+    end
+  end
+
   describe "#create_personal_namespace!" do
     context "no registry defined yet" do
       before do

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -32,19 +32,6 @@ module Helpers
     find(field).native.send_keys([:control, "a"], :backspace)
   end
 
-  # Creates the Portus user. The Portus user cannot be created with neither the
-  # "user" factory nor the "admin" one. This is because in the application this
-  # same user is created in a special way (directly, without associating a
-  # namespace to it, etc.).
-  def create_portus_user!
-    User.create!(
-      username: "portus",
-      password: Rails.application.secrets.portus_password,
-      email:    "portus@portus.com",
-      admin:    true
-    )
-  end
-
   # Unfortunately vue-multiselect component is not very friendly regarding
   # interactions without being in the vue/node testing world.
   def fill_vue_multiselect(element, text)


### PR DESCRIPTION
### Summary

This pull request introduces two commits that prevents someone from updating the portus hidden user. This user is not to be used externally (i.e. it's not an explicit admin), but it's used internally for requests performed against the registry. That being said, if an attacker has access to the email being set for this hidden user, then it may be able to reset the password and use it externally too. This is now mitigated:

1. The update on the portus hidden user is no longer allowed (at the model level).
2. An initializer has been introduced that updates the password of this hidden user depending on the password secret. This is useful when the administrator thinks that this secret has been compromised and wants to update it: simply set a new secret and restart portus.
3. The "I forgot my password" workflow has been disabled for this hidden user.

Thanks @kiorky for noticing this bug :clap: 

Fixes #1878

#### To be done

- [ ] Port to the `v2.3` branch.
- [ ] Update the documentation on the second point.