### PR TITLE
ldap: automatically set admin according to filter

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -107,6 +107,12 @@ ldap:
   # The base where users are located (e.g. "ou=users,dc=example,dc=com").
   base: ""
 
+  # The base where admin users are located.
+  # (e.g. "ou=admin,dc=example,dc=com"). Use this base if you have a separate
+  # route for admin users. Users logging in from this base will be considered
+  # Portus administrators automatically.
+  admin_base: ""
+
   # User filter (e.g. "mail=george*").
   filter: ""
 

--- a/lib/portus/ldap/authenticatable.rb
+++ b/lib/portus/ldap/authenticatable.rb
@@ -44,7 +44,8 @@ module Portus
         # rubocop:disable Style/GuardClause
         if cfg.enabled?
           connection = initialized_adapter
-          portus_login!(connection, cfg) if bind_as(connection, cfg)
+          entry, admin = bind_as(connection, cfg)
+          portus_login!(connection, cfg, admin) if entry
         else
           # rubocop:disable Style/SignalException
           fail cfg.reason_message

--- a/spec/integration/helpers/ldap.rb
+++ b/spec/integration/helpers/ldap.rb
@@ -35,8 +35,8 @@ end
 
 originals = {}
 
-ARGV[2].to_s.split(",").each do |env|
-  k, val = env.split("=")
+ARGV[2].to_s.split(";").each do |env|
+  k, val = env.split("=", 2)
 
   *key, last = k.split(":")
   hsh = APP_CONFIG["ldap"]
@@ -45,6 +45,8 @@ ARGV[2].to_s.split(",").each do |env|
   originals[k] = hsh[last].dup
   hsh[last] = val
 end
+
+puts "APP_CONFIG for LDAP: #{APP_CONFIG["ldap"]}"
 
 # Regardless of what happens in the end, set the APP_CONFIG to the original
 # values.

--- a/spec/integration/ldap/login.bats
+++ b/spec/integration/ldap/login.bats
@@ -59,8 +59,14 @@ function setup() {
     [ $status -eq 0 ]
 }
 
-@test "LDAP: portus user is skipped" {
+@test "LDAP: bot user is not expected to be present on LDAP" {
     helper_runner ldap.rb pfabra giecftw1918
     [ $status -eq 0 ]
     [[ "${lines[-1]}" =~ "Soft fail: Bot user is not expected to be present on LDAP" ]]
+}
+
+@test "LDAP: admin user can login" {
+    helper_runner ldap.rb calbert victorcatala admin_base='cn=admins,dc=example,dc=org'
+    [ $status -eq 0 ]
+    [[ "${lines[-1]}" =~ "name: calbert, email: , admin: true, display_name:" ]]
 }

--- a/spec/integration/profiles/ldap.rb
+++ b/spec/integration/profiles/ldap.rb
@@ -43,7 +43,17 @@ end
 ldap = Net::LDAP.new(params)
 
 ##
-# Add a test user.
+# Add test users and admins group.
+
+# Prints the last operation result, and if it's not ok (neither 0 nor 68 (entry
+# already exists)), then it will raise an exception.
+def handle_ldap_result!(ldap, params)
+  puts "#{ldap.get_operation_result.message} (code #{ldap.get_operation_result.code})."
+  code = ldap.get_operation_result.code
+  return if code.zero? || code == 68
+
+  raise StandardError, "Parameters used: #{params}"
+end
 
 ldap.add(
   dn:         "uid=jverdaguer,dc=example,dc=org",
@@ -57,6 +67,24 @@ ldap.add(
     mail:         "jverdaguer@renaixenca.cat"
   }
 )
+handle_ldap_result!(ldap, params)
 
-puts "#{ldap.get_operation_result.message} (code #{ldap.get_operation_result.code})."
-puts "Parameters used: #{params}" if ldap.get_operation_result.code != 0
+ldap.add(
+  dn:         "dc=admins,dc=example,dc=org",
+  attributes: { dc: "admins", objectclass: %w[top domain] }
+)
+handle_ldap_result!(ldap, params)
+
+ldap.add(
+  dn:         "uid=calbert,dc=admins,dc=example,dc=org",
+  attributes: {
+    cn:           "Caterina Albert",
+    givenName:    "Caterina",
+    sn:           "Albert",
+    displayName:  "Caterina Albert",
+    objectclass:  %w[top inetorgperson],
+    userPassword: Net::LDAP::Password.generate(:md5, "victorcatala"),
+    mail:         "calbert@renaixenca.cat"
+  }
+)
+handle_ldap_result!(ldap, params)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -120,6 +120,7 @@ RSpec.configure do |config|
         }
       },
       "base"           => "ou=users,dc=example,dc=com",
+      "base_admin"     => "",
       "filter"         => "",
       "uid"            => "uid",
       "authentication" => {


### PR DESCRIPTION
Introduced the new `ldap.admin_base` filter, which allows users to set a
filter for Portus administrators. When a new user logs in, it will
automatically set the `admin` flag depending on whether it was found on
this filter or not. If this configuration option is not set (default),
then this whole workflow will be ignored.

Fixes #1298

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>