### PR TITLE
[packaging] fix the _service file

### DIFF
--- a/packaging/suse/release/release.sh
+++ b/packaging/suse/release/release.sh
@@ -64,7 +64,7 @@ update_package() {
 
   cp _service _service.orig
   echo "Disabling service"
-  sed -e "s/<service name=\"download_url\">/<service name=\"download_url\" mode=\"disabled\">/g" -i _service
+  sed -E "s/<service name=\"(.*)\">/<service name=\"\1\" mode=\"disabled\">/g" -i _service
   if [ $? -eq 0 ];then
     echo "WARNING: _service file has not been changed"
   fi


### PR DESCRIPTION
in commit 556778b9f3aa8cd06f4519a16bafc352b7913c9c we fixed the gem
packaging for master

However, when creating a release branch, all services should be in
disabled mode and we needed to adapt the sed expression to do that.

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>


