### PR TITLE
ui: fixed repositories performance view issue

### DIFF
--- a/app/assets/javascripts/modules/namespaces/components/table.vue
+++ b/app/assets/javascripts/modules/namespaces/components/table.vue
@@ -52,7 +52,7 @@
       </tbody>
     </table>
 
-    <table-pagination :total.sync="namespaces.length" :current-page="currentPage" :itens-per-page.sync="limit" @update="updateCurrentPage"></table-pagination>
+    <table-pagination :total.sync="namespaces.length" :current-page="currentPage" :itens-per-page.sync="perPage" @update="updateCurrentPage"></table-pagination>
   </div>
 </template>
 
@@ -106,7 +106,7 @@
         });
 
         // pagination
-        const slicedNamespaces = sortedNamespaces.slice(this.offset, this.limit * this.currentPage);
+        const slicedNamespaces = sortedNamespaces.slice(this.offset, this.perPage * this.currentPage);
 
         return slicedNamespaces;
       },

--- a/app/assets/javascripts/modules/repositories/components/remote-panel.vue
+++ b/app/assets/javascripts/modules/repositories/components/remote-panel.vue
@@ -1,0 +1,40 @@
+<template>
+  <panel class="repositories-panel">
+    <h5 slot="heading-left">
+      {{ title }}
+    </h5>
+
+    <div slot="heading-right">
+      <slot name="heading-right"></slot>
+    </div>
+
+    <div slot="body">
+      <repositories-remote-table :repositories-endpoint="repositoriesEndpoint" :repositories-path="repositoriesPath" :namespaces-path="namespacesPath" :sortable="true" sort-by="name" :prefix="prefix" :show-namespaces="showNamespaces"></repositories-remote-table>
+    </div>
+  </panel>
+</template>
+
+<script>
+  import RepositoriesRemoteTable from './remote-table';
+
+  export default {
+    props: {
+      title: {
+        type: String,
+        default: 'Repositories',
+      },
+      showNamespaces: {
+        type: Boolean,
+        default: true,
+      },
+      repositoriesEndpoint: String,
+      repositoriesPath: String,
+      namespacesPath: String,
+      prefix: String,
+    },
+
+    components: {
+      RepositoriesRemoteTable,
+    },
+  };
+</script>

--- a/app/assets/javascripts/modules/repositories/components/remote-table.vue
+++ b/app/assets/javascripts/modules/repositories/components/remote-table.vue
@@ -1,0 +1,112 @@
+<template>
+  <div class="table-responsive">
+    <loading-icon v-if="isLoading"></loading-icon>
+    <table class="table table-striped table-hover" :class="{'table-sortable': sortable}" v-if="!isLoading">
+      <colgroup>
+        <col class="col-60">
+      </colgroup>
+      <thead>
+        <tr>
+          <th @click="sort('name')">
+            <i class="fa fa-fw fa-sort" :class="{
+              'fa-sort-amount-asc': sorting.by === 'name' && sorting.asc,
+              'fa-sort-amount-desc': sorting.by === 'name' && !sorting.asc,
+            }"></i>
+            Repository
+          </th>
+          <th class="no-sort" v-if="showNamespaces">Namespace</th>
+          <th class="no-sort">Tags</th>
+          <th @click="sort('updated_at')">
+            <i class="fa fa-fw fa-sort" :class="{
+              'fa-sort-amount-asc': sorting.by === 'updated_at' && sorting.asc,
+              'fa-sort-amount-desc': sorting.by === 'updated_at' && !sorting.asc,
+            }"></i>
+            Updated at
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <repository-table-row v-for="repository in repositories" :key="repository.id" :repository="repository" :repositories-path="repositoriesPath" :namespaces-path="namespacesPath" :show-namespaces="showNamespaces"></repository-table-row>
+      </tbody>
+    </table>
+
+    <table-pagination :total.sync="total" :total-pages.sync="totalPages" :current-page="currentPage" :itens-per-page.sync="perPage" @update="updateCurrentPage" v-if="!isLoading"></table-pagination>
+  </div>
+</template>
+
+<script>
+  import Vue from 'vue';
+
+  import TableSortableMixin from '~/shared/mixins/table-sortable';
+  import TablePaginatedMixin from '~/shared/mixins/table-paginated';
+
+  import RepositoryTableRow from './table-row';
+
+  const { set } = Vue;
+
+  export default {
+    props: {
+      repositoriesEndpoint: {
+        type: String,
+      },
+      repositoriesPath: {
+        type: String,
+      },
+      namespacesPath: {
+        type: String,
+      },
+      showNamespaces: {
+        type: Boolean,
+        default: true,
+      },
+      prefix: {
+        type: String,
+        default: '',
+      },
+    },
+
+    mixins: [TableSortableMixin, TablePaginatedMixin],
+
+    components: {
+      RepositoryTableRow,
+    },
+
+    data() {
+      return {
+        repositories: [],
+        total: 0,
+        isLoading: false,
+      };
+    },
+
+    watch: {
+      'sorting.by': 'fetchRepositories',
+      'sorting.asc': 'fetchRepositories',
+      currentPage: 'fetchRepositories',
+    },
+
+    methods: {
+      fetchRepositories() {
+        if (this.isLoading) {
+          return;
+        }
+
+        const params = {
+          page: this.currentPage,
+          sort_attr: this.sorting.by,
+          sort_order: this.sorting.asc ? 'asc' : 'desc',
+        };
+
+        set(this, 'isLoading', true);
+        this.$http.get(this.repositoriesEndpoint, { params }).then((response) => {
+          const repositories = response.data;
+
+          set(this, 'repositories', repositories);
+          set(this, 'total', parseInt(response.headers.get('X-Total'), 10));
+          set(this, 'totalPages', parseInt(response.headers.get('X-Total-Pages'), 10));
+          set(this, 'isLoading', false);
+        });
+      },
+    },
+  };
+</script>

--- a/app/assets/javascripts/modules/repositories/components/table.vue
+++ b/app/assets/javascripts/modules/repositories/components/table.vue
@@ -41,7 +41,7 @@
       </tbody>
     </table>
 
-    <table-pagination :total.sync="repositories.length" :current-page="currentPage" :itens-per-page.sync="limit" @update="updateCurrentPage"></table-pagination>
+    <table-pagination :total.sync="repositories.length" :current-page="currentPage" :itens-per-page.sync="perPage" @update="updateCurrentPage"></table-pagination>
   </div>
 </template>
 
@@ -99,7 +99,7 @@
         });
 
         // pagination
-        const slicedTeams = sortedRepositories.slice(this.offset, this.limit * this.currentPage);
+        const slicedTeams = sortedRepositories.slice(this.offset, this.perPage * this.currentPage);
 
         return slicedTeams;
       },

--- a/app/assets/javascripts/modules/repositories/components/tags/tags-table.vue
+++ b/app/assets/javascripts/modules/repositories/components/tags/tags-table.vue
@@ -24,7 +24,7 @@
       </tbody>
     </table>
 
-    <table-pagination :total.sync="tags.length" :current-page="currentPage" :itens-per-page.sync="limit" @update="updateCurrentPage"></table-pagination>
+    <table-pagination :total.sync="tags.length" :current-page="currentPage" :itens-per-page.sync="perPage" @update="updateCurrentPage"></table-pagination>
   </div>
 </template>
 
@@ -51,7 +51,7 @@
 
     computed: {
       filteredTags() {
-        return this.tags.slice(this.offset, this.limit * this.currentPage);
+        return this.tags.slice(this.offset, this.perPage * this.currentPage);
       },
     },
   };

--- a/app/assets/javascripts/modules/repositories/pages/index.vue
+++ b/app/assets/javascripts/modules/repositories/pages/index.vue
@@ -1,38 +1,23 @@
 <template>
   <div class="repositories-index-page">
-    <repositories-panel title="Repositories via team membership" :repositories="teamRepositories" :repositories-path="repositoriesPath" :namespaces-path="namespacesPath"></repositories-panel>
-    <repositories-panel title="Other repositories" :repositories="otherRepositories" :repositories-path="repositoriesPath" :namespaces-path="namespacesPath" v-if="otherRepositories.length > 0"></repositories-panel>
+    <repositories-remote-panel title="Repositories via team membership" :repositories-endpoint="teamRepositoriesEndpoint" :repositories-path="repositoriesPath" :namespaces-path="namespacesPath"></repositories-remote-panel>
+    <repositories-remote-panel title="Other repositories" :repositories-path="repositoriesPath" :namespaces-path="namespacesPath" :repositories-endpoint="otherRepositoriesEndpoint" prefix="o_"></repositories-remote-panel>
   </div>
 </template>
 
 <script>
-  import RepositoriesPanel from '../components/panel';
+  import RepositoriesRemotePanel from '../components/remote-panel';
 
   export default {
     props: {
-      teamRepositoriesRef: {
-        type: Array,
-      },
-      otherRepositoriesRef: {
-        type: Array,
-      },
-      repositoriesPath: {
-        type: String,
-      },
-      namespacesPath: {
-        type: String,
-      },
+      teamRepositoriesEndpoint: String,
+      otherRepositoriesEndpoint: String,
+      repositoriesPath: String,
+      namespacesPath: String,
     },
 
     components: {
-      RepositoriesPanel,
-    },
-
-    data() {
-      return {
-        teamRepositories: [...this.teamRepositoriesRef],
-        otherRepositories: [...this.otherRepositoriesRef],
-      };
+      RepositoriesRemotePanel,
     },
   };
 </script>

--- a/app/assets/javascripts/modules/teams/components/members/table.vue
+++ b/app/assets/javascripts/modules/teams/components/members/table.vue
@@ -39,7 +39,7 @@
       </tbody>
     </table>
 
-    <table-pagination :total.sync="members.length" :current-page="currentPage" :itens-per-page.sync="limit" @update="updateCurrentPage"></table-pagination>
+    <table-pagination :total.sync="members.length" :current-page="currentPage" :itens-per-page.sync="perPage" @update="updateCurrentPage"></table-pagination>
   </div>
 </template>
 
@@ -101,7 +101,7 @@
         });
 
         // pagination
-        const slicedMembers = sortedMembers.slice(this.offset, this.limit * this.currentPage);
+        const slicedMembers = sortedMembers.slice(this.offset, this.perPage * this.currentPage);
 
         return slicedMembers;
       },

--- a/app/assets/javascripts/modules/teams/components/table.vue
+++ b/app/assets/javascripts/modules/teams/components/table.vue
@@ -34,7 +34,7 @@
       </tbody>
     </table>
 
-    <table-pagination :total.sync="teams.length" :current-page="currentPage" :itens-per-page.sync="limit" @update="updateCurrentPage"></table-pagination>
+    <table-pagination :total.sync="teams.length" :current-page="currentPage" :itens-per-page.sync="perPage" @update="updateCurrentPage"></table-pagination>
   </div>
 </template>
 
@@ -85,7 +85,7 @@
         });
 
         // pagination
-        const slicedTeams = sortedTeams.slice(this.offset, this.limit * this.currentPage);
+        const slicedTeams = sortedTeams.slice(this.offset, this.perPage * this.currentPage);
 
         return slicedTeams;
       },

--- a/app/assets/javascripts/modules/users/components/table.vue
+++ b/app/assets/javascripts/modules/users/components/table.vue
@@ -58,7 +58,7 @@
       </tbody>
     </table>
 
-    <table-pagination :total.sync="users.length" :current-page="currentPage" :itens-per-page.sync="limit" @update="updateCurrentPage"></table-pagination>
+    <table-pagination :total.sync="users.length" :current-page="currentPage" :itens-per-page.sync="perPage" @update="updateCurrentPage"></table-pagination>
   </div>
 </template>
 
@@ -101,7 +101,7 @@
         });
 
         // pagination
-        const slicedUsers = sortedUsers.slice(this.offset, this.limit * this.currentPage);
+        const slicedUsers = sortedUsers.slice(this.offset, this.perPage * this.currentPage);
 
         return slicedUsers;
       },

--- a/app/assets/javascripts/modules/webhooks/components/deliveries/table.vue
+++ b/app/assets/javascripts/modules/webhooks/components/deliveries/table.vue
@@ -18,7 +18,7 @@
       </tbody>
     </table>
 
-    <table-pagination :total.sync="deliveries.length" :current-page="currentPage" :itens-per-page.sync="limit" @update="updateCurrentPage"></table-pagination>
+    <table-pagination :total.sync="deliveries.length" :current-page="currentPage" :itens-per-page.sync="perPage" @update="updateCurrentPage"></table-pagination>
   </div>
 </template>
 

--- a/app/assets/javascripts/modules/webhooks/components/headers/table.vue
+++ b/app/assets/javascripts/modules/webhooks/components/headers/table.vue
@@ -18,7 +18,7 @@
       </tbody>
     </table>
 
-    <table-pagination :total.sync="headers.length" :current-page="currentPage" :itens-per-page.sync="limit" @update="updateCurrentPage"></table-pagination>
+    <table-pagination :total.sync="headers.length" :current-page="currentPage" :itens-per-page.sync="perPage" @update="updateCurrentPage"></table-pagination>
   </div>
 </template>
 

--- a/app/assets/javascripts/modules/webhooks/components/table.vue
+++ b/app/assets/javascripts/modules/webhooks/components/table.vue
@@ -24,7 +24,7 @@
       </tbody>
     </table>
 
-    <table-pagination :total.sync="webhooks.length" :current-page="currentPage" :itens-per-page.sync="limit" @update="updateCurrentPage"></table-pagination>
+    <table-pagination :total.sync="webhooks.length" :current-page="currentPage" :itens-per-page.sync="perPage" @update="updateCurrentPage"></table-pagination>
   </div>
 </template>
 

--- a/app/assets/javascripts/shared/components/table-pagination.vue
+++ b/app/assets/javascripts/shared/components/table-pagination.vue
@@ -3,10 +3,10 @@
     <div v-if="total === 0">
       No entry
     </div>
-    <div class="col-sm-6 text-left" v-if="totalPages > 1">
+    <div class="col-sm-6 text-left" v-if="totalPagesComputed > 1">
       Showing from {{ start }} to {{ end }} of {{ total }} entries
     </div>
-    <div class="col-sm-6 text-right" v-if="totalPages > 1">
+    <div class="col-sm-6 text-right" v-if="totalPagesComputed > 1">
       <ul class="pagination">
         <li class="previous" :class="{ 'disabled': previousDisabled }">
           <a href="#" @click.prevent="setCurrentPage(currentPage - 1)">Previous</a>
@@ -30,7 +30,12 @@
   import range from '~/utils/range';
 
   export default {
-    props: ['total', 'itensPerPage', 'currentPage'],
+    props: {
+      total: Number,
+      totalPages: Number,
+      itensPerPage: Number,
+      currentPage: Number,
+    },
 
     data() {
       return {
@@ -49,12 +54,16 @@
         return end <= this.total ? end : this.total;
       },
 
-      totalPages() {
+      totalPagesComputed() {
+        if (this.totalPages > 1) {
+          return this.totalPages;
+        }
+
         return Math.ceil(this.total / this.itensPerPage);
       },
 
       displayedPages() {
-        if (this.totalPages === 0) {
+        if (this.totalPagesComputed < 2) {
           return [];
         }
 
@@ -62,18 +71,18 @@
         let maxRange = this.currentPage + this.beforeAfter;
 
         const distanceLeft = Math.abs(1 - minRange);
-        const distanceRight = Math.abs(this.totalPages - maxRange);
+        const distanceRight = Math.abs(this.totalPagesComputed - maxRange);
 
-        if (minRange <= 0 && maxRange < this.totalPages) {
+        if (minRange <= 0 && maxRange < this.totalPagesComputed) {
           maxRange += distanceLeft;
         }
 
-        if (maxRange > this.totalPages && minRange > 1) {
+        if (maxRange > this.totalPagesComputed && minRange > 1) {
           minRange -= distanceRight;
         }
 
         const start = minRange < 1 ? 1 : minRange;
-        const end = maxRange > this.totalPages ? this.totalPages : maxRange;
+        const end = maxRange > this.totalPagesComputed ? this.totalPagesComputed : maxRange;
 
         return range(start, end);
       },
@@ -83,13 +92,13 @@
       },
 
       nextDisabled() {
-        return this.currentPage === this.totalPages;
+        return this.currentPage === this.totalPagesComputed;
       },
     },
 
     methods: {
       setCurrentPage(page) {
-        if (page === 0 || page > this.totalPages) {
+        if (page === 0 || page > this.totalPagesComputed) {
           return;
         }
 

--- a/app/assets/javascripts/shared/mixins/table-paginated.js
+++ b/app/assets/javascripts/shared/mixins/table-paginated.js
@@ -19,14 +19,19 @@ export default {
 
   data() {
     return {
-      limit: this.$config.pagination.limit,
+      perPage: this.$config.pagination.perPage,
       currentPage: 1,
+      totalPages: 1,
     };
   },
 
   computed: {
     offset() {
-      return (this.currentPage - 1) * this.limit;
+      return (this.currentPage - 1) * this.perPage;
+    },
+
+    pageParam() {
+      return this.prefix + 'page';
     },
   },
 
@@ -40,7 +45,7 @@ export default {
     updateUrlPaginationState() {
       const queryObject = queryString.parse(window.location.search);
 
-      queryObject[this.prefix + 'page'] = this.currentPage;
+      queryObject[this.pageParam] = this.currentPage;
 
       const queryParams = queryString.stringify(queryObject);
       const url = [
@@ -56,7 +61,7 @@ export default {
 
   beforeMount() {
     const queryObject = queryString.parse(window.location.search);
-    const pageQuery = parseInt(queryObject[this.prefix + 'page'], 10) || this.currentPage;
+    const pageQuery = parseInt(queryObject[this.pageParam], 10) || 1;
 
     set(this, 'currentPage', pageQuery);
   },

--- a/app/assets/stylesheets/components/tables.scss
+++ b/app/assets/stylesheets/components/tables.scss
@@ -33,4 +33,8 @@
   th {
     cursor: pointer;
   }
+
+  .no-sort {
+    cursor: default;
+  }
 }

--- a/app/controllers/concerns/with_ordering.rb
+++ b/app/controllers/concerns/with_ordering.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Concern for handling of ordering parameters.
+module WithOrdering
+  extend ActiveSupport::Concern
+
+  include ::API::Helpers::Ordering
+
+  included do
+    before_action :default_ordering_params
+  end
+
+  # Adds some default ordering parameters.
+  def default_ordering_params
+    params[:sort_attr] ||= :id
+    params[:sort_order] ||= :asc
+  end
+end

--- a/app/controllers/concerns/with_pagination.rb
+++ b/app/controllers/concerns/with_pagination.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Concern for handling of pagination parameters.
+module WithPagination
+  extend ActiveSupport::Concern
+
+  include ::API::Helpers::Pagination
+
+  included do
+    before_action :default_pagination_params
+  end
+
+  # Adds some default pagination parameters.
+  def default_pagination_params
+    params[:page] ||= 1
+    params[:per_page] = APP_CONFIG["pagination"]["per_page"]
+  end
+
+  def header(header, value)
+    response.headers[header] = value
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -56,8 +56,8 @@ module ApplicationHelper
   end
 
   # Returns pagination limit config
-  def pagination_limit
-    APP_CONFIG["pagination"]["limit"]
+  def pagination_per_page
+    APP_CONFIG["pagination"]["per_page"]
   end
 
   # Returns pagination before after config

--- a/app/views/repositories/index.html.slim
+++ b/app/views/repositories/index.html.slim
@@ -1,1 +1,1 @@
-<repositories-index-page :team-repositories-ref="#{@team_repositories_serialized}" :other-repositories-ref="#{@other_repositories_serialized}" namespaces-path="#{namespaces_path}" repositories-path="#{repositories_path}"></repositories-index-page>
+<repositories-index-page namespaces-path="#{namespaces_path}" repositories-path="#{repositories_path}" team-repositories-endpoint="#{team_repositories_path}" other-repositories-endpoint="#{other_repositories_path}"></repositories-index-page>

--- a/app/views/shared/_config.html.slim
+++ b/app/views/shared/_config.html.slim
@@ -1,6 +1,6 @@
 javascript:
   window.API_URL = '//#{app_path}';
   window.PAGINATION = {
-    limit: #{pagination_limit},
+    perPage: #{pagination_per_page},
     beforeAfter: #{pagination_before_after}
   };

--- a/config/config.yml
+++ b/config/config.yml
@@ -393,7 +393,7 @@ background:
 # Pagination configuration
 pagination:
   # Number of entries to be listed per page
-  limit: 10
+  per_page: 10
 
   # Number of pages to be showed before and after the current one
   # e,g.: Prev 1 2 [3] 4 5 Next

--- a/config/routes/repositories.rb
+++ b/config/routes/repositories.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 resources :repositories, only: %i[index show destroy] do
+  get :team, action: :team_repositories, on: :collection
+  get :other, action: :other_repositories, on: :collection
   post :toggle_star, on: :member
   resources :comments, only: %i[create destroy]
 end

--- a/lib/api/helpers/ordering.rb
+++ b/lib/api/helpers/ordering.rb
@@ -6,7 +6,18 @@ module API
     # can be customized through request parameters like `sort_attr` and `sort_order`.
     module Ordering
       def order(relation)
-        relation.order(params[:sort_attr] => params[:sort_order])
+        relation.order(sanitized_attr(relation) => sanitized_order)
+      end
+
+      private
+
+      def sanitized_order
+        params[:sort_order] == "asc" ? :asc : :desc
+      end
+
+      def sanitized_attr(relation)
+        attribute = params[:sort_attr]
+        relation.model.respond_to?(attribute) ? attribute : :id
       end
     end
   end

--- a/lib/api/helpers/pagination.rb
+++ b/lib/api/helpers/pagination.rb
@@ -24,7 +24,10 @@ module API
         header "X-Prev-Page",   paginated_data.prev_page.to_s
         header "X-Total",       paginated_data.total_count.to_s
         header "X-Total-Pages", total_pages(paginated_data).to_s
-        header "Link",          pagination_links(paginated_data)
+
+        return if params[:action] && params[:controller]
+
+        header "Link", pagination_links(paginated_data)
       end
 
       def pagination_links(paginated_data)

--- a/spec/javascripts/modules/repositories/tags-table.spec.js
+++ b/spec/javascripts/modules/repositories/tags-table.spec.js
@@ -31,7 +31,7 @@ describe('tags-table', () => {
     const $config = {
       pagination: {
         beforeAfter: 2,
-        limit: 3,
+        perPage: 3,
       },
     };
 

--- a/spec/javascripts/shared/table-pagination.spec.js
+++ b/spec/javascripts/shared/table-pagination.spec.js
@@ -11,6 +11,7 @@ describe('table-pagination', () => {
     wrapper = mount(TablePagination, {
       propsData: {
         total: 10,
+        totalPages: 4,
         itensPerPage: 3,
         currentPage: 1,
       },
@@ -21,12 +22,12 @@ describe('table-pagination', () => {
   });
 
   it('shows "No entry" if total is zero', () => {
-    wrapper.setProps({ total: 0 });
+    wrapper.setProps({ total: 0, totalPages: 1 });
     expect(wrapper.html()).toContain('No entry');
   });
 
   it('shows no pagination element', () => {
-    wrapper.setProps({ total: 0 });
+    wrapper.setProps({ total: 0, totalPages: 1 });
     expect(wrapper.find('.previous').exists()).toBe(false);
     expect(wrapper.find('.next').exists()).toBe(false);
     expect(wrapper.find('.page').exists()).toBe(false);

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,6 +8,8 @@ require File.expand_path("../config/environment", __dir__)
 require "rspec/rails"
 require "pundit/rspec"
 
+Capybara.server = :puma, { Silent: true }
+
 # Raise exception for pending migrations after reading the schema.
 ActiveRecord::Migration.maintain_test_schema!
 

--- a/spec/requests/repositories_controller_spec.rb
+++ b/spec/requests/repositories_controller_spec.rb
@@ -21,13 +21,6 @@ describe RepositoriesController do
     sign_in user
   end
 
-  describe "GET #index" do
-    it "assigns all repositories as @repositories" do
-      get repositories_url
-      expect(assigns(:repositories)).to eq([visible_repository])
-    end
-  end
-
   describe "GET #show" do
     it "assigns the requested repository as @repository" do
       get repository_url(visible_repository.to_param)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -103,7 +103,7 @@ RSpec.configure do |config|
     }
 
     APP_CONFIG["pagination"] = {
-      "limit"        => 10,
+      "per_page"     => 10,
       "before_after" => 2
     }
 

--- a/spec/system/repositories_spec.rb
+++ b/spec/system/repositories_spec.rb
@@ -33,27 +33,27 @@ describe "Feature: Repositories" do
 
     context "table sorting" do
       it "considers url parameters" do
-        # sort asc & namespace.name
-        visit repositories_path(sort_asc: true, sort_by: "namespace.name")
-        expect(page).to have_css("th:nth-child(2) .fa-sort-amount-asc")
+        # sort asc & updated_at
+        visit repositories_path(sort_asc: true, sort_by: "updated_at")
+        expect(page).to have_css("th:nth-child(4) .fa-sort-amount-asc")
 
-        # sort desc & namespace.name
-        visit repositories_path(sort_asc: false, sort_by: "namespace.name")
-        expect(page).to have_css("th:nth-child(2) .fa-sort-amount-desc")
+        # sort desc & updated_at
+        visit repositories_path(sort_asc: false, sort_by: "updated_at")
+        expect(page).to have_css("th:nth-child(4) .fa-sort-amount-desc")
       end
 
       it "updates url when sorted" do
-        path = repositories_path(sort_asc: true, sort_by: "namespace.name")
-        find(".repositories-panel:last-of-type th:nth-child(2)").click
+        path = repositories_path(sort_asc: true, sort_by: "updated_at")
+        find(".repositories-panel:first-of-type th:nth-child(4)").click
 
-        expect(page).to have_css(".repositories-panel th:nth-child(2) .fa-sort-amount-asc")
+        expect(page).to have_css(".repositories-panel th:nth-child(4) .fa-sort-amount-asc")
         expect(page).to have_current_path(path)
 
-        # sort desc & namespace.name
-        path = repositories_path(sort_asc: false, sort_by: "namespace.name")
-        find(".repositories-panel:last-of-type th:nth-child(2)").click
+        # sort desc & updated_at
+        path = repositories_path(sort_asc: false, sort_by: "updated_at")
+        find(".repositories-panel:first-of-type th:nth-child(4)").click
 
-        expect(page).to have_css(".repositories-panel th:nth-child(2) .fa-sort-amount-desc")
+        expect(page).to have_css(".repositories-panel th:nth-child(4) .fa-sort-amount-desc")
         expect(page).to have_current_path(path)
       end
     end
@@ -90,19 +90,6 @@ describe "Feature: Repositories" do
       it "shows all repositories" do
         expect(page).to have_content(repository.name)
         expect(page).to have_content("Other repositories")
-      end
-    end
-
-    context "when not admin" do
-      before do
-        login_as contributor, scope: :user
-        visit repositories_path
-      end
-
-      it "doesn't show 'other repositories' panel" do
-        expect(page).to have_content(repository.name)
-        expect(page).to have_content(repository2.name)
-        expect(page).not_to have_content("Other repositories")
       end
     end
   end


### PR DESCRIPTION
Previously all the repositories were fetched and that caused a
performance issue because of the amount of tags that could be associated
to the repositories.

Instead of fetching all the repositories at once, we introduced
pagination to the repositories#index page.

Signed-off-by: Vítor Avelino <vavelino@suse.com>

Fixes #1940 