### PR TITLE
Upgrade rubyzip to 1.2.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -354,7 +354,7 @@ GEM
     ruby-openid (2.7.0)
     ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
-    rubyzip (1.2.1)
+    rubyzip (1.2.2)
     safe_yaml (1.0.4)
     sass (3.4.25)
     sass-rails (5.0.7)


### PR DESCRIPTION
A vulnerability has been found against the version we were using, so
I've upgraded this gem to a version fixing this. That being said, we are
only using on tests, since it's only used by selenium-webdriver. Hence,
it does not affect us, really.

See CVE-2018-1000544
See bsc#1099280

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>