### PR TITLE
Adds filter to tags to be collected

### DIFF
--- a/lib/portus/background/garbage_collector.rb
+++ b/lib/portus/background/garbage_collector.rb
@@ -49,10 +49,10 @@ module Portus
         tags = Tag.where(marked: false).where("updated_at < ?", older_than)
         return tags if APP_CONFIG["delete"]["garbage_collector"]["tag"].blank?
 
-        not_matching_tags = tags.select { |t| !t.name.match(tag_regexp) }
-        not_matching_image_id = not_matching_tags.map { |t| t.image_id }
+        not_match_tags = tags.reject { |t| t.name.match(tag_regexp) }
+        not_match_image = not_match_tags.map(&:image_id)
 
-        tags.select { |t| t.name.match(tag_regexp) and not not_matching_image_id.include?(t.image_id)  }
+        tags.select { |t| t.name.match(tag_regexp) && !not_match_image.include?(t.image_id) }
       end
 
       def older_than

--- a/lib/portus/background/garbage_collector.rb
+++ b/lib/portus/background/garbage_collector.rb
@@ -49,8 +49,10 @@ module Portus
         tags = Tag.where(marked: false).where("updated_at < ?", older_than)
         return tags if APP_CONFIG["delete"]["garbage_collector"]["tag"].blank?
 
-        rx = tag_regexp
-        tags.select { |t| t.name.match(rx) }
+        not_matching_tags = tags.select { |t| !t.name.match(tag_regexp) }
+        not_matching_image_id = not_matching_tags.map { |t| t.image_id }
+
+        tags.select { |t| t.name.match(tag_regexp) and not not_matching_image_id.include?(t.image_id)  }
       end
 
       def older_than


### PR DESCRIPTION
When an image_id has multiple tags, it's posible delete it, even when it should not.
Now, the garbage collector verifies if exists another tag that does not match.
For example: the image id 7602d1365872f9bf8b27bb7947f04dab91ad6cbd364457a206d1be4a4c535d32
has tags: build-646783 (to be delete) and release-34354678
build-646783 match with the regex, but release-34354678 doesn't.

Signed-off-by: Saúl Piña <sauljabin@gmail.com>
