### PR TITLE
Implemented namespace deletion

### DIFF
--- a/app/assets/javascripts/modules/namespaces/components/delete-btn.vue
+++ b/app/assets/javascripts/modules/namespaces/components/delete-btn.vue
@@ -1,0 +1,69 @@
+<template>
+  <div>
+    <button
+      class="btn btn-danger namespace-delete-btn"
+      data-container="body"
+      data-placement="left"
+      data-toggle="popover"
+      data-content="<p>Are you sure you want to remove this namespace?</p>
+      <a class='btn btn-default'>No</a> <a class='btn btn-primary yes'>Yes</a>"
+      data-template="<div class='popover popover-namespace-delete' role='tooltip'><div class='arrow'></div><h3 class='popover-title'></h3><div class='popover-content'></div></div>'"
+      data-html="true"
+      role="button"
+      title="Delete image"
+      :disabled="state.isDeleting">
+      <i class="fa fa-trash"></i>
+      Delete namespace
+    </button>
+  </div>
+</template>
+
+<script>
+  import Vue from 'vue';
+
+  import { handleHttpResponseError } from '~/utils/http';
+
+  import NamespacesStore from '../store';
+  import NamespacesService from '../services/namespaces';
+
+  const { set } = Vue;
+
+  export default {
+    props: {
+      namespace: {
+        type: Object,
+        required: true,
+      },
+      redirectPath: String,
+    },
+
+    data() {
+      return {
+        state: NamespacesStore.state,
+      };
+    },
+
+    methods: {
+      deleteNamespace() {
+        set(this.state, 'isDeleting', true);
+
+        NamespacesService.remove(this.namespace.id).then(() => {
+          this.$alert.$schedule('Namespace removed with all its repositories');
+          window.location.href = this.redirectPath;
+        }).catch(handleHttpResponseError)
+          .finally(() => set(this.state, 'isDeleting', false));
+      },
+    },
+
+    mounted() {
+      const DELETE_BTN = '.namespace-delete-btn';
+      const POPOVER_DELETE = '.popover-namespace-delete';
+
+      // TODO: refactor bootstrap popover to a component
+      $(this.$el).on('inserted.bs.popover', DELETE_BTN, () => {
+        const $yes = $(POPOVER_DELETE).find('.yes');
+        $yes.click(this.deleteNamespace.bind(this));
+      });
+    },
+  };
+</script>

--- a/app/assets/javascripts/modules/namespaces/pages/show.vue
+++ b/app/assets/javascripts/modules/namespaces/pages/show.vue
@@ -1,5 +1,13 @@
 <template>
   <div class="namespaces-show-page">
+    <div class="header clearfix">
+      <div class="btn-toolbar pull-right">
+        <div class="btn-group">
+          <delete-namespace-btn :namespace="namespace" :redirect-path="namespacesPath" v-if="namespace.destroyable"></delete-namespace-btn>
+        </div>
+      </div>
+    </div>
+
     <namespace-details-panel :namespace="namespace" :state="state" :teams-path="teamsPath" :webhooks-path="webhooksPath"></namespace-details-panel>
     <repositories-panel title="Namespace's repositories" :repositories="repositories" :show-namespaces="false" :repositories-path="repositoriesPath">
       <div slot="heading-right">
@@ -68,6 +76,7 @@
 
   import RepositoriesPanel from '~/modules/repositories/components/panel';
   import WebhooksPanel from '~/modules/webhooks/components/panel';
+  import DeleteNamespaceBtn from '../components/delete-btn';
 
   import NamespaceDetailsPanel from '../components/details';
 
@@ -82,6 +91,9 @@
       },
       repositoriesRef: {
         type: Array,
+      },
+      namespacesPath: {
+        type: String,
       },
       repositoriesPath: {
         type: String,
@@ -98,6 +110,7 @@
       NamespaceDetailsPanel,
       RepositoriesPanel,
       WebhooksPanel,
+      DeleteNamespaceBtn,
     },
 
     data() {

--- a/app/assets/javascripts/modules/namespaces/services/namespaces.js
+++ b/app/assets/javascripts/modules/namespaces/services/namespaces.js
@@ -58,11 +58,16 @@ function teamExists(value) {
     .catch(() => null);
 }
 
+function remove(id) {
+  return resource.delete({ id });
+}
+
 export default {
   get,
   all,
   update,
   save,
+  remove,
   searchTeam,
   teamExists,
   validate,

--- a/app/assets/javascripts/modules/namespaces/store.js
+++ b/app/assets/javascripts/modules/namespaces/store.js
@@ -3,6 +3,7 @@ class RepositoriesStore {
     this.state = {
       newFormVisible: false,
       editFormVisible: false,
+      isDeleting: false,
       isLoading: false,
       notLoaded: false,
       onGoingVisibilityRequest: false,

--- a/app/assets/javascripts/modules/users/components/application-tokens/panel.vue
+++ b/app/assets/javascripts/modules/users/components/application-tokens/panel.vue
@@ -3,7 +3,7 @@
     <h5 slot="heading-left">Application tokens</h5>
 
     <div slot="heading-right" v-if="canCreate">
-      <toggle-link text="Create new team" :state="state" state-key="newFormVisible" class="toggle-link-new-app-token"></toggle-link>
+      <toggle-link text="Create new token" :state="state" state-key="newFormVisible" class="toggle-link-new-app-token"></toggle-link>
     </div>
 
     <div slot="body">

--- a/app/helpers/namespaces_helper.rb
+++ b/app/helpers/namespaces_helper.rb
@@ -9,4 +9,43 @@ module NamespacesHelper
   def can_create_namespace?
     current_user.admin? || APP_CONFIG.enabled?("user_permission.create_namespace")
   end
+
+  # Render the name for the namespace from the given activity. An article can be
+  # prepended to the activity if `article` is set to true (e.g. "deleted the
+  # namespace" vs "deleted namespace").
+  #
+  # NOTE: to be removed when working on #1936,
+  def render_namespace_name(activity, article = false)
+    name = activity.parameters[:namespace_name]
+
+    if name
+      articled("the ", name, article)
+    elsif activity.trackable && activity.trackable_type == "Namespace"
+      articled("the ", link_to(activity.trackable.name, activity.trackable), article)
+    else
+      articled(name, "a", article)
+    end
+  end
+
+  # Render the team for the namespace from the given activity.
+  #
+  # NOTE: to be removed when working on #1936,
+  def render_namespace_team(activity)
+    name = activity.parameters[:team]
+
+    if activity.trackable_type == "Namespace" && activity.trackable&.team
+      content_tag(:span, "the ") + link_to(activity.trackable.team.name, activity.trackable.team)
+    elsif name
+      content_tag(:span, "the ") + name
+    else
+      content_tag(:span, "a")
+    end
+  end
+
+  protected
+
+  # NOTE: to be removed when working on #1936,
+  def articled(pre, post, article)
+    article ? content_tag(:span, pre) + post : post
+  end
 end

--- a/app/helpers/repositories_helper.rb
+++ b/app/helpers/repositories_helper.rb
@@ -65,7 +65,7 @@ module RepositoriesHelper
     owner = content_tag(:strong, "#{activity_owner(activity)} #{action} ")
 
     namespace = render_namespace(activity)
-    namespace += " / " unless namespace.empty?
+    namespace += "/" unless namespace.empty?
 
     owner + namespace + render_repository(activity)
   end
@@ -78,7 +78,7 @@ module RepositoriesHelper
   def render_namespace(activity)
     tr = activity.trackable
 
-    if tr.nil? || tr.is_a?(Namespace)
+    if tr.nil? || tr.is_a?(Namespace) || tr.is_a?(Registry)
       if activity.parameters[:namespace_name].nil?
         ""
       else
@@ -111,7 +111,7 @@ module RepositoriesHelper
   def get_repo_link_tag(activity)
     tr = activity.trackable
 
-    if tr.nil?
+    if tr.nil? || tr.is_a?(Registry)
       if repo_name(activity).nil?
         ["a repository", nil, ""]
       else

--- a/app/models/activity/fallback.rb
+++ b/app/models/activity/fallback.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Activity holds utility methods to update activity records depending on the
+# model including this module.
+module Activity
+  # Fallback has a set of methods that manage trackable types for existing
+  # activities.
+  module Fallback
+    # fallback_activity updates the model including this method by setting a new
+    # type an id for all the rows.
+    def fallback_activity(type, id)
+      PublicActivity::Activity.where(trackable: self).update_all(
+        trackable_type: type,
+        trackable_id:   id,
+        recipient_type: nil
+      )
+    end
+  end
+end

--- a/app/models/registry.rb
+++ b/app/models/registry.rb
@@ -24,6 +24,8 @@
 # NOTE: currently only one Registry is allowed to exist in the database. This
 # might change in the future.
 class Registry < ActiveRecord::Base
+  include PublicActivity::Common
+
   has_many :namespaces, dependent: :destroy
 
   validates :name, presence: true, uniqueness: true

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -20,6 +20,7 @@
 class Repository < ActiveRecord::Base
   include PublicActivity::Common
   include SearchCop
+  include ::Activity::Fallback
 
   belongs_to :namespace
   has_many :tags, dependent: :delete_all
@@ -247,12 +248,7 @@ class Repository < ActiveRecord::Base
 
   # Create/update the activities for a delete operation.
   def create_delete_activities!(actor)
-    # Take care of current activities.
-    PublicActivity::Activity.where(trackable: self).update_all(
-      trackable_type: Namespace,
-      trackable_id:   namespace.id,
-      recipient_type: nil
-    )
+    fallback_activity(Namespace, namespace.id)
 
     # Add a "delete" activity"
     namespace.create_activity(

--- a/app/policies/public_activity/activity_policy.rb
+++ b/app/policies/public_activity/activity_policy.rb
@@ -14,6 +14,7 @@ class PublicActivity::ActivityPolicy
       public_visibility = Namespace.visibilities[:visibility_public]
 
       team_activities(teams_ids, count)
+        .union_all(registry_activities(count))
         .union_all(namespace_activities(teams_ids, public_visibility, count))
         .union_all(repository_activities(teams_ids, public_visibility, count))
         .union_all(application_token_activities(count))
@@ -22,6 +23,14 @@ class PublicActivity::ActivityPolicy
     end
 
     protected
+
+    def registry_activities(count)
+      @scope
+        .where("activities.trackable_type = ? AND activities.trackable_id IN (?)",
+               "Registry", Registry.get&.id)
+        .order(id: :desc)
+        .limit(count)
+    end
 
     # Show Team events only if user is a member of the team
     def team_activities(teams_ids, count)

--- a/app/policies/repository_policy.rb
+++ b/app/policies/repository_policy.rb
@@ -19,13 +19,7 @@ class RepositoryPolicy
 
   # Returns true if the repository can be destroyed.
   def destroy?
-    raise Pundit::NotAuthorizedError, "must be logged in" unless @user
-
-    delete_enabled         = APP_CONFIG.enabled?("delete")
-    is_owner               = @repository.namespace.team.owners.exists?(user.id)
-    can_contributor_delete = APP_CONFIG["delete"]["contributors"] &&
-                             @repository.namespace.team.contributors.exists?(user.id)
-    delete_enabled && (@user.admin? || is_owner || can_contributor_delete)
+    NamespacePolicy.new(@user, @repository.namespace).destroy?
   end
 
   class Scope

--- a/app/services/namespaces/destroy_service.rb
+++ b/app/services/namespaces/destroy_service.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Namespaces
+  class DestroyService < ::BaseService
+    attr_accessor :error
+
+    def execute(namespace)
+      raise ActiveRecord::RecordNotFound if namespace.nil?
+      attempt_destroy!(namespace)
+    end
+
+    protected
+
+    # attempt_destroy! checks that there are no semantic errors (e.g. trying to
+    # remove a personal namespace manually), then it removes repositories
+    # depending on this namespace and finally it removes the namespace.
+    #
+    # If any of the aforementioned steps fail, it will return false while
+    # setting the proper value to the `error` instance variable. Otherwise it
+    # returns true.
+    def attempt_destroy!(namespace)
+      return false if personal_namespace?(namespace)
+      return false unless destroy_repositories!(namespace)
+
+      destroyed = namespace.delete_by!(current_user)
+      return true if destroyed
+
+      full_messages = !namespace.errors.empty? && namespace.errors.full_messages
+      @error = full_messages || "Could not remove namespace"
+      false
+    end
+
+    # Returns true if the given namespace is a personal namespace of some
+    # user. If so, then it will also set the `error` instance variable
+    # accordingly.
+    def personal_namespace?(namespace)
+      return false unless User.find_by(namespace: namespace)
+      @error = "Cannot remove personal namespace"
+      true
+    end
+
+    # Destroys the repositories of the given namespace and returns true on
+    # success, false otherwise.
+    def destroy_repositories!(namespace)
+      errors = {}
+      namespace.repositories.each do |r|
+        svc = ::Repositories::DestroyService.new(current_user)
+        errors[r.full_name.to_s] = svc.error unless svc.execute(r)
+      end
+
+      @error = errors unless errors.empty?
+      errors.empty?
+    end
+  end
+end

--- a/app/views/namespaces/show.html.slim
+++ b/app/views/namespaces/show.html.slim
@@ -1,1 +1,1 @@
-<namespaces-show-page :namespace-ref="#{@namespace_serialized}" :repositories-ref="#{@repositories_serialized}" repositories-path="#{repositories_path}" webhooks-path="#{namespace_webhooks_path(@namespace)}" teams-path="#{teams_path}"></namespaces-show-page>
+<namespaces-show-page :namespace-ref="#{@namespace_serialized}" :repositories-ref="#{@repositories_serialized}" repositories-path="#{repositories_path}" webhooks-path="#{namespace_webhooks_path(@namespace)}" teams-path="#{teams_path}" namespaces-path="#{namespaces_path}"></namespaces-show-page>

--- a/app/views/public_activity/namespace/_delete.html.slim
+++ b/app/views/public_activity/namespace/_delete.html.slim
@@ -9,11 +9,11 @@ li
         strong
           = " #{activity_owner(activity)} deleted "
         - if activity.parameters[:repository_name]
-          = link_to activity.trackable.clean_name, activity.trackable
-          = " / #{activity.parameters[:repository_name]}"
+          = render_namespace_name(activity)
+          = "/#{activity.parameters[:repository_name]}"
         - else
-          = "a repository under the "
-          = link_to activity.trackable.clean_name, activity.trackable
+          = "a repository under "
+          = render_namespace_name(activity)
           = " namespace"
       small
         i.fa.fa-clock-o

--- a/app/views/public_activity/registry/_delete.csv.slim
+++ b/app/views/public_activity/registry/_delete.csv.slim
@@ -1,0 +1,1 @@
+= CSV.generate_line(['user', "-", 'removed namespace', activity.parameters[:namespace_name], activity_owner(activity), activity.created_at, "-"])

--- a/app/views/public_activity/registry/_delete.html.slim
+++ b/app/views/public_activity/registry/_delete.html.slim
@@ -1,17 +1,14 @@
 li
   .activitie-container
-    .activity-type.create-namespace
+    .activity-type.repo-deleted
       i.fa.fa-ship
     .user-image
       = user_image_tag(activity.owner)
     .description
       h6
         strong
-          = "#{activity_owner(activity)} created "
-        = render_namespace_name(activity, true)
-        = " namespace under "
-        = render_namespace_team(activity)
-        = " team"
+          = " #{activity_owner(activity)} removed namespace "
+          = "'#{activity.parameters[:namespace_name]}'"
       small
         i.fa.fa-clock-o
         = activity_time_tag activity.created_at

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -6,7 +6,7 @@ ENV["CCONFIG_PREFIX"] = "PORTUS"
 
 # Workers and connections.
 threads 1, ENV.fetch("PORTUS_PUMA_MAX_THREADS") { 4 }.to_i
-workers ENV.fetch("PORTUS_PUMA_WORKERS") { 2 }.to_i
+workers ENV.fetch("PORTUS_PUMA_WORKERS") { 4 }.to_i
 
 # We can bind in three different ways:
 #

--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -338,6 +338,11 @@ module API
       }, if: { type: :internal } do |namespace, options|
         can_manage_namespace?(namespace, options[:current_user])
       end
+      expose :destroyable, documentation: {
+        desc: "Boolean that tells if the current user can destroy the namespace"
+      }, if: { type: :internal } do |namespace, options|
+        can_destroy_namespace?(namespace, options[:current_user])
+      end
       expose :permissions, documentation: {
         desc: "Different permissions for the current user"
       }, if: { type: :internal } do |namespace, options|

--- a/lib/api/helpers/namespaces.rb
+++ b/lib/api/helpers/namespaces.rb
@@ -8,6 +8,10 @@ module API
         NamespacePolicy.new(user, namespace).update?
       end
 
+      def can_destroy_namespace?(namespace, user)
+        NamespacePolicy.new(user, namespace).destroy? && !User.exists?(namespace: namespace)
+      end
+
       def can_change_visibility?(namespace, user)
         NamespacePolicy.new(user, namespace).change_visibility?
       end

--- a/lib/api/v1/namespaces.rb
+++ b/lib/api/v1/namespaces.rb
@@ -131,6 +131,25 @@ module API
           end
         end
 
+        desc "Delete namespace",
+             params:  API::Entities::Namespaces.documentation.slice(:id),
+             failure: [
+               [401, "Authentication fails"],
+               [403, "Authorization fails"],
+               [404, "Not found"],
+               [422, "Unprocessable Entity", API::Entities::ApiErrors]
+             ]
+
+        delete ":id" do
+          namespace = Namespace.find(params[:id])
+          authorize namespace, :destroy?
+
+          service = ::Namespaces::DestroyService.new(current_user)
+          destroyed = service.execute(namespace)
+
+          destroyed ? status(204) : unprocessable_entity!(service.error)
+        end
+
         route_param :id, type: Integer, requirements: { id: /.*/ } do
           resource :repositories do
             desc "Returns the list of the repositories for the given namespace",

--- a/spec/api/helpers/namespaces_spec.rb
+++ b/spec/api/helpers/namespaces_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ::API::Helpers::Namespaces, type: :helper do
+  let!(:registry)  { create(:registry) }
+  let!(:user)      { create(:admin) }
+  let!(:loser)     { create(:user) }
+  let!(:team)      { create(:team, owners: [user]) }
+  let!(:namespace) { create(:namespace, team: team, registry: registry) }
+
+  describe "can_destroy_namespace?" do
+    before do
+      APP_CONFIG["delete"]["enabled"] = true
+    end
+
+    it "can destroy a namespace with the right authorization" do
+      expect(can_destroy_namespace?(namespace, user)).to be_truthy
+    end
+
+    it "cannot destroy a namespace without authorization" do
+      expect(can_destroy_namespace?(namespace, loser)).to be_falsey
+    end
+
+    it "cannot destroy a personal namespace" do
+      expect(can_destroy_namespace?(user.namespace, user)).to be_falsey
+    end
+  end
+end

--- a/spec/features/namespaces_spec.rb
+++ b/spec/features/namespaces_spec.rb
@@ -19,7 +19,6 @@ describe "Namespaces support" do
       visit namespaces_path
 
       find(".toggle-link-new-namespace").click
-
       expect(page).to have_button("Create", disabled: true)
     end
 
@@ -291,6 +290,19 @@ describe "Namespaces support" do
         visit namespace_path(namespace.id)
         expect(page).to have_content("Pull Viewer")
       end
+    end
+  end
+
+  describe "#destroy", js: true do
+    it "destroys the namespace" do
+      APP_CONFIG["delete"] = { "enabled" => true }
+      visit namespace_path(namespace)
+
+      expect(page).to have_css(".namespace-delete-btn")
+      find(".namespace-delete-btn").click
+      find(".popover-content .yes").click
+      expect(page).to have_content("Namespace removed with all its repositories")
+      expect(page).not_to have_link(namespace.clean_name)
     end
   end
 end

--- a/spec/helpers/namespaces_helper_spec.rb
+++ b/spec/helpers/namespaces_helper_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe NamespacesHelper, type: :helper do
+  describe "known activity" do
+    let!(:registry) { create(:registry) }
+    let!(:user)     { create(:admin) }
+    let!(:team)     { create(:team, owners: [user]) }
+    let!(:namespace) do
+      Namespaces::BuildService.new(user, name: "name", team: team.name).execute
+    end
+
+    it "returns 'the' plus a link when the resource is available" do
+      Namespaces::CreateService.new(user, namespace).execute
+      activity = PublicActivity::Activity.first
+
+      # Namespace
+      text = render_namespace_name(activity)
+      expect(text).to eq "<a href=\"/namespaces/#{namespace.id}\">#{namespace.name}</a>"
+
+      # Team
+      text = render_namespace_team(activity)
+      expect(text).to eq "<span>the </span><a href=\"/teams/#{team.id}\">#{team.name}</a>"
+    end
+
+    it "returns 'the' without a link when the resource is not available" do
+      Namespaces::CreateService.new(user, namespace).execute
+      Namespace.find(namespace.id).delete_by!(user)
+      activity = PublicActivity::Activity.find_by(key: "namespace.create")
+
+      # Namespace
+      text = render_namespace_name(activity)
+      expect(text).to eq "name"
+
+      # Team
+      text = render_namespace_team(activity)
+      expect(text).to eq "<span>the </span>#{team.name}"
+    end
+  end
+
+  describe "unknown activity (i.e. backwards compatibility)" do
+    let!(:registry) { create(:registry) }
+    let!(:user) { create(:admin) }
+
+    it "simply returns 'a' on unknown namespace activity" do
+      ::Teams::CreateService.new(user, name: "team").execute
+      PublicActivity::Activity.all.update_all(parameters: nil)
+      activity = PublicActivity::Activity.first
+
+      expect(render_namespace_name(activity)).to eq "a"
+      expect(render_namespace_team(activity)).to eq "<span>a</span>"
+    end
+  end
+end

--- a/spec/helpers/repositories_helper_spec.rb
+++ b/spec/helpers/repositories_helper_spec.rb
@@ -100,15 +100,15 @@ RSpec.describe RepositoriesHelper, type: :helper do
       global = registry.global_namespace.id
 
       expectations = [
-        "<strong>#{nameo} pushed </strong><a href=\"/namespaces/#{global}\">registry:5000</a> / "\
+        "<strong>#{nameo} pushed </strong><a href=\"/namespaces/#{global}\">registry:5000</a>/"\
           "<a href=\"/repositories/#{repo.id}\">repo:latest</a>",
-        "<strong>#{nameo} pushed </strong><a href=\"/namespaces/#{global}\">registry:5000</a> / "\
+        "<strong>#{nameo} pushed </strong><a href=\"/namespaces/#{global}\">registry:5000</a>/"\
           "<a href=\"/repositories/#{repo.id}\">repo</a>",
         "<strong>#{nameo} pushed </strong><span>a repository</span>",
-        "<strong>#{nameo} pushed </strong><a href=\"/namespaces/#{global}\">registry:5000</a> / "\
+        "<strong>#{nameo} pushed </strong><a href=\"/namespaces/#{global}\">registry:5000</a>/"\
           "<a href=\"/repositories/#{repo2.id}\">repo2:0.3</a>",
-        "<strong>#{nameo} pushed </strong><a href=\"/namespaces/#{namespace.id}\">namespace</a> "\
-          "/ <a href=\"/repositories/#{repo3.id}\">repo3:0.4</a>"
+        "<strong>#{nameo} pushed </strong><a href=\"/namespaces/#{namespace.id}\">namespace</a>"\
+          "/<a href=\"/repositories/#{repo3.id}\">repo3:0.4</a>"
       ]
 
       idx = 0
@@ -127,14 +127,14 @@ RSpec.describe RepositoriesHelper, type: :helper do
 
       idx = 0
 
-      na = "<strong>Someone pushed </strong><a href=\"/namespaces/#{global}\">registry:5000</a> / "\
+      na = "<strong>Someone pushed </strong><a href=\"/namespaces/#{global}\">registry:5000</a>/"\
            "<a href=\"/repositories/#{repo.id}\">repo:0.1</a>"
       expectations = expectations.unshift na
 
       # Changes because of the Catalog job.
       expectations[4] = "<strong>#{nameo} pushed </strong><a href=\"/namespaces/#{global}\">"\
-        "registry:5000</a> / <span>repo2:0.3</span>"
-      expectations[5] = "<strong>#{nameo} pushed </strong><span>namespace</span> / <span>repo"\
+        "registry:5000</a>/<span>repo2:0.3</span>"
+      expectations[5] = "<strong>#{nameo} pushed </strong><span>namespace</span>/<span>repo"\
           "3:0.4</span>"
 
       # Push activities
@@ -147,14 +147,14 @@ RSpec.describe RepositoriesHelper, type: :helper do
 
       idx = 0
       expectations = [
-        "<strong>Someone deleted </strong><a href=\"/namespaces/#{global}\">registry:5000</a> / "\
+        "<strong>Someone deleted </strong><a href=\"/namespaces/#{global}\">registry:5000</a>/"\
           "<a href=\"/repositories/#{repo.id}\">repo:latest</a>",
-        "<strong>Someone deleted </strong><a href=\"/namespaces/#{global}\">registry:5000</a> / "\
+        "<strong>Someone deleted </strong><a href=\"/namespaces/#{global}\">registry:5000</a>/"\
           "<span>repo2:0.3</span>",
-        "<strong>Someone deleted </strong><span>namespace</span> / <span>repo3:0.4</span>",
-        "<strong>Someone deleted </strong><a href=\"/namespaces/#{global}\">registry:5000</a> / "\
+        "<strong>Someone deleted </strong><span>namespace</span>/<span>repo3:0.4</span>",
+        "<strong>Someone deleted </strong><a href=\"/namespaces/#{global}\">registry:5000</a>/"\
             "<span>repo2</span>",
-        "<strong>Someone deleted </strong><span>namespace</span> / <span>repo3</span>"
+        "<strong>Someone deleted </strong><span>namespace</span>/<span>repo3</span>"
       ]
 
       # Delete Activities

--- a/spec/policies/namespace_policy_spec.rb
+++ b/spec/policies/namespace_policy_spec.rb
@@ -225,6 +225,39 @@ describe NamespacePolicy do
   permissions :push?, &push_all
   permissions :all?, &push_all
 
+  permissions :destroy? do
+    before do
+      APP_CONFIG["delete"]["enabled"] = true
+    end
+
+    it "does not allow if delete is disabled" do
+      APP_CONFIG["delete"]["enabled"] = false
+      expect(subject).not_to permit(@admin, namespace)
+    end
+
+    it "allows to delete for admin" do
+      expect(subject).to permit(@admin, namespace)
+    end
+
+    it "allows an onwer to delete the namespace" do
+      expect(subject).to permit(owner, namespace)
+    end
+
+    it "disallows a contributor to delete the namespace" do
+      expect(subject).not_to permit(contributor, namespace)
+    end
+
+    it "allows a contributor to delete the namespace when configured" do
+      APP_CONFIG["delete"]["contributors"] = true
+      expect(subject).to permit(contributor, namespace)
+    end
+
+    it "disallows everyone to destroy a global namespace" do
+      global = Namespace.find_by(global: true)
+      expect(subject).to_not permit(@admin, global)
+    end
+  end
+
   permissions :change_visibility? do
     it "allows admin to change it" do
       expect(subject).to permit(@admin, namespace)

--- a/spec/services/namespaces/destroy_service_spec.rb
+++ b/spec/services/namespaces/destroy_service_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Namespaces::DestroyService" do
+  let!(:registry)   { create(:registry, hostname: "registry.test.lan") }
+  let!(:user)       { create(:admin) }
+  let!(:team)       { create(:team, owners: [user]) }
+  let!(:namespace)  { create(:namespace, team: team, registry: registry) }
+  let!(:repository) { create(:repository, namespace: namespace, name: "repo") }
+  let!(:tag)        { create(:tag, repository: repository, name: "tag") }
+
+  subject(:service) { ::Namespaces::DestroyService.new(user) }
+
+  context "with params" do
+    before do
+      allow_any_instance_of(::Repositories::DestroyService).to(receive(:execute).and_return(true))
+    end
+
+    it "fails if the given namespace is personal" do
+      status = true
+
+      expect { status = service.execute(user.namespace) }
+        .to_not(change { Namespace.count + Repository.count })
+
+      expect(status).to be_falsey
+      expect(service.error).to eq "Cannot remove personal namespace"
+    end
+
+    it "destroys namespace" do
+      expect { service.execute(namespace) }.to change(Namespace, :count).by(-1)
+    end
+
+    it "stores the error on delete" do
+      allow_any_instance_of(Namespace).to(receive(:delete_by!).and_return(false))
+      service.execute(namespace)
+      expect(service.error).to eq "Could not remove namespace"
+    end
+
+    it "stores the errors on repositories that failed to be removed" do
+      allow_any_instance_of(::Repositories::DestroyService).to(receive(:execute).and_return(false))
+      allow_any_instance_of(::Repositories::DestroyService).to(
+        receive(:error).and_return("I AM ERROR")
+      )
+
+      expect { service.execute(namespace) }.not_to change(Namespace, :count)
+      expect(service.error.size).to eq 1
+      expect(service.error[repository.full_name.to_s]).to eq "I AM ERROR"
+    end
+  end
+
+  context "without params" do
+    it "raises RecordNotFound exception" do
+      expect { service.execute(nil) }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+end

--- a/spec/views/public_activity/registry/_delete.csv.slim_spec.rb
+++ b/spec/views/public_activity/registry/_delete.csv.slim_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "public_activity/webhook/_delete.csv.slim" do
+  let!(:registry)       { create(:registry) }
+  let!(:user)           { create(:admin) }
+  let!(:team)           { create(:team, owners: [user]) }
+  let!(:namespace)      { create(:namespace, team: team, registry: registry) }
+  let(:repository_name) { "busybox" }
+  let(:tag_name)        { "latest" }
+
+  before do
+    user.create_personal_namespace!
+  end
+
+  it "renders the activity properly" do
+    allow_any_instance_of(::Portus::RegistryClient).to receive(:manifest).and_return(%w[id foo])
+    allow_any_instance_of(::Portus::RegistryClient).to receive(:delete).and_return(true)
+
+    # Adding a repo like this so it also creates a tag and activities beneath it
+    # all.
+    event = { "actor" => { "name" => user.username } }
+    Repository.add_repo(event, namespace, repository_name, tag_name)
+    ::Namespaces::DestroyService.new(user).execute(namespace)
+
+    activity = PublicActivity::Activity.find_by(key: "registry.delete")
+    text = render "public_activity/registry/delete.csv.slim", activity: activity
+    expect(text).to include "user,-,removed namespace,#{namespace.clean_name},#{user.username}"
+  end
+end

--- a/spec/views/public_activity/registry/_delete.html.slim_spec.rb
+++ b/spec/views/public_activity/registry/_delete.html.slim_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "public_activity/webhook/_delete" do
+  let!(:registry)       { create(:registry) }
+  let!(:user)           { create(:admin) }
+  let!(:team)           { create(:team, owners: [user]) }
+  let!(:namespace)      { create(:namespace, team: team, registry: registry) }
+  let(:repository_name) { "busybox" }
+  let(:tag_name)        { "latest" }
+
+  before do
+    user.create_personal_namespace!
+  end
+
+  it "renders the activity properly" do
+    allow_any_instance_of(::Portus::RegistryClient).to receive(:manifest).and_return(%w[id foo])
+    allow_any_instance_of(::Portus::RegistryClient).to receive(:delete).and_return(true)
+
+    # Adding a repo like this so it also creates a tag and activities beneath it
+    # all.
+    event = { "actor" => { "name" => user.username } }
+    Repository.add_repo(event, namespace, repository_name, tag_name)
+    ::Namespaces::DestroyService.new(user).execute(namespace)
+
+    activity = PublicActivity::Activity.find_by(key: "registry.delete")
+    text = render "public_activity/registry/delete", activity: activity
+    expect(text).to include "#{user.username} removed namespace &#39;#{namespace.name}&#39;"
+  end
+
+  it "renders the repo delete activity below" do
+    allow_any_instance_of(::Portus::RegistryClient).to receive(:manifest).and_return(%w[id foo])
+    allow_any_instance_of(::Portus::RegistryClient).to receive(:delete).and_return(true)
+
+    # Adding a repo like this so it also creates a tag and activities beneath it
+    # all.
+    event = { "actor" => { "name" => user.username } }
+    Repository.add_repo(event, namespace, repository_name, tag_name)
+    ::Namespaces::DestroyService.new(user).execute(namespace)
+
+    activity = PublicActivity::Activity.find_by(key: "namespace.delete")
+    text = render "public_activity/registry/delete", activity: activity
+    expect(text).to include("#{user.username} removed namespace")
+    expect(text).to include(namespace.clean_name)
+  end
+end


### PR DESCRIPTION
This commit fixes one of the oldest requests we've had: being able to
delete a namespace. It also introduces an API endpoint for it.

Fixes #767

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>