### PR TITLE
Fixed regression on registries not being created

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -104,6 +104,13 @@ class User < ActiveRecord::Base
   # Adds an error if the user to be updated is the portus one. This is a
   # validation on update, so it can be skipped when strictly required.
   def portus_user_validation
+    # If nothing really changed (e.g. Rails simply touched this record), then we
+    # can leave early.
+    return if changed.empty?
+
+    # If validation for this was temporarily disabled (e.g. we are creating the
+    # Portus hidden user for the first time), then enable it back but return
+    # early.
     if User.skip_portus_validation
       User.skip_portus_validation = nil
       return

--- a/app/services/registries/create_service.rb
+++ b/app/services/registries/create_service.rb
@@ -11,6 +11,7 @@ module Registries
       check!
       if @valid
         Namespace.update_all(registry_id: @registry.id) if @registry.save
+        @valid = @registry.persisted?
       end
 
       @registry

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -119,6 +119,34 @@ describe User do
       described_class.create_portus_user!
       expect(User.skip_portus_validation).to be_nil
     end
+
+    it "does not create a namespace or a team because there's no registry" do
+      described_class.create_portus_user!
+      expect(Team.count).to eq 0
+      expect(Namespace.count).to eq 0
+    end
+  end
+
+  describe "#portus_user_validation" do
+    it "does nothing if the portus user was simply touched" do
+      described_class.create_portus_user!
+      portus = User.find_by(username: "portus")
+
+      portus.touch
+      expect(portus.errors.any?).to be_falsey
+    end
+
+    it "does nothing if the portus user has a new team" do
+      User.delete_all
+      described_class.create_portus_user!
+
+      r = Registry.new(name: "r", hostname: "registry.mssola.cat:5000", use_ssl: true)
+      r.save!
+
+      portus = User.find_by(username: "portus")
+      expect(portus.namespace).not_to be_nil
+      expect(portus.namespace.team).not_to be_nil
+    end
   end
 
   describe "#create_personal_namespace!" do

--- a/spec/services/registries/create_service_spec.rb
+++ b/spec/services/registries/create_service_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# It creates a registry (by force so reachability is not checked) by using the
+# create service. It accepts a boolean parameter: set it to true if you want the
+# `persisted?` to be mocked (returning false).
+def create_registry_with_service(should_mock)
+  allow_any_instance_of(Registry).to receive(:persisted?).and_return(false) if should_mock
+  svc = ::Registries::CreateService.new(nil, name: "test", hostname: "test.lan", use_ssl: false)
+  svc.force = true
+  svc.execute
+  svc
+end
+
+describe "Registries::CreateService" do
+  describe "#execute" do
+    it "marks the registry as invalid if it didn't persist" do
+      svc = create_registry_with_service(true)
+      expect(svc).not_to be_valid
+    end
+
+    it "is valid if it did persist" do
+      svc = create_registry_with_service(false)
+      expect(svc).to be_valid
+    end
+  end
+end


### PR DESCRIPTION
This commit fixes a regression introduced in the pull request #1896 in
which registries were no longer creatable. This happened because of a
validation error on `portus_user_validation` produced by adding a team
to the portus hidden user.

Fixes #1909

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>