### PR TITLE
github: add documentation in the exemptLabels

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -12,6 +12,7 @@ exemptLabels:
   - junior job
   - feature
   - enhancement
+  - documentation
 
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: true


### PR DESCRIPTION
Documentation issues should never be marked as stale.

See #1833

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>