### PR TITLE
ldap: allow failures to fallback to the DB

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -60,6 +60,7 @@ class User < ApplicationRecord
 
   # Actions performed before/after create.
   validates :username, presence: true, uniqueness: true
+  validates :password, confirmation: true
   validate :private_namespace_and_team_available, on: :create
   validate :portus_user_validation, on: :update
   after_create :create_personal_namespace!, if: :needs_namespace?

--- a/lib/api/v1/users.rb
+++ b/lib/api/v1/users.rb
@@ -42,11 +42,18 @@ module API
           end
 
           post do
-            user = User.create declared(params)[:user]
-            if user.valid?
-              present user, with: API::Entities::Users
+            attrs = declared(params)[:user]
+            msg = ::Portus::LDAP::Search.new.with_error_message(attrs[:username])
+
+            if msg.nil?
+              user = User.create attrs
+              if user.valid?
+                present user, with: API::Entities::Users
+              else
+                unprocessable_entity!(user.errors)
+              end
             else
-              unprocessable_entity!(user.errors)
+              unprocessable_entity!(ldap: [msg])
             end
           end
 

--- a/lib/portus/ldap/connection.rb
+++ b/lib/portus/ldap/connection.rb
@@ -24,11 +24,18 @@ module Portus
         raise ::Portus::LDAP::Error, "Some parameters are missing" unless cfg.initialized?
 
         res, admin = bind_admin_or_user(connection, cfg)
-        logged_error_message!(connection, cfg.username) unless res
+        binding_failed!(connection, cfg.username) unless res
         [res, admin]
       end
 
       protected
+
+      # Tries to fallback into the DB, otherwise it logs an error and fails.
+      def binding_failed!(connection, username)
+        return if User.exists?(username: username)
+
+        logged_error_message!(connection, username)
+      end
 
       # If `ldap.admin_base` is enabled, then it tries to bind first on the
       # admin route, and then as a regular user. Otherwise, it tries to bind

--- a/lib/portus/ldap/search.rb
+++ b/lib/portus/ldap/search.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "portus/ldap/adapter"
+require "portus/ldap/configuration"
+require "portus/ldap/connection"
+
+module Portus
+  module LDAP
+    # Search implements methods that only perform search actions towards the
+    # configured LDAP server.
+    class Search
+      include ::Portus::LDAP::Adapter
+      include ::Portus::LDAP::Connection
+
+      # Returns true if the given name exists on the LDAP server, false
+      # otherwise.
+      def exists?(name)
+        return if APP_CONFIG.disabled?("ldap")
+
+        configuration = ::Portus::LDAP::Configuration.new(user: { username: name })
+        connection = initialized_adapter
+        record = search_admin_or_user(connection, configuration)
+        record&.size != 0
+      end
+
+      # Returns nil if the given user was not found, otherwise it returns an
+      # error message.
+      def with_error_message(name)
+        return if APP_CONFIG.disabled?("ldap")
+        return unless exists?(name)
+
+        "The username '#{name}' already exists on the LDAP server. Use " \
+        "another name to avoid name collision"
+      end
+    end
+  end
+end

--- a/spec/integration/health.bats
+++ b/spec/integration/health.bats
@@ -7,17 +7,17 @@ function setup() {
 }
 
 @test "health runs just fine" {
-    helper_runner curl.rb /api/v1/health
-    [[ "${lines[-2]}" =~ "database is up-to-date" ]]
-    [[ "${lines[-2]}" =~ "clair is reachable" ]]
-    [[ "${lines[-2]}" =~ "registry is reachable" ]]
+    helper_runner curl.rb get /api/v1/health
+    [[ "${lines[-1]}" =~ "database is up-to-date" ]]
+    [[ "${lines[-1]}" =~ "clair is reachable" ]]
+    [[ "${lines[-1]}" =~ "registry is reachable" ]]
 }
 
 @test "health reports an invalid registry" {
     # Modify the registry hostname to some unknown hostname.
     ruby_puts "Registry.get.update(hostname:\"wrong.whatever\")"
 
-    helper_runner curl.rb /api/v1/health
+    helper_runner curl.rb get /api/v1/health
     [ $status -eq 1 ]
     [[ "${lines[-2]}" =~ "SocketError: connection refused" ]]
 }

--- a/spec/integration/helpers/curl.rb
+++ b/spec/integration/helpers/curl.rb
@@ -3,11 +3,58 @@
 require "net/http"
 require "uri"
 
-hostname = ENV["PORTUS_MACHINE_FQDN_VALUE"]
-endpoint = ARGV.first
+##
+# What we expect from the environment and from passed parameters.
+
+hostname   = ENV["PORTUS_MACHINE_FQDN_VALUE"]
+method     = ARGV[0].downcase
+endpoint   = ARGV[1]
+username   = ARGV[2]
+parameters = ARGV[3]
+
+##
+# Initialize the request object.
 
 uri = URI.parse("http://#{hostname}:3000#{endpoint}")
-response = Net::HTTP.get_response(uri)
+req = Net::HTTP.const_get(method.capitalize).new(uri)
+req["Accept"] = "application/json"
+
+if method == "post" && parameters.present?
+  ##
+  # Application token
+
+  ApplicationToken.delete_all
+  user = User.find_by(username: username)
+  _, plain = ApplicationToken.create_token(
+    current_user: user, user_id: user.id, params: { application: "integration-test" }
+  )
+  req["Portus-Auth"] = "#{username}:#{plain}"
+
+  ##
+  # Body
+
+  req["Content-Type"] = "application/json"
+  body = {}
+  parameters.split(",").each do |kv|
+    k, v = kv.split("=", 2)
+    first, second = k.split(".", 2)
+    if second.nil?
+      body[first] = v
+    else
+      body[first] = body.fetch(first, {})
+      body[first][second] = v
+    end
+  end
+  req.body = body.to_json
+end
+
+##
+# Perform the HTTP request and print the response.
+
+response = Net::HTTP.start(uri.hostname, uri.port) do |http|
+  http.request(req)
+end
 
 puts response.body
-exit response.code == 200 ? 0 : 1
+exit 0 if response.code.to_i == 200 || response.code.to_i == 201
+exit 1

--- a/spec/integration/ldap/health.bats
+++ b/spec/integration/ldap/health.bats
@@ -7,6 +7,7 @@ function setup() {
 }
 
 @test "LDAP: health status is up" {
-    helper_runner curl.rb /api/v1/health
-    [[ "${lines[-2]}" =~ "LDAP server is reachable" ]]
+    helper_runner curl.rb get /api/v1/health
+    [ $status -eq 0 ]
+    [[ "${lines[-1]}" =~ "LDAP server is reachable" ]]
 }

--- a/spec/integration/ldap/login.bats
+++ b/spec/integration/ldap/login.bats
@@ -9,7 +9,7 @@ function setup() {
 @test "LDAP: proper user can login" {
     helper_runner ldap.rb jverdaguer folgueroles
     [ $status -eq 0 ]
-    [[ "${lines[-1]}" =~ "name: jverdaguer, email: , admin: true, display_name:" ]]
+    [[ "${lines[-1]}" =~ "name: jverdaguer, email: , admin: false, display_name:" ]]
 }
 
 @test "LDAP: bad password" {
@@ -66,7 +66,12 @@ function setup() {
 }
 
 @test "LDAP: admin user can login" {
-    helper_runner ldap.rb calbert victorcatala admin_base='cn=admins,dc=example,dc=org'
+    helper_runner ldap.rb calbert victorcatala admin_base='dc=admins,dc=example,dc=org'
     [ $status -eq 0 ]
     [[ "${lines[-1]}" =~ "name: calbert, email: , admin: true, display_name:" ]]
+}
+
+@test "LDAP: DB user can log in" {
+    helper_runner ldap.rb noller lapapallona
+    [ $status -eq 0 ]
 }

--- a/spec/integration/ldap/user.bats
+++ b/spec/integration/ldap/user.bats
@@ -1,0 +1,19 @@
+#!/usr/bin/env bats -t
+
+load ../helpers
+
+function setup() {
+    __setup ldap
+}
+
+@test "LDAP: you can create a user that doesn't exist" {
+    helper_runner curl.rb post /api/v1/users rllull user.username=mrodoreda,user.email=lala@example.org,user.password=12341234
+    [ $status -eq 0 ]
+    [[ "${lines[-1]}" =~ "\"username\":\"mrodoreda\"" ]]
+}
+
+@test "LDAP: you cannot create an existing user" {
+    helper_runner curl.rb post /api/v1/users rllull user.username=jverdaguer,user.email=lala@example.org,user.password=12341234
+    [ $status -eq 1 ]
+    [[ "${lines[-2]}" =~ "Use another name to avoid name collision" ]]
+}

--- a/spec/integration/profiles/ldap.rb
+++ b/spec/integration/profiles/ldap.rb
@@ -5,12 +5,17 @@ require_relative "shared"
 
 clean_db!
 create_registry!
+
+##
+# Create bot and DB user.
+
 User.create!(
   username: "pfabra",
   password: "giecftw1918",
   email:    "pfabra@iec.cat",
   bot:      true
 )
+User.create!(username: "noller", password: "lapapallona", email: "noller@renaixenca.cat")
 
 ##
 # Set parameters and initialize LDAP object.

--- a/spec/integration/profiles/ldap.rb
+++ b/spec/integration/profiles/ldap.rb
@@ -16,6 +16,7 @@ User.create!(
   bot:      true
 )
 User.create!(username: "noller", password: "lapapallona", email: "noller@renaixenca.cat")
+User.create!(username: "rllull", password: "lomeuart", admin: true, email: "rllull@medieval.cat")
 
 ##
 # Set parameters and initialize LDAP object.

--- a/spec/lib/portus/ldap/authenticatable_spec.rb
+++ b/spec/lib/portus/ldap/authenticatable_spec.rb
@@ -569,6 +569,16 @@ describe ::Portus::LDAP::Authenticatable do
       expect { lm.authenticate! }.to(change { User.all.size }.by(1))
       expect(lm.fail_message).to eq ""
     end
+
+    it "returns successful if binding failed but it was on the database" do
+      create(:user, username: "user", password: "12341234")
+      allow_any_instance_of(Net::LDAP).to receive(:bind_as).and_return(false)
+      params = { user: { username: "user", password: "12341234" } }
+
+      lm = AuthenticatableMock.new(params)
+      expect { lm.authenticate! }.to_not raise_error
+      expect(lm.fail_message).to eq ""
+    end
   end
 
   describe "#guess_email" do

--- a/spec/lib/portus/ldap/search_spec.rb
+++ b/spec/lib/portus/ldap/search_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+describe ::Portus::LDAP::Search do
+  context "#with_error_message" do
+    it "returns nil if LDAP is disabled" do
+      APP_CONFIG["ldap"]["enabled"] = false
+
+      expect(described_class.new.with_error_message("name")).to be_nil
+    end
+
+    it "returns nil if the name doesn't exist" do
+      allow_any_instance_of(described_class).to receive(:search_admin_or_user).and_return([])
+      APP_CONFIG["ldap"]["enabled"] = true
+
+      expect(described_class.new.with_error_message("name")).to be_nil
+    end
+
+    it "returns the message if the user exist" do
+      allow_any_instance_of(described_class).to receive(:search_admin_or_user).and_return([1])
+      APP_CONFIG["ldap"]["enabled"] = true
+
+      expect(described_class.new.with_error_message("name")).not_to be_nil
+    end
+  end
+end

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -82,7 +82,22 @@ RSpec.describe Admin::UsersController do
       end.to change(User, :count).by(1)
     end
 
-    it "failes to create new user without matching password" do
+    it "fails to create new user without matching password" do
+      expect do
+        post admin_users_url, params: { user: {
+          username:              "solomon",
+          email:                 "soloman@example.org",
+          password:              "password",
+          password_confirmation: "drowssap"
+        }, format: :json }
+      end.not_to change(User, :count)
+    end
+
+    it "fails to create new user if check_ldap_user! fails" do
+      allow_any_instance_of(::Portus::LDAP::Search).to(
+        receive(:with_error_message).and_return("error message")
+      )
+
       expect do
         post admin_users_url, params: { user: {
           username:              "solomon",

--- a/spec/requests/webhooks_controller_spec.rb
+++ b/spec/requests/webhooks_controller_spec.rb
@@ -401,7 +401,7 @@ RSpec.describe WebhooksController do
       expect(activity.trackable).to eq(Webhook.last)
     end
 
-    it "tracks set webhook enabled", lala: true do
+    it "tracks set webhook enabled" do
       webhook.update(enabled: false)
 
       expect do


### PR DESCRIPTION
In some cases, administrators won't have some users on the LDAP server
but they would on the local Portus instance. On these cases, let's allow
LDAP bind failures to fall back to the database.

Fixes #1862 
Fixes #1731

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>