### PR TITLE
ui: fixed namespaces duplication

### DIFF
--- a/app/policies/namespace_policy.rb
+++ b/app/policies/namespace_policy.rb
@@ -121,6 +121,7 @@ class NamespacePolicy
             protected: Namespace.visibilities[:visibility_protected],
             user_id:   user.id
           )
+          .distinct
       end
     end
   end


### PR DESCRIPTION
Standard users were seeing duplicated namespaces entries in the
namespaces#index page.

Signed-off-by: Vítor Avelino <vavelino@suse.com>