### PR TITLE
policies: fixed destroy for repositories/tags

### DIFF
--- a/app/policies/namespace_policy.rb
+++ b/app/policies/namespace_policy.rb
@@ -55,10 +55,8 @@ class NamespacePolicy
   def destroy?
     raise Pundit::NotAuthorizedError, "must be logged in" unless user
 
-    is_owner               = @namespace.team.owners.exists?(user.id)
-    can_contributor_delete = APP_CONFIG["delete"]["contributors"] &&
-                             @namespace.team.contributors.exists?(user.id)
-    delete_enabled? && (@user.admin? || is_owner || can_contributor_delete)
+    can_contributor_delete = APP_CONFIG["delete"]["contributors"] && contributor?
+    delete_enabled? && (@user.admin? || owner? || can_contributor_delete)
   end
 
   def update?

--- a/spec/policies/repository_policy_spec.rb
+++ b/spec/policies/repository_policy_spec.rb
@@ -73,7 +73,10 @@ describe RepositoryPolicy do
   permissions :destroy? do
     before do
       namespace = create(:namespace, team: team2, registry: registry)
+      global_team = registry.global_namespace.team
+      global_namespace = create(:namespace, team: global_team, registry: registry)
       @repository = create(:repository, namespace: namespace)
+      @global_repository = create(:repository, namespace: global_namespace)
     end
 
     context "delete disabled" do
@@ -84,6 +87,7 @@ describe RepositoryPolicy do
       it "denies access to admin" do
         admin = create(:admin)
         expect(subject).not_to permit(admin, @repository)
+        expect(subject).not_to permit(admin, @global_repository)
       end
 
       it "denies access to owner" do
@@ -91,6 +95,7 @@ describe RepositoryPolicy do
         TeamUser.create(team: team2, user: owner, role: TeamUser.roles["owner"])
 
         expect(subject).not_to permit(owner, @repository)
+        expect(subject).not_to permit(owner, @global_repository)
       end
 
       it "denies access to contributor" do
@@ -98,10 +103,12 @@ describe RepositoryPolicy do
         TeamUser.create(team: team2, user: contributor, role: TeamUser.roles["contributor"])
 
         expect(subject).not_to permit(contributor, @repository)
+        expect(subject).not_to permit(contributor, @global_repository)
       end
 
       it "denies access to non-member" do
         expect(subject).not_to permit(user, @repository)
+        expect(subject).not_to permit(user, @global_repository)
       end
     end
 
@@ -113,24 +120,32 @@ describe RepositoryPolicy do
       it "grants access to admin" do
         admin = create(:admin)
         expect(subject).to permit(admin, @repository)
+        expect(subject).to permit(admin, @global_repository)
       end
 
       it "grants access to owner" do
         owner = create(:user)
+        global_team = @global_repository.namespace.team
         TeamUser.create(team: team2, user: owner, role: TeamUser.roles["owner"])
+        TeamUser.create(team: global_team, user: owner, role: TeamUser.roles["owner"])
 
         expect(subject).to permit(owner, @repository)
+        expect(subject).to permit(owner, @global_repository)
       end
 
       it "denies access to contributor" do
         contributor = create(:user)
+        global_team = @global_repository.namespace.team
         TeamUser.create(team: team2, user: contributor, role: TeamUser.roles["contributor"])
+        TeamUser.create(team: global_team, user: contributor, role: TeamUser.roles["contributor"])
 
         expect(subject).not_to permit(contributor, @repository)
+        expect(subject).not_to permit(contributor, @global_repository)
       end
 
       it "denies access to non-member" do
         expect(subject).not_to permit(user, @repository)
+        expect(subject).not_to permit(user, @global_repository)
       end
     end
 
@@ -144,9 +159,12 @@ describe RepositoryPolicy do
 
       it "grants access to contributor" do
         contributor = create(:user)
+        global_team = @global_repository.namespace.team
         TeamUser.create(team: team2, user: contributor, role: TeamUser.roles["contributor"])
+        TeamUser.create(team: global_team, user: contributor, role: TeamUser.roles["contributor"])
 
         expect(subject).to permit(contributor, @repository)
+        expect(subject).to permit(contributor, @global_repository)
       end
     end
   end


### PR DESCRIPTION
Repositories and tags that belonged to a global namespace was not being
able to be deleted. The regression was introduced in the 2.4 release.

Fixed #2011 