### PR TITLE
Removed deprecated sass gem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN zypper addrepo https://download.opensuse.org/repositories/devel:languages:go
     zypper -n in --no-recommends ruby2.5-devel \
            libmysqlclient-devel postgresql-devel \
            nodejs libxml2-devel libxslt1 git-core \
-           go1.10 phantomjs && \
+           go1.10 phantomjs gcc-c++ && \
     zypper -n in --no-recommends -t pattern devel_basis && \
     gem install bundler --no-ri --no-rdoc -v 1.16.0 && \
     update-alternatives --install /usr/bin/bundle bundle /usr/bin/bundle.ruby2.5 3 && \

--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem "public_activity", "~> 1.6.3"
 gem "pundit"
 gem "rails", "~> 5.2.0"
 gem "redcarpet"
-gem "sass"
+gem "sassc-rails"
 gem "search_cop"
 gem "slim"
 gem "webpack-rails"
@@ -62,7 +62,6 @@ gem "temple"
 
 group :assets do
   gem "bootstrap-sass"
-  gem "sass-rails"
   gem "uglifier"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,7 +53,7 @@ GEM
       io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
-    autoprefixer-rails (9.3.1)
+    autoprefixer-rails (9.4.3)
       execjs
     awesome_print (1.8.0)
     axiom-types (0.1.1)
@@ -65,9 +65,9 @@ GEM
     bindex (0.5.0)
     binman (5.1.0)
       opener (>= 0.1.0, < 1)
-    bootstrap-sass (3.3.7)
+    bootstrap-sass (3.4.0)
       autoprefixer-rails (>= 5.2.1)
-      sass (>= 3.3.4)
+      sassc (>= 2.0.0)
     brakeman (4.3.1)
     builder (3.2.3)
     byebug (10.0.2)
@@ -335,8 +335,8 @@ GEM
     rainbow (3.0.0)
     rake (12.3.2)
     rb-fsevent (0.10.3)
-    rb-inotify (0.9.10)
-      ffi (>= 0.5.0, < 2)
+    rb-inotify (0.10.0)
+      ffi (~> 1.0)
     redcarpet (3.4.0)
     regexp_parser (1.2.0)
     responders (2.4.0)
@@ -377,17 +377,15 @@ GEM
     ruby_dep (1.5.0)
     rubyzip (1.2.2)
     safe_yaml (1.0.4)
-    sass (3.7.1)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (5.0.7)
-      railties (>= 4.0.0, < 6)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (>= 1.1, < 3)
+    sassc (2.0.0)
+      ffi (~> 1.9.6)
+      rake
+    sassc-rails (2.1.0)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     sawyer (0.3.0)
       faraday (~> 0.8, < 0.10)
       uri_template (~> 0.5.0)
@@ -527,8 +525,7 @@ DEPENDENCIES
   rspec-core
   rspec-rails
   rubocop
-  sass
-  sass-rails
+  sassc-rails
   search_cop
   selenium-webdriver
   shoulda
@@ -548,4 +545,4 @@ DEPENDENCIES
   wirble
 
 BUNDLED WITH
-   1.17.1
+   1.17.3


### PR DESCRIPTION
This was deprecated in favor of sassc-rails. I've also upgraded
bootstrap-sass so it uses this dependency instead of the old sass gem.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>