### PR TITLE
Allow automatic creation of unknown namespaces

### DIFF
--- a/app/assets/javascripts/modules/namespaces/components/details.vue
+++ b/app/assets/javascripts/modules/namespaces/components/details.vue
@@ -3,7 +3,6 @@
     <h5 slot="heading-left">
       <a data-placement="right"
         data-toggle="popover"
-        data-container=".panel-heading"
         data-content="<p>Information about the namespace.</p>"
         data-original-title="What's this?"
         tabindex="0"

--- a/app/assets/javascripts/modules/namespaces/components/info.vue
+++ b/app/assets/javascripts/modules/namespaces/components/info.vue
@@ -5,6 +5,21 @@
       <col class="col-80">
     </colgroup>
     <tbody>
+      <tr v-if="namespace.orphan">
+        <th class="v-align-top">Team</th>
+        <td>
+          None (aka orphan)
+          <a data-placement="right"
+            data-toggle="popover"
+            data-content="<p>An orphan namespace is a namespace that was created automatically
+              via background sync job because it previously existed in your registry when Portus was set up.</p>"
+            data-original-title="What's this?"
+            tabindex="0"
+            data-html="true">
+            <i class="fa fa-info-circle"></i>
+          </a>
+      </td>
+      </tr>
       <tr v-if="!namespace.global && !namespace.team.hidden">
         <th class="v-align-top">Team</th>
         <td><a :href="teamHref">{{ namespace.team.name }}</a></td>

--- a/app/assets/javascripts/modules/namespaces/pages/index.vue
+++ b/app/assets/javascripts/modules/namespaces/pages/index.vue
@@ -21,6 +21,10 @@
       <h5 slot="name">Namespaces you have access to through membership</h5>
     </namespaces-panel>
 
+    <namespaces-panel :namespaces="orphanNamespaces" :namespaces-path="namespacesPath" :webhooks-path="webhooksPath" prefix="ons_" :table-sortable="true" v-if="orphanNamespaces.length">
+      <h5 slot="name">Orphan namespaces (no team assigned)</h5>
+    </namespaces-panel>
+
     <namespaces-panel :namespaces="otherNamespaces" :namespaces-path="namespacesPath" :webhooks-path="webhooksPath" prefix="ons_" :table-sortable="true" v-if="otherNamespaces.length">
       <h5 slot="name">Other namespaces</h5>
     </namespaces-panel>
@@ -76,7 +80,8 @@
         return this.namespaces.filter((n) => {
           return !n.global
               && n.id !== this.userNamespaceId
-              && this.accessibleTeamsIds.indexOf(n.team.id) === -1;
+              && this.accessibleTeamsIds.indexOf(n.team.id) === -1
+              && n.team.name.indexOf('global_team') === -1;
         });
       },
 
@@ -86,6 +91,13 @@
           return !n.global
               && n.id !== this.userNamespaceId
               && this.accessibleTeamsIds.indexOf(n.team.id) !== -1;
+        });
+      },
+
+      orphanNamespaces() {
+        // eslint-disable-next-line
+        return this.namespaces.filter((n) => {
+          return n.orphan;
         });
       },
 

--- a/app/models/namespace/auth_scope.rb
+++ b/app/models/namespace/auth_scope.rb
@@ -5,15 +5,15 @@ class Namespace::AuthScope < Portus::AuthScope
   attr_accessor :actions, :resource_type, :resource_name
 
   def resource
-    found_resource = if @namespace_name.blank?
-                       @registry.namespaces.find_by(global: true)
-                     else
-                       @registry.namespaces.find_by(name: @namespace_name)
-                     end
+    resource = if @namespace_name.blank?
+                 @registry.namespaces.find_by(global: true)
+               else
+                 @registry.namespaces.find_by(name: @namespace_name)
+               end
 
-    raise ResourceNotFound, "Cannot find namespace #{@namespace_name}" if found_resource.nil?
+    resource = Namespace.new(name: @namespace_name) if resource.nil?
 
-    found_resource
+    resource
   end
 
   # Re-impemented to handle the special "*" action. If the action is "*", then

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -157,7 +157,7 @@ class Repository < ApplicationRecord
   # found, then it returns nil.
   def self.from_catalog(name, create_if_missing = false)
     # If the namespace does not exist, get out.
-    namespace, name = Namespace.get_from_name(name)
+    namespace, name = Namespace.get_from_repository_name(name, nil, create_if_missing)
     return if namespace.nil?
 
     if create_if_missing
@@ -187,9 +187,9 @@ class Repository < ApplicationRecord
 
     # Create missing tags and update current ones.
     client = Registry.get.client
-    portus = User.find_by(username: "portus")
-    update_tags client, repository, portus, repo["tags"] & tags
-    create_tags client, repository, portus, repo["tags"] - tags
+    portus = User.portus
+    update_tags(client, repository, portus, repo["tags"] & tags)
+    create_tags(client, repository, portus, repo["tags"] - tags)
 
     # Finally remove the tags that are left and return the repo.
     to_be_deleted_tags = tags - repo["tags"]

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -49,6 +49,11 @@ class Team < ApplicationRecord
     team_users.pluck(:user_id)
   end
 
+  # Returns the main global team
+  def self.global
+    find_by(name: "portus_global_team_1")
+  end
+
   # Returns all teams whose name match the query
   def self.search_from_query(valid_teams, query)
     all_non_special.where(id: valid_teams).where(arel_table[:name].matches(query))

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -77,9 +77,9 @@ class User < ApplicationRecord
   has_many :tags, dependent: :nullify
   has_many :comments, dependent: :destroy
 
-  scope :not_portus, -> { where.not username: "portus" }
-  scope :enabled,    -> { not_portus.where enabled: true }
-  scope :admins,     -> { not_portus.where enabled: true, admin: true }
+  scope :not_portus, -> { where.not(username: "portus") }
+  scope :enabled,    -> { not_portus.where(enabled: true) }
+  scope :admins,     -> { not_portus.where(enabled: true, admin: true) }
 
   class <<self
     attr_accessor :skip_portus_validation
@@ -94,6 +94,11 @@ class User < ApplicationRecord
       email:    "portus@portus.com",
       admin:    true
     )
+  end
+
+  # Returns portus user
+  def self.portus
+    find_by(username: "portus")
   end
 
   # Special method used by Devise to require an email on signup. This is always

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -63,7 +63,7 @@ class Webhook < ApplicationRecord
     registry = Registry.find_from_event(event)
     return if registry.nil?
 
-    namespace, = Namespace.get_from_name(event["target"]["repository"], registry)
+    namespace, = Namespace.get_from_repository_name(event["target"]["repository"], registry)
     return if namespace.nil?
 
     hydra = Typhoeus::Hydra.hydra

--- a/app/policies/namespace_policy.rb
+++ b/app/policies/namespace_policy.rb
@@ -8,7 +8,11 @@ class NamespacePolicy
     @namespace = namespace
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def pull?
+    # If user is portus, it can pull anything
+    return true if user&.portus?
+
     # Even non-logged in users can pull from a public namespace.
     return true if namespace.visibility_public?
 
@@ -24,6 +28,7 @@ class NamespacePolicy
     # Everybody can pull from the global namespace
     namespace.global? || user.admin? || member?
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   alias show? pull?
 

--- a/app/views/public_activity/namespace/_create.html.slim
+++ b/app/views/public_activity/namespace/_create.html.slim
@@ -8,10 +8,14 @@ li
       h6
         strong
           = "#{activity_owner(activity)} created "
-        = render_namespace_name(activity, true)
-        = " namespace under "
-        = render_namespace_team(activity)
-        = " team"
+        - if activity.trackable.orphan?
+          = render_namespace_name(activity, true)
+          |  namespace automatically (orphan)
+        - else
+          = render_namespace_name(activity, true)
+          = " namespace under "
+          = render_namespace_team(activity)
+          = " team"
       small
         i.fa.fa-clock-o
         = activity_time_tag activity.created_at

--- a/config/initializers/portus_user.rb
+++ b/config/initializers/portus_user.rb
@@ -15,6 +15,6 @@ end
 
 password = Rails.application.secrets.portus_password
 if portus_exists && password.present?
-  portus = User.find_by(username: "portus")
+  portus = User.portus
   portus&.update_attribute("password", Rails.application.secrets.portus_password)
 end

--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -333,6 +333,14 @@ module API
         type: "Boolean",
         desc: "Whether this is the global namespace or not"
       }
+      # rubocop:disable Style/SymbolProc
+      expose :orphan, documentation: {
+        type: "Boolean",
+        desc: "Whether this is an orphan namespace or not"
+      }, if: { type: :internal } do |namespace|
+        namespace.orphan?
+      end
+      # rubocop:enable Style/SymbolProc
       expose :updatable, documentation: {
         desc: "Boolean that tells if the current user can manage the namespace"
       }, if: { type: :internal } do |namespace, options|

--- a/lib/portus/background/sync.rb
+++ b/lib/portus/background/sync.rb
@@ -128,7 +128,7 @@ module Portus
       def delete_maybe!(repositories)
         return if APP_CONFIG["background"]["sync"]["strategy"] == "update"
 
-        portus = User.find_by(username: "portus")
+        portus = User.portus
         Tag.where(repository_id: repositories).find_each { |t| t.delete_by!(portus) }
         Repository.where(id: repositories).find_each { |r| r.delete_by!(portus) }
       end

--- a/spec/api/v2/token_spec.rb
+++ b/spec/api/v2/token_spec.rb
@@ -372,7 +372,9 @@ describe "/v2/token", type: :request do
 
         context "reposity scope" do
           it "responds with 200 and no access" do
-            # force creation of the namespace
+            allow_any_instance_of(NamespacePolicy).to receive(:push?).and_call_original
+            allow_any_instance_of(NamespacePolicy).to receive(:pull?).and_call_original
+
             namespace = create(:namespace,
                                team:     Team.find_by(name: user.username),
                                registry: registry)
@@ -383,6 +385,7 @@ describe "/v2/token", type: :request do
               account: user.username,
               scope:   "repository:#{namespace.name}/busybox:push,pull"
             }, headers: valid_auth_header
+
             expect(response.status).to eq(200)
             payload = parse_token response.body
             expect(payload["access"]).to be_empty

--- a/spec/models/namespace/auth_scope_spec.rb
+++ b/spec/models/namespace/auth_scope_spec.rb
@@ -19,11 +19,10 @@ describe Namespace::AuthScope, type: :model do
     expect(scope.scopes).to match_array(["pull"])
   end
 
-  it "raises an exception when it's not found" do
+  it "returns namespace instance (not persisted) when it's not found" do
     scope = Namespace::AuthScope.new(registry, "registry:mssola/busybox:pull")
-    expect do
-      scope.resource
-    end.to raise_error(Portus::AuthScope::ResourceNotFound)
+    expect(scope.resource.id).to be_nil
+    expect(scope.resource).not_to be_persisted
   end
 
   it "handles the special action *" do

--- a/spec/models/namespace_spec.rb
+++ b/spec/models/namespace_spec.rb
@@ -126,7 +126,7 @@ describe Namespace do
     end
   end
 
-  describe "get_from_name" do
+  describe "get_from_repository_name" do
     let!(:registry)    { create(:registry) }
     let!(:owner)       { create(:user) }
     let!(:team)        { create(:team, owners: [owner]) }
@@ -135,13 +135,13 @@ describe Namespace do
 
     it "works for global namespaces" do
       ns = described_class.find_by(global: true)
-      namespace, name = described_class.get_from_name(repo.name)
+      namespace, name = described_class.get_from_repository_name(repo.name)
       expect(namespace.id).to eq ns.id
       expect(name).to eq repo.name
     end
 
     it "works for user namespaces" do
-      ns, name = described_class.get_from_name("#{namespace.name}/#{repo.name}")
+      ns, name = described_class.get_from_repository_name("#{namespace.name}/#{repo.name}")
       expect(ns.id).to eq namespace.id
       expect(name).to eq repo.name
     end
@@ -149,13 +149,14 @@ describe Namespace do
     context "when providing a registry" do
       it "works for global namespaces" do
         ns = described_class.find_by(global: true)
-        namespace, name = described_class.get_from_name(repo.name, registry)
+        namespace, name = described_class.get_from_repository_name(repo.name, registry)
         expect(namespace.id).to eq ns.id
         expect(name).to eq repo.name
       end
 
       it "works for user namespaces" do
-        ns, name = described_class.get_from_name("#{namespace.name}/#{repo.name}", registry)
+        repository_name = "#{namespace.name}/#{repo.name}"
+        ns, name = described_class.get_from_repository_name(repository_name, registry)
         expect(ns.id).to eq namespace.id
         expect(name).to eq repo.name
       end

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -624,7 +624,10 @@ describe Repository do
 
       # Trying to create a repo into an unknown namespace.
       repo = { "name" => "unknown/repo1", "tags" => ["latest", "0.1"] }
-      expect(described_class.create_or_update!(repo)).to be_nil
+      repo = described_class.create_or_update!(repo)
+      expect(repo.name).to eq "repo1"
+      expect(repo.namespace.name).to eq "unknown"
+      expect(repo.tags.map(&:name).sort).to match_array(["latest", "0.1"])
     end
 
     it "doesn't remove tags of same name for different repo" do

--- a/spec/vcr_cassettes/registry/get_registry_catalog_namespace_missing.yml
+++ b/spec/vcr_cassettes/registry/get_registry_catalog_namespace_missing.yml
@@ -158,7 +158,7 @@ http_interactions:
       - Mon, 10 Aug 2015 16:06:08 GMT
     body:
       string: |
-        {"name": "missing/busybox", "tags":["latest"]}
+        {"name": "missing/busybox", "tags":["latest", "2.0"]}
   http_version:
   recorded_at: Mon, 10 Aug 2015 16:06:08 GMT
 - request:


### PR DESCRIPTION
Repositories with unknown namespaces from a pre-existent registry
were being ignored while syncing.
    
Now, by default, all the repositories will be considered and orphan
namespaces will be created. These namespaces can be transfered to its
respective teams later by any admin.

Fixes #1961 