### PR TITLE
Remind users to login again after password update

### DIFF
--- a/app/controllers/auth/registrations_controller.rb
+++ b/app/controllers/auth/registrations_controller.rb
@@ -51,18 +51,22 @@ class Auth::RegistrationsController < Devise::RegistrationsController
   end
 
   def update
+    msg = "Profile updated successfully!"
+
     success =
       if password_update?
         succ = current_user.update_with_password(user_params)
-        bypass_sign_in(current_user) if succ
+        if succ
+          bypass_sign_in(current_user)
+          msg += " Remember to login again on the Docker CLI."
+        end
         succ
       else
         current_user.update_without_password(params.require(:user).permit(:email, :display_name))
       end
 
     if success
-      redirect_to edit_user_registration_path,
-                  notice: "Profile updated successfully!", float: true
+      redirect_to edit_user_registration_path, notice: msg, float: true
     else
       redirect_to edit_user_registration_path,
                   alert: resource.errors.full_messages, float: true

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -34,8 +34,8 @@ en:
       no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
       send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
       send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
-      updated: "Your password has been changed successfully. You are now signed in."
-      updated_not_active: "Your password has been changed successfully."
+      updated: "Your password has been changed successfully. You are now signed in. Remember to login again on the Docker CLI."
+      updated_not_active: "Your password has been changed successfully. Remember to login again on the Docker CLI."
     registrations:
       destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
       signed_up: "Welcome! You have signed up successfully."


### PR DESCRIPTION
Upon password update, users should `docker login` again, otherwise
push/pull command will fail.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>