### PR TITLE
Use the correct reference for Leap 42.3 in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensuse/amd64:42.3
+FROM opensuse/leap:42.3
 MAINTAINER SUSE Containers Team <containers@suse.com>
 
 # Install the entrypoint of this image.


### PR DESCRIPTION
opensuse/amd64 is dead for some time now.

docker build works and starting the image (by itself) works as well.
