### PR TITLE
config: raised the value for JWT expiration time

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -253,7 +253,7 @@ registry:
   #
   # See: https://github.com/SUSE/Portus/issues/510
   jwt_expiration_time:
-    value: 5
+    value: 15
 
   # Set the pagination value for API calls that fetch data from the
   # registry. You can read more about pagination in the registry here:


### PR DESCRIPTION
We have been noticed that the default value for the JWT expiration time
was simply to small. This commit simply raises this value to a hopefully
more suited one.

Fixes #1978

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>