### PR TITLE
ui: fixed team creation for standard user

### DIFF
--- a/app/assets/javascripts/modules/teams/components/new-form.vue
+++ b/app/assets/javascripts/modules/teams/components/new-form.vue
@@ -73,7 +73,13 @@
 
     methods: {
       onSubmit() {
-        TeamsService.save(this.team).then((response) => {
+        const params = { ...this.team };
+
+        if (!this.isAdmin) {
+          delete params.owner_id;
+        }
+
+        TeamsService.save(params).then((response) => {
           const team = response.data;
 
           this.toggleForm();

--- a/spec/system/teams_spec.rb
+++ b/spec/system/teams_spec.rb
@@ -88,6 +88,25 @@ describe "Teams support", type: :system, js: true do
 
         expect(page).not_to have_css("#team_owner_id")
       end
+
+      it "creates a team" do
+        toggle_new_team_form
+        fill_in "Name", with: "valid-team2"
+
+        click_button "Add"
+
+        expect(page).to have_content("Team 'valid-team2' was created successfully")
+        expect(page).to have_link("valid-team2")
+      end
+
+      context "permission disabled" do
+        it "doesn't see link to create team" do
+          APP_CONFIG["user_permission"]["create_team"]["enabled"] = false
+          visit teams_path
+
+          expect(page).not_to have_content("Create new team")
+        end
+      end
     end
   end
 


### PR DESCRIPTION
When standard user, the UI was sending a parameter through the request
that was supposed to be sent only by admin user. This was preventing
standard users from creating teams.

Signed-off-by: Vítor Avelino <vavelino@suse.com>