### PR TITLE
entity (repositories): reduced amount of rendered data

### DIFF
--- a/app/controllers/explore_controller.rb
+++ b/app/controllers/explore_controller.rb
@@ -19,7 +19,7 @@ class ExploreController < ActionController::Base
     if @current
       repository    = @current.split(":").first
       repositories  = policy_scope(Repository).includes(:stars).search(repository)
-      @repositories = API::Entities::Repositories.represent(repositories, type: :internal).to_json
+      @repositories = API::Entities::Repositories.represent(repositories, type: :search).to_json
     else
       @repositories = []
     end

--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -146,7 +146,7 @@ module API
         type: Integer,
         desc: "The repository's registry hostname. Prioritizes external hostname value" \
               "if present, otherwise internal hostname is shown"
-      }, if: { type: :internal } do |repository|
+      }, if: :type do |repository|
         repository.registry.reachable_hostname
       end
       expose :stars, documentation: {
@@ -164,19 +164,19 @@ module API
       expose :tags, documentation: {
         is_array: true,
         desc:     "The repository's tags grouped by digest"
-      }, if: { type: :internal } do |repository|
+      }, if: { type: :search } do |repository|
         repository.groupped_tags.map do |k1|
           API::Entities::Tags.represent(k1)
         end
       end
       expose :starred, documentation: {
         desc: "Boolean that tells if the current user starred the repository"
-      }, if: { type: :internal } do |repository, options|
+      }, if: :type do |repository, options|
         repository.starred_by?(options[:current_user])
       end
       expose :destroyable, documentation: {
         desc: "Boolean that tells if the current user can destroy or not the repository"
-      }, if: { type: :internal } do |repository, options|
+      }, if: :type do |repository, options|
         user = options[:current_user]
         can_destroy_repository?(repository, user) if user
       end

--- a/spec/api/grape_api/v1/repositories_spec.rb
+++ b/spec/api/grape_api/v1/repositories_spec.rb
@@ -77,6 +77,7 @@ describe API::V1::Repositories, type: :request do
       expect(response).to have_http_status(:success)
       expect(repository_parsed["id"]).to eq(repository.id)
       expect(repository_parsed["name"]).to eq(repository.name)
+      expect(repository_parsed["tags"]).to be_nil
     end
 
     it "returns 404 if it doesn't exist" do


### PR DESCRIPTION
Tags were being rendered in repositories entity whenever repositories
were fetched. When rendering tags, we fetch vulnerabilities data that
might be too. That was causing slowness in repositories#index page.

We now only render tags when rendering respositories for the explore
page result. There's still room for improvement to fetch asynchronously
the vulnerabilities with its own endpoint.

Signed-off-by: Vítor Avelino <vavelino@suse.com>

Fixes #2059 