### PR TITLE
ui: created <sign-out-btn> component

### DIFF
--- a/app/assets/javascripts/bootstrap.js
+++ b/app/assets/javascripts/bootstrap.js
@@ -10,6 +10,14 @@ import { setTimeOutAlertDelay, refreshFloatAlertPosition } from './utils/effects
 dayjs.extend(relativeTime);
 
 $(function () {
+  // this is a fallback to always instantiate a vue instance
+  // useful for isolated shared components like <sign-out-btn>
+  // eslint-disable-next-line no-underscore-dangle
+  if (!$('.vue-root')[0].__vue__) {
+    // eslint-disable-next-line no-new
+    new Vue({ el: '.vue-root' });
+  }
+
   if ($.fn.popover) {
     $('a[rel~=popover], .has-popover').popover();
   }
@@ -17,6 +25,8 @@ $(function () {
   if ($.fn.tooltip) {
     $('a[rel~=tooltip], .has-tooltip').tooltip();
   }
+
+  $('.alert .close').on('click', function () { $(this).closest('.alert-wrapper').fadeOut(); });
 
   // process scheduled alerts
   Alert.$process();

--- a/app/assets/javascripts/plugins/unauthenticated.js
+++ b/app/assets/javascripts/plugins/unauthenticated.js
@@ -1,0 +1,5 @@
+import Vue from 'vue';
+
+import Alert from '~/plugins/alert';
+
+Vue.use(Alert);

--- a/app/assets/javascripts/shared/components/sign-out-btn.vue
+++ b/app/assets/javascripts/shared/components/sign-out-btn.vue
@@ -1,0 +1,39 @@
+<template>
+  <span>
+    <a class="topbar btn btn-default" id="logout" data-placement="bottom" data-toggle="tooltip" :title="title" rel="nofollow" href="#" v-bind="$attrs" @click.prevent="onClick">
+      <i class="fa fa-sign-out"></i>
+    </a>
+    <form method="post" :action="href" class="hidden" ref="form">
+      <input name="_method" value="delete" type="hidden" />
+      <input name="authenticity_token" :value="csrfToken" type="hidden" />
+    </form>
+  </span>
+</template>
+
+<script>
+  import CSRF from '~/utils/csrf';
+
+  export default {
+    inheritAttrs: false,
+
+    props: {
+      href: String,
+      title: {
+        type: String,
+        default: 'Sign out',
+      },
+    },
+
+    computed: {
+      csrfToken() {
+        return CSRF.token();
+      },
+    },
+
+    methods: {
+      onClick() {
+        this.$refs.form.submit();
+      },
+    },
+  };
+</script>

--- a/app/assets/javascripts/unauthenticated.js
+++ b/app/assets/javascripts/unauthenticated.js
@@ -1,8 +1,8 @@
-
 // Bootstrap
 import 'bootstrap/js/tooltip';
 
 // misc
+import './plugins/unauthenticated';
 import './polyfill';
 
 // modules

--- a/app/controllers/auth/sessions_controller.rb
+++ b/app/controllers/auth/sessions_controller.rb
@@ -35,9 +35,4 @@ class Auth::SessionsController < Devise::SessionsController
       flash[:notice] = nil
     end
   end
-
-  def destroy
-    super
-    flash[:notice] = nil
-  end
 end

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -15,5 +15,4 @@
         = link_to edit_user_registration_path, class: 'btn-inline-header', data: {placement: 'bottom', toggle: 'tooltip'}, title: 'My profile' do
           = user_image_tag(current_user)
           span.username = current_user.display_username
-      = link_to destroy_user_session_path, method: :delete, class: 'topbar btn btn-default', id: 'logout', data: {placement: 'bottom', toggle: 'tooltip'}, title: 'Logout' do
-        i.fa.fa-sign-out
+      <sign-out-btn class="topbar" href="#{destroy_user_session_path}" title="Logout"></sign-out-btn>

--- a/app/views/shared/_notification.html.slim
+++ b/app/views/shared/_notification.html.slim
@@ -1,4 +1,4 @@
-div [id="#{float == true ? 'float' : 'fixed'}-alert" class="#{messages && messages.first ? '' : 'collapse'}"]
+div [id="#{float == true ? 'float' : 'fixed'}-alert" class="#{messages && messages.first ? '' : 'collapse'} alert-wrapper"]
   .alert.alert-dismissible.fade.in.text-left[class="alert-#{alert == 'alert' ? 'danger' : 'info'} #{float == true ? 'float-alert' : ''}"]
     button.close class="alert-hide" type="button"
       span aria-hidden="true" &times;

--- a/spec/features/application_spec.rb
+++ b/spec/features/application_spec.rb
@@ -13,7 +13,7 @@ describe "Global application" do
       expect(page).to have_current_path(root_path)
     end
 
-    it "redirects properly for accounts without email" do
+    it "redirects properly for accounts without email", js: true do
       APP_CONFIG["ldap"]["enabled"] = true
       incomplete = create(:user, email: "")
       login_as incomplete, scope: :user

--- a/spec/features/auth/logout_feature_spec.rb
+++ b/spec/features/auth/logout_feature_spec.rb
@@ -2,24 +2,26 @@
 
 require "rails_helper"
 
-describe "Logout feature" do
+describe "Logout feature", js: true do
   let!(:registry) { create(:registry) }
   let!(:user) { create(:user) }
 
   before do
-    login user
+    login_as user
+    visit authenticated_root_path
   end
 
   it "Redirects to login screen" do
+    expect(page).to have_css("#logout")
     click_link("logout")
-    expect(current_url).to eq new_user_session_url
-    expect(page).not_to have_content("Signed out")
+    expect(page).to have_content("Signed out successfully")
   end
 
   it "After login guest redirects to login page when he attempts to access dashboard again" do
+    expect(page).to have_css("#logout")
     click_link("logout")
-    visit root_url
+
+    visit authenticated_root_path
     expect(page).to have_content("Login")
-    expect(current_url).to eq root_url
   end
 end


### PR DESCRIPTION
After the removal os jquery-ujs, the sign out button stopped working.

A component to mimic the previous behavior was created and it's called
<sign-out-btn> by default in the shared/components folder.

Signed-off-by: Vítor Avelino <vavelino@suse.com>

Fixes #1931 
