### PR TITLE
db: added index on scan_result

### DIFF
--- a/app/models/scan_result.rb
+++ b/app/models/scan_result.rb
@@ -10,6 +10,10 @@
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #
+# Indexes
+#
+#  index_scan_results_on_vulnerability_id_and_tag_id  (vulnerability_id,tag_id)
+#
 
 # Relationship linking tags and vulnerabilities: a scan result involves
 # vulnerabilities for tags.

--- a/db/migrate/20181213101302_add_index_scan_results_vulnerability_tag.rb
+++ b/db/migrate/20181213101302_add_index_scan_results_vulnerability_tag.rb
@@ -1,0 +1,5 @@
+class AddIndexScanResultsVulnerabilityTag < ActiveRecord::Migration[5.2]
+  def change
+    add_index(:scan_results, [:vulnerability_id, :tag_id])
+  end
+end

--- a/db/schema.mysql.rb
+++ b/db/schema.mysql.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_12_145708) do
+ActiveRecord::Schema.define(version: 2018_12_13_101302) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "trackable_type"
@@ -96,6 +96,7 @@ ActiveRecord::Schema.define(version: 2018_06_12_145708) do
     t.integer "vulnerability_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["vulnerability_id", "tag_id"], name: "index_scan_results_on_vulnerability_id_and_tag_id"
   end
 
   create_table "stars", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/db/schema.postgresql.rb
+++ b/db/schema.postgresql.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_12_145708) do
+ActiveRecord::Schema.define(version: 2018_12_13_101302) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -99,6 +99,7 @@ ActiveRecord::Schema.define(version: 2018_06_12_145708) do
     t.integer "vulnerability_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["vulnerability_id", "tag_id"], name: "index_scan_results_on_vulnerability_id_and_tag_id"
   end
 
   create_table "stars", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
In particular, I've added the index on vulnerability_id and tag_id. As
reported on #2053, this index makes the scanning of vulnerability issues
way faster on large amounts of tags.

Fixes #2053

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>