### PR TITLE
[packaging] fix gem packaging

### DIFF
--- a/packaging/suse/portus.spec.in
+++ b/packaging/suse/portus.spec.in
@@ -47,8 +47,9 @@ Source0:        %{branch}.tar.gz
 Source1:        node_modules.tar.gz
 Source2:        yarn.lock
 __PATCHSOURCES__
-
-# Add gems as sources with the https://github.com/openSUSE/obs-service-bundle_gems service
+# We need to add bundler cause https://github.com/openSUSE/obs-service-bundle_gems
+# does not add it by default
+Source100:      bundler-1.16.4.gem
 
 Requires:       timezone
 Requires:       net-tools
@@ -114,7 +115,11 @@ tar xzvf node_modules.tar.gz
 
 # Deal with Ruby gems.
 install -d vendor/cache
-cp %{_sourcedir}/*.gem vendor/cache
+# obs-service-bundle_gems will install gems in SOURCE/vendor/cache when using the cpio strategy
+# https://github.com/openSUSE/obs-service-bundle_gems/
+cp %{_sourcedir}/vendor/cache/*.gem vendor/cache
+# copy bundler gem
+cp %{S:100} vendor/cache
 
 # Deploy gems for compiling the assets.
 export GEM_HOME=$PWD/vendor GEM_PATH=$PWD/vendor PATH=$PWD/vendor/bin:$PWD/bin:$PATH


### PR DESCRIPTION
Instead of adding all the gems as sources, we will use the cpio
strategy, which does not need to change the spec file or, more
important, does not need us to add/remove the .gem files into the
package every time there is a change in the Gemfile.lock file.

However, using this strategy the gems are copied on another path, and we
need to fix this.

Then, we will need to adapt the _service file in obs to have this
section

```
  <service name="download_url">
    <param name="protocol">https</param>
    <param name="host">raw.githubusercontent.com</param>
    <param name="path">/SUSE/Portus/master/Gemfile</param>
  </service>
  <service name="download_url">
    <param name="protocol">https</param>
    <param name="host">raw.githubusercontent.com</param>
    <param name="path">/SUSE/Portus/master/Gemfile.lock</param>
  </service>

  <service name="bundle_gems">
    <param name="strategy">cpio</param>
  </service>
```

A part from that, we need to add bundler-*.gem as a SOURCE in the spec
file, since the obs-service-bundle_gems does not add this gem into the
cpio.

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>


