### PR TITLE
Fix: add 'yarn upgrade'

### DIFF
--- a/examples/development/compose/bootstrap-webpack
+++ b/examples/development/compose/bootstrap-webpack
@@ -7,4 +7,5 @@ if [ $? -ne 0 ]; then
   yarn install --no-emoji --no-progress
 fi
 
+yarn upgrade
 yarn run webpack


### PR DESCRIPTION
### Summary

To be sure to found webpack, otherwise you can have an error who can do crashing portus webpack service.