### PR TITLE
js: remove input after copying to clipboard

### DIFF
--- a/app/assets/javascripts/modules/repositories/components/tags/tag.vue
+++ b/app/assets/javascripts/modules/repositories/components/tags/tag.vue
@@ -32,6 +32,7 @@
         tempInput.value = this.commandToPull;
         tempInput.select();
         document.execCommand('copy');
+        tempInput.parentNode.removeChild(tempInput);
 
         this.$alert.$show('Copied pull command to clipboard');
       },


### PR DESCRIPTION
Input was being added to the body but not being removed after its
content was copied to the clipboard.

Signed-off-by: Vítor Avelino <vavelino@suse.com>