### PR TITLE
Added some more notes on OAuth support

### DIFF
--- a/_docs/Configuring-Portus.md
+++ b/_docs/Configuring-Portus.md
@@ -234,6 +234,9 @@ from one of the supported platforms. Here is the full list:
 
 {% highlight yaml %}
 oauth:
+  local_login:
+    enabled: true
+
   google_oauth2:
     enabled: false
     id: ""
@@ -274,6 +277,10 @@ oauth:
       team: ""
 {% endhighlight %}
 
+As you can see, the only option enabled by default is `local_login`, which tells
+Portus that users can log in with their Portus credentials. You can disable this
+if you want users to only login with OAuth credentials.
+
 All supported platforms have their own settings, but there are some common
 attributes that might not be evident:
 
@@ -286,6 +293,9 @@ attributes that might not be evident:
   fetch the proper source. That is, you can specify the Gitlab server (by
   default gitlab.com), or the OpenID provider (by default you'll be prompted
   with a form asking for this information).
+
+For more info, take a look at the [dedicated page](/features/oauth.html) for
+OAuth support.
 
 ### Advanced registry options
 

--- a/_features/oauth.md
+++ b/_features/oauth.md
@@ -12,13 +12,22 @@ longtitle: Authenticate with an OAuth backend or an OpenID Connect provider
 ## OAuth and OpenID Connect support
 
 You can tell Portus to use an OAuth or an OpenID Connect provider to login. The
-currently supported providers are: Google, Github, Gitlab and Bitbucket. An
-example (with a Github provider):
+currently supported providers are: Google, Github, Gitlab and Bitbucket. For the
+full configuration read [this page](/docs/Configuring-Portus.html). An example
+(with a Github provider):
 
 ![OAuth](/images/docs/oauth.gif)
 
-One thing to notice is that the password is auto-generated. So, if you want to
-login afterwards with the given username and a password, you will have to go to
-your profile and change your password. Another possibility is to simply create an
-[application token](/features/application_tokens.html). This is also important
-if you want to login with the docker CLI.
+Some things to note:
+
+1. The password for the user is auto-generated. So, if you want to login
+   afterwards with the given username and a password, you will have to go to
+   your profile and change your password. Another possibility is to simply
+   create an [application token](/features/application_tokens.html). This is
+   also important if you want to login with the Docker CLI.
+2. The callback URL to be used for each provider is different for each of them:
+   - Google: `<host>/users/auth/google_oauth2/callback`
+   - Open ID: `<host>/users/auth/open_id/callback`
+   - Github: `<host>/users/auth/github/callback`
+   - Gitlab: `<host>/users/auth/gitlab/callback`
+   - Bitbucket: `<host>/users/auth/bitbucket/callback`


### PR DESCRIPTION
I've also added the missing configuration option `local_login`.

Fixes #1842

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>