### PR TITLE
Restrict deletes into the repository

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -65,7 +65,7 @@ class Tag < ActiveRecord::Base
     dig = fetch_digest
     return false if dig.blank?
 
-    Tag.where(digest: dig).update_all(marked: true)
+    Tag.where(repository: repository, digest: dig).update_all(marked: true)
 
     begin
       Registry.get.client.delete(repository.full_name, dig, "manifests")
@@ -76,7 +76,7 @@ class Tag < ActiveRecord::Base
     end
 
     success = true
-    Tag.where(digest: dig).find_each do |tag|
+    Tag.where(repository: repository, digest: dig).find_each do |tag|
       success &&= tag&.delete_by!(actor)
     end
     success

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -33,9 +33,10 @@ class TagMock < Tag
 end
 
 describe Tag do
-  let!(:registry)   { create(:registry, hostname: "registry.test.lan") }
-  let!(:user)       { create(:admin) }
-  let!(:repository) { create(:repository, namespace: registry.global_namespace, name: "repo") }
+  let!(:registry)    { create(:registry, hostname: "registry.test.lan") }
+  let!(:user)        { create(:admin) }
+  let!(:repository)  { create(:repository, namespace: registry.global_namespace, name: "repo") }
+  let!(:repository1) { create(:repository, namespace: registry.global_namespace, name: "repo1") }
 
   it { is_expected.to belong_to(:repository) }
   it { is_expected.to belong_to(:author) }
@@ -70,6 +71,7 @@ describe Tag do
   describe "#delete_by_digest!" do
     let!(:tag)  { create(:tag, name: "tag1", repository: repository, digest: "1") }
     let!(:tag2) { create(:tag, name: "tag2", repository: repository, digest: "2") }
+    let!(:tag3) { create(:tag, name: "tag3", repository: repository1, digest: "2") }
 
     it "returns false if there is no digest" do
       allow_any_instance_of(described_class).to receive(:fetch_digest).and_return(nil)
@@ -149,6 +151,20 @@ describe Tag do
       tag.delete_by_digest!(user)
 
       expect(described_class.find_by(name: "t")).to be_nil
+    end
+
+    it "does not remove tags from other repositories" do
+      allow_any_instance_of(Tag).to receive(:fetch_digest).and_return("2")
+      allow_any_instance_of(Portus::RegistryClient).to(
+        receive(:delete)
+          .with(repository.full_name, "2", "manifests")
+          .and_return(true)
+      )
+
+      tag2.delete_by_digest!(user)
+
+      expect(repository.tags.count).to eq 1
+      expect(repository1.tags.count).to eq 1
     end
   end
 


### PR DESCRIPTION
Deletes of registry objects are referenced by their digest, but in some
situations, we accidentally deleted objects from other places. For
example, if we pushed the same image:tag into multiple namespaces, then
a delete on one of them removed also the others from other namespaces.

This commits restricts this into the given namespace/repository.

Fixes #1125

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>