### PR TITLE
Ldap groups

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ packaging
 log/*
 .DS_Store
 .bundle/config
+config/config-local.yml

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -11,6 +11,7 @@
 #  hidden             :boolean          default(FALSE)
 #  description        :text(65535)
 #  ldap_group_checked :integer          default(0)
+#  checked_at         :datetime
 #
 # Indexes
 #
@@ -116,7 +117,7 @@ class Team < ApplicationRecord
       add_team_member!(portus_user, member)
     end
 
-    update_attributes!(ldap_group_checked: Team.ldap_statuses[:checked])
+    update!(ldap_group_checked: Team.ldap_statuses[:checked], checked_at: Time.zone.now)
   end
 
   # If possible, add the user with the given username into the team. The

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -128,10 +128,11 @@ class Team < ApplicationRecord
 
     team_user = ::TeamUsers::BuildService.new(author, params).execute
     team_user = ::TeamUsers::CreateService.new(author, team_user).execute
-    return if team_user.valid? && team_user.persisted?
+    return true if team_user.valid? && team_user.persisted?
 
     Rails.logger.tagged(:ldap) do
       Rails.logger.warn "Could not add team member: #{team_user.errors.full_messages.join(", ")}"
     end
+    false
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -310,6 +310,7 @@ class User < ApplicationRecord
     ::Portus::LDAP::Search.new.user_groups(username).each do |group|
       t = Team.find_by(name: group)
       next if t.nil?
+      next if t.ldap_group_checked == Team.ldap_statuses[:disabled]
       next if t.users.map(&:id).include?(id)
 
       t.add_team_member!(portus_user, username)

--- a/bin/background.rb
+++ b/bin/background.rb
@@ -12,6 +12,7 @@
 #
 
 require "portus/background/garbage_collector"
+require "portus/background/ldap"
 require "portus/background/registry"
 require "portus/background/security_scanning"
 require "portus/background/sync"
@@ -20,7 +21,8 @@ they = [
   ::Portus::Background::Registry.new,
   ::Portus::Background::SecurityScanning.new,
   ::Portus::Background::Sync.new,
-  ::Portus::Background::GarbageCollector.new
+  ::Portus::Background::GarbageCollector.new,
+  ::Portus::Background::LDAP.new
 ].select(&:enabled?)
 
 values = they.map { |v| "'#{v}'" }.join(", ")

--- a/bin/test-integration.sh
+++ b/bin/test-integration.sh
@@ -148,7 +148,9 @@ for p in ${profiles[*]}; do
     status=$?
     set -e
 
-    cleanup_containers "docker-compose.$p.yml"
+    if [[ ! -z "$TEARDOWN_TESTS" ]]; then
+        cleanup_containers "docker-compose.$p.yml"
+    fi
 
     if [ $status -ne 0 ]; then
         exit $status

--- a/config/config.yml
+++ b/config/config.yml
@@ -113,6 +113,9 @@ ldap:
   # Portus administrators automatically.
   admin_base: ""
 
+  # The base where groups are located (e.g. "ou=groups,dc=example,dc=com").
+  group_base: ""
+
   # User filter (e.g. "mail=george*").
   filter: ""
 
@@ -124,6 +127,15 @@ ldap:
     enabled: false
     bind_dn: ""
     password: ""
+
+  # Automatically add team members from a matching LDAP group into each
+  # team. Note that this will not delete nor update existing team members.
+  group_sync:
+    enabled: true
+
+    # The role in which new team members will be added. Note that Portus
+    # administrators will be added as team owners regardless of this setting.
+    default_role: "viewer"
 
   # Portus needs an email for each user, but there's no standard way to get
   # that from LDAP servers. You can tell Portus how to get the email from users

--- a/config/config.yml
+++ b/config/config.yml
@@ -129,7 +129,8 @@ ldap:
     password: ""
 
   # Automatically add team members from a matching LDAP group into each
-  # team. Note that this will not delete nor update existing team members.
+  # team. Note that this will not delete nor update existing team members. Only
+  # `groupOfNames` and `groupOfUniqueNames` are supported.
   group_sync:
     enabled: true
 

--- a/db/migrate/20181224123453_add_ldap_group_checked_to_teams.rb
+++ b/db/migrate/20181224123453_add_ldap_group_checked_to_teams.rb
@@ -1,0 +1,5 @@
+class AddLdapGroupCheckedToTeams < ActiveRecord::Migration[5.2]
+  def change
+    add_column :teams, :ldap_group_checked, :int, default: Team.ldap_statuses[:unchecked]
+  end
+end

--- a/db/migrate/20190103113934_add_checked_at_to_team.rb
+++ b/db/migrate/20190103113934_add_checked_at_to_team.rb
@@ -1,0 +1,5 @@
+class AddCheckedAtToTeam < ActiveRecord::Migration[5.2]
+  def change
+    add_column :teams, :checked_at, :datetime, default: nil
+  end
+end

--- a/db/migrate/20190103124548_add_ldap_group_checked_to_user.rb
+++ b/db/migrate/20190103124548_add_ldap_group_checked_to_user.rb
@@ -1,0 +1,5 @@
+class AddLdapGroupCheckedToUser < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :ldap_group_checked, :integer, default: User.ldap_statuses[:unchecked]
+  end
+end

--- a/db/schema.mysql.rb
+++ b/db/schema.mysql.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_03_113934) do
+ActiveRecord::Schema.define(version: 2019_01_03_124548) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "trackable_id"
@@ -170,6 +170,7 @@ ActiveRecord::Schema.define(version: 2019_01_03_113934) do
     t.string "provider"
     t.string "uid"
     t.boolean "bot", default: false
+    t.integer "ldap_group_checked", default: 0
     t.index ["display_name"], name: "index_users_on_display_name", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["namespace_id"], name: "index_users_on_namespace_id"

--- a/db/schema.mysql.rb
+++ b/db/schema.mysql.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_24_123453) do
+ActiveRecord::Schema.define(version: 2019_01_03_113934) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "trackable_id"
@@ -142,6 +142,7 @@ ActiveRecord::Schema.define(version: 2018_12_24_123453) do
     t.boolean "hidden", default: false
     t.text "description"
     t.integer "ldap_group_checked", default: 0
+    t.datetime "checked_at"
     t.index ["name"], name: "index_teams_on_name", unique: true
   end
 

--- a/db/schema.mysql.rb
+++ b/db/schema.mysql.rb
@@ -10,17 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_03_124548) do
+ActiveRecord::Schema.define(version: 2019_01_09_112643) do
 
-  create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
-    t.integer "trackable_id"
+  create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "trackable_type"
-    t.integer "owner_id"
+    t.integer "trackable_id"
     t.string "owner_type"
+    t.integer "owner_id"
     t.string "key"
     t.text "parameters"
-    t.integer "recipient_id"
     t.string "recipient_type"
+    t.integer "recipient_id"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["key"], name: "index_activities_on_key"
@@ -30,7 +30,7 @@ ActiveRecord::Schema.define(version: 2019_01_03_124548) do
     t.index ["trackable_type"], name: "index_activities_on_trackable_type"
   end
 
-  create_table "application_tokens", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "application_tokens", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "application", null: false
     t.string "token_hash", null: false
     t.string "token_salt", null: false
@@ -38,7 +38,7 @@ ActiveRecord::Schema.define(version: 2019_01_03_124548) do
     t.index ["user_id"], name: "index_application_tokens_on_user_id"
   end
 
-  create_table "comments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "comments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.text "body"
     t.integer "repository_id"
     t.datetime "created_at", null: false
@@ -48,7 +48,7 @@ ActiveRecord::Schema.define(version: 2019_01_03_124548) do
     t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
-  create_table "namespaces", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "namespaces", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -62,7 +62,7 @@ ActiveRecord::Schema.define(version: 2019_01_03_124548) do
     t.index ["team_id"], name: "index_namespaces_on_team_id"
   end
 
-  create_table "registries", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "registries", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
     t.string "hostname", null: false
     t.datetime "created_at", null: false
@@ -73,7 +73,7 @@ ActiveRecord::Schema.define(version: 2019_01_03_124548) do
     t.index ["name"], name: "index_registries_on_name", unique: true
   end
 
-  create_table "registry_events", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "registry_events", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "event_id", default: ""
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -81,7 +81,7 @@ ActiveRecord::Schema.define(version: 2019_01_03_124548) do
     t.text "data"
   end
 
-  create_table "repositories", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "repositories", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", default: "", null: false
     t.integer "namespace_id"
     t.datetime "created_at", null: false
@@ -92,7 +92,7 @@ ActiveRecord::Schema.define(version: 2019_01_03_124548) do
     t.index ["namespace_id"], name: "index_repositories_on_namespace_id"
   end
 
-  create_table "scan_results", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "scan_results", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "tag_id"
     t.integer "vulnerability_id"
     t.datetime "created_at", null: false
@@ -100,7 +100,7 @@ ActiveRecord::Schema.define(version: 2019_01_03_124548) do
     t.index ["vulnerability_id", "tag_id"], name: "index_scan_results_on_vulnerability_id_and_tag_id"
   end
 
-  create_table "stars", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "stars", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id"
     t.integer "repository_id"
     t.datetime "created_at", null: false
@@ -109,7 +109,7 @@ ActiveRecord::Schema.define(version: 2019_01_03_124548) do
     t.index ["user_id"], name: "index_stars_on_user_id"
   end
 
-  create_table "tags", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "tags", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", default: "latest", null: false
     t.integer "repository_id", null: false
     t.datetime "created_at", null: false
@@ -125,7 +125,7 @@ ActiveRecord::Schema.define(version: 2019_01_03_124548) do
     t.index ["user_id"], name: "index_tags_on_user_id"
   end
 
-  create_table "team_users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "team_users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id"
     t.integer "team_id"
     t.datetime "created_at", null: false
@@ -135,7 +135,7 @@ ActiveRecord::Schema.define(version: 2019_01_03_124548) do
     t.index ["user_id"], name: "index_team_users_on_user_id"
   end
 
-  create_table "teams", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "teams", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -146,7 +146,7 @@ ActiveRecord::Schema.define(version: 2019_01_03_124548) do
     t.index ["name"], name: "index_teams_on_name", unique: true
   end
 
-  create_table "users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "username", default: "", null: false
     t.string "email", default: ""
     t.string "encrypted_password", default: "", null: false
@@ -178,7 +178,7 @@ ActiveRecord::Schema.define(version: 2019_01_03_124548) do
     t.index ["username"], name: "index_users_on_username", unique: true
   end
 
-  create_table "vulnerabilities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "vulnerabilities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
     t.string "scanner", default: "", null: false
     t.string "severity", default: "", null: false
@@ -191,7 +191,7 @@ ActiveRecord::Schema.define(version: 2019_01_03_124548) do
     t.index ["name"], name: "index_vulnerabilities_on_name", unique: true
   end
 
-  create_table "webhook_deliveries", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "webhook_deliveries", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "webhook_id"
     t.string "uuid"
     t.integer "status"
@@ -205,7 +205,7 @@ ActiveRecord::Schema.define(version: 2019_01_03_124548) do
     t.index ["webhook_id"], name: "index_webhook_deliveries_on_webhook_id"
   end
 
-  create_table "webhook_headers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "webhook_headers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "webhook_id"
     t.string "name"
     t.string "value"
@@ -215,7 +215,7 @@ ActiveRecord::Schema.define(version: 2019_01_03_124548) do
     t.index ["webhook_id"], name: "index_webhook_headers_on_webhook_id"
   end
 
-  create_table "webhooks", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "webhooks", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "namespace_id"
     t.string "url"
     t.string "username"

--- a/db/schema.mysql.rb
+++ b/db/schema.mysql.rb
@@ -10,17 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_09_112643) do
+ActiveRecord::Schema.define(version: 2018_12_24_123453) do
 
-  create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "trackable_type"
+  create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "trackable_id"
-    t.string "owner_type"
+    t.string "trackable_type"
     t.integer "owner_id"
+    t.string "owner_type"
     t.string "key"
     t.text "parameters"
-    t.string "recipient_type"
     t.integer "recipient_id"
+    t.string "recipient_type"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["key"], name: "index_activities_on_key"
@@ -30,7 +30,7 @@ ActiveRecord::Schema.define(version: 2019_01_09_112643) do
     t.index ["trackable_type"], name: "index_activities_on_trackable_type"
   end
 
-  create_table "application_tokens", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "application_tokens", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "application", null: false
     t.string "token_hash", null: false
     t.string "token_salt", null: false
@@ -38,7 +38,7 @@ ActiveRecord::Schema.define(version: 2019_01_09_112643) do
     t.index ["user_id"], name: "index_application_tokens_on_user_id"
   end
 
-  create_table "comments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "comments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.text "body"
     t.integer "repository_id"
     t.datetime "created_at", null: false
@@ -48,7 +48,7 @@ ActiveRecord::Schema.define(version: 2019_01_09_112643) do
     t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
-  create_table "namespaces", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "namespaces", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -62,7 +62,7 @@ ActiveRecord::Schema.define(version: 2019_01_09_112643) do
     t.index ["team_id"], name: "index_namespaces_on_team_id"
   end
 
-  create_table "registries", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "registries", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "hostname", null: false
     t.datetime "created_at", null: false
@@ -73,7 +73,7 @@ ActiveRecord::Schema.define(version: 2019_01_09_112643) do
     t.index ["name"], name: "index_registries_on_name", unique: true
   end
 
-  create_table "registry_events", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "registry_events", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "event_id", default: ""
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -81,7 +81,7 @@ ActiveRecord::Schema.define(version: 2019_01_09_112643) do
     t.text "data"
   end
 
-  create_table "repositories", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "repositories", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "name", default: "", null: false
     t.integer "namespace_id"
     t.datetime "created_at", null: false
@@ -92,7 +92,7 @@ ActiveRecord::Schema.define(version: 2019_01_09_112643) do
     t.index ["namespace_id"], name: "index_repositories_on_namespace_id"
   end
 
-  create_table "scan_results", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "scan_results", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "tag_id"
     t.integer "vulnerability_id"
     t.datetime "created_at", null: false
@@ -100,7 +100,7 @@ ActiveRecord::Schema.define(version: 2019_01_09_112643) do
     t.index ["vulnerability_id", "tag_id"], name: "index_scan_results_on_vulnerability_id_and_tag_id"
   end
 
-  create_table "stars", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "stars", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "repository_id"
     t.datetime "created_at", null: false
@@ -109,7 +109,7 @@ ActiveRecord::Schema.define(version: 2019_01_09_112643) do
     t.index ["user_id"], name: "index_stars_on_user_id"
   end
 
-  create_table "tags", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "tags", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "name", default: "latest", null: false
     t.integer "repository_id", null: false
     t.datetime "created_at", null: false
@@ -125,7 +125,7 @@ ActiveRecord::Schema.define(version: 2019_01_09_112643) do
     t.index ["user_id"], name: "index_tags_on_user_id"
   end
 
-  create_table "team_users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "team_users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "team_id"
     t.datetime "created_at", null: false
@@ -135,16 +135,17 @@ ActiveRecord::Schema.define(version: 2019_01_09_112643) do
     t.index ["user_id"], name: "index_team_users_on_user_id"
   end
 
-  create_table "teams", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "teams", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "hidden", default: false
     t.text "description"
+    t.integer "ldap_group_checked", default: 0
     t.index ["name"], name: "index_teams_on_name", unique: true
   end
 
-  create_table "users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "username", default: "", null: false
     t.string "email", default: ""
     t.string "encrypted_password", default: "", null: false
@@ -175,7 +176,7 @@ ActiveRecord::Schema.define(version: 2019_01_09_112643) do
     t.index ["username"], name: "index_users_on_username", unique: true
   end
 
-  create_table "vulnerabilities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "vulnerabilities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "scanner", default: "", null: false
     t.string "severity", default: "", null: false
@@ -188,7 +189,7 @@ ActiveRecord::Schema.define(version: 2019_01_09_112643) do
     t.index ["name"], name: "index_vulnerabilities_on_name", unique: true
   end
 
-  create_table "webhook_deliveries", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "webhook_deliveries", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "webhook_id"
     t.string "uuid"
     t.integer "status"
@@ -202,7 +203,7 @@ ActiveRecord::Schema.define(version: 2019_01_09_112643) do
     t.index ["webhook_id"], name: "index_webhook_deliveries_on_webhook_id"
   end
 
-  create_table "webhook_headers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "webhook_headers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "webhook_id"
     t.string "name"
     t.string "value"
@@ -212,7 +213,7 @@ ActiveRecord::Schema.define(version: 2019_01_09_112643) do
     t.index ["webhook_id"], name: "index_webhook_headers_on_webhook_id"
   end
 
-  create_table "webhooks", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "webhooks", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "namespace_id"
     t.string "url"
     t.string "username"

--- a/db/schema.postgresql.rb
+++ b/db/schema.postgresql.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_03_124548) do
+ActiveRecord::Schema.define(version: 2019_01_09_112643) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.postgresql.rb
+++ b/db/schema.postgresql.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_09_112643) do
+ActiveRecord::Schema.define(version: 2019_01_03_113934) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -144,6 +144,8 @@ ActiveRecord::Schema.define(version: 2019_01_09_112643) do
     t.datetime "updated_at", null: false
     t.boolean "hidden", default: false
     t.text "description"
+    t.integer "ldap_group_checked", default: 0
+    t.datetime "checked_at"
     t.index ["name"], name: "index_teams_on_name", unique: true
   end
 

--- a/db/schema.postgresql.rb
+++ b/db/schema.postgresql.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_03_113934) do
+ActiveRecord::Schema.define(version: 2019_01_03_124548) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -173,6 +173,7 @@ ActiveRecord::Schema.define(version: 2019_01_03_113934) do
     t.string "provider"
     t.string "uid"
     t.boolean "bot", default: false
+    t.integer "ldap_group_checked", default: 0
     t.index ["display_name"], name: "index_users_on_display_name", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["namespace_id"], name: "index_users_on_namespace_id"

--- a/examples/compose/docker-compose.ldap.yml
+++ b/examples/compose/docker-compose.ldap.yml
@@ -29,6 +29,7 @@ services:
       - PORTUS_LDAP_PORT=389
       - PORTUS_LDAP_UID=uid
       - PORTUS_LDAP_BASE=dc=example,dc=org
+      - PORTUS_LDAP_GROUP_BASE=ou=canigo,dc=example,dc=org
       - PORTUS_LDAP_FILTER=
       - PORTUS_LDAP_AUTHENTICATION_ENABLED=true
       - PORTUS_LDAP_AUTHENTICATION_BIND_DN=cn=admin,dc=example,dc=org
@@ -70,11 +71,27 @@ services:
       - PORTUS_KEY_PATH=/certificates/portus.key
       - PORTUS_PASSWORD=${PORTUS_PASSWORD}
 
+      # LDAP
+      - PORTUS_LDAP_ENABLED=true
+      - PORTUS_LDAP_HOSTNAME=ldap
+      - PORTUS_LDAP_PORT=389
+      - PORTUS_LDAP_UID=uid
+      - PORTUS_LDAP_BASE=dc=example,dc=org
+      - PORTUS_LDAP_GROUP_BASE=ou=canigo,dc=example,dc=org
+      - PORTUS_LDAP_FILTER=
+      - PORTUS_LDAP_AUTHENTICATION_ENABLED=true
+      - PORTUS_LDAP_AUTHENTICATION_BIND_DN=cn=admin,dc=example,dc=org
+      - PORTUS_LDAP_AUTHENTICATION_PASSWORD=admin
+      - PORTUS_LDAP_ENCRYPTION_METHOD=start_tls
+      - PORTUS_LDAP_ENCRYPTION_OPTIONS_CA_FILE=/ldap-certificates/ca.pem
+      - PORTUS_LDAP_ENCRYPTION_OPTIONS_SSL_VERSION=TLSv1_2
+
       - PORTUS_BACKGROUND=true
     links:
       - db
     volumes:
       - ./secrets:/certificates:ro
+      - ./secrets/ldap:/ldap-certificates:ro
 
   db:
     image: library/mariadb:10.0.23

--- a/lib/portus/background/ldap.rb
+++ b/lib/portus/background/ldap.rb
@@ -28,18 +28,8 @@ module Portus
       end
 
       def execute!
-        # Force the check for teams that have never been checked (checked_at is
-        # nil and they have not been disabled), or that they have been checked a
-        # long time ago.
-        Team.where(checked_at: nil)
-            .where.not(ldap_group_checked: Team.ldap_statuses[:disabled]).or(
-          Team.where(ldap_group_checked: Team.ldap_statuses[:checked])
-              .where("checked_at < ?", FORCE_CHECK_IN_DAYS.days.ago)
-        ).update_all(ldap_group_checked: Team.ldap_statuses[:unchecked])
-
-        # For each team to be checked, let's check LDAP groups.
-        Team.where(ldap_group_checked: Team.ldap_statuses[:unchecked])
-            .find_each(&:ldap_add_members!)
+        team_count = execute_team!
+        execute_user!(team_count)
       end
 
       # Once enabled, it cannot be disabled.
@@ -49,6 +39,55 @@ module Portus
 
       def to_s
         "LDAP synchronization"
+      end
+
+      protected
+
+      # Processes the LDAP check for teams and returns the teams that have been
+      # updated.
+      def execute_team!
+        # Disable all hidden teams that weren't disabled yet.
+        Team.where(hidden: true).where.not(ldap_group_checked: Team.ldap_statuses[:disabled])
+          .update_all(ldap_group_checked: Team.ldap_statuses[:disabled])
+
+        # Force the check for teams that have never been checked (checked_at is
+        # nil and they have not been disabled), or that they have been checked a
+        # long time ago.
+        Team.where(checked_at: nil)
+            .where.not(ldap_group_checked: Team.ldap_statuses[:disabled]).or(
+          Team.where(ldap_group_checked: Team.ldap_statuses[:checked])
+              .where("checked_at < ?", FORCE_CHECK_IN_DAYS.days.ago)
+        ).update_all(ldap_group_checked: Team.ldap_statuses[:unchecked])
+
+        # For each team to be checked, let's check LDAP groups. Notice that they
+        # both have a query which is nearly identical. This is because we need
+        # #find_each for batch processing, but this method doesn't return the
+        # rows that have been affected. So, instead, we first get the count
+        # (which should be pretty cheap), and then we do the actual batch
+        # processing.
+        count = Team.where(ldap_group_checked: Team.ldap_statuses[:unchecked]).count
+        Team.where(ldap_group_checked: Team.ldap_statuses[:unchecked])
+          .find_each(&:ldap_add_members!)
+        count
+      end
+
+      # Processes the LDAP group membership check for users. This seems
+      # redundant at first, but this serves for cases such as:
+      #   1. Teams are checked.
+      #   2. A couple of hours later, a user logs in for the first time and
+      #      gets created.
+      #   3. Instead of waiting `FORCE_CHECK_IN_DAYS` days, let's insert them
+      #      now.
+      def execute_user!(team_count)
+        # If we just updated all the available teams, then we don't have to
+        # re-check again, because all the possibilities have already been
+        # crossed.
+        if team_count == Team.all_non_special.size
+          User.not_portus.update_all(ldap_group_checked: User.ldap_statuses[:checked])
+        else
+          User.not_portus.where(ldap_group_checked: User.ldap_statuses[:unchecked])
+            .find_each(&:ldap_add_as_member!)
+        end
       end
     end
   end

--- a/lib/portus/background/ldap.rb
+++ b/lib/portus/background/ldap.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "portus/errors"
+
+module Portus
+  module Background
+    # LDAP keeps track of some tasks to be done on the background for LDAP
+    # maintenance.
+    class LDAP
+      def sleep_value
+        10
+      end
+
+      # Returns true if there's work to be done.
+      def work?
+        return false unless enabled?
+
+        # Are there teams to be checked?
+        Team.where(ldap_group_checked: Team.ldap_statuses[:unchecked]).any?
+      end
+
+      # Returns true only if LDAP is enabled.
+      def enabled?
+        APP_CONFIG.enabled?("ldap") && APP_CONFIG.enabled?("ldap.group_sync")
+      end
+
+      def execute!
+        # For each team to be checked, let's check LDAP groups.
+        Team.where(ldap_group_checked: Team.ldap_statuses[:unchecked])
+            .find_each(&:ldap_add_members!)
+      end
+
+      # Once enabled, it cannot be disabled.
+      def disable?
+        false
+      end
+
+      def to_s
+        "LDAP synchronization"
+      end
+    end
+  end
+end

--- a/lib/portus/background/ldap.rb
+++ b/lib/portus/background/ldap.rb
@@ -7,6 +7,9 @@ module Portus
     # LDAP keeps track of some tasks to be done on the background for LDAP
     # maintenance.
     class LDAP
+      # The number of days in which we should force a recheck.
+      FORCE_CHECK_IN_DAYS = 7
+
       def sleep_value
         10
       end
@@ -25,6 +28,15 @@ module Portus
       end
 
       def execute!
+        # Force the check for teams that have never been checked (checked_at is
+        # nil and they have not been disabled), or that they have been checked a
+        # long time ago.
+        Team.where(checked_at: nil)
+            .where.not(ldap_group_checked: Team.ldap_statuses[:disabled]).or(
+          Team.where(ldap_group_checked: Team.ldap_statuses[:checked])
+              .where("checked_at < ?", FORCE_CHECK_IN_DAYS.days.ago)
+        ).update_all(ldap_group_checked: Team.ldap_statuses[:unchecked])
+
         # For each team to be checked, let's check LDAP groups.
         Team.where(ldap_group_checked: Team.ldap_statuses[:unchecked])
             .find_each(&:ldap_add_members!)

--- a/lib/portus/ldap/search.rb
+++ b/lib/portus/ldap/search.rb
@@ -30,7 +30,7 @@ module Portus
 
         connection = initialized_adapter
         results = connection.search(group_search_options(name))
-        return filtered_results(results) unless results.blank?
+        return filtered_results(results) if results.present?
 
         Rails.logger.tagged(:ldap) do
           o = ldap.get_operation_result

--- a/lib/portus/ldap/search.rb
+++ b/lib/portus/ldap/search.rb
@@ -20,28 +20,41 @@ module Portus
 
       # Returns the entry matching the given user name.
       def find_user(name)
-        return if APP_CONFIG.disabled?("ldap")
+        return [] if APP_CONFIG.disabled?("ldap")
 
         configuration = ::Portus::LDAP::Configuration.new(user: { username: name })
         connection = initialized_adapter
         search_admin_or_user(connection, configuration)
+      rescue ::Net::LDAP::Error => e
+        Rails.logger.tagged(:ldap) { Rails.logger.warn "Connection error: #{e.message}" }
+        []
+      end
+
+      # Returns the entry containing the group with the given name.
+      def find_group(name)
+        return [] if APP_CONFIG.disabled?("ldap")
+
+        connection = initialized_adapter
+        options    = search_options_for(filter: "(cn=#{name})", attributes: %w[member uniqueMember])
+        results    = connection.search(options)
+        o = connection.get_operation_result
+        return results if o.code.to_i.zero?
+
+        Rails.logger.tagged(:ldap) do
+          msg = o.extended_response ? " and message '#{o.extended_response}'" : ""
+          Rails.logger.debug "LDAP group failed with code #{o.code}" + msg
+        end
+        []
+      rescue ::Net::LDAP::Error => e
+        Rails.logger.tagged(:ldap) { Rails.logger.warn "Connection error: #{e.message}" }
+        []
       end
 
       # Returns a list of usernames containing the members of the specified LDAP
       # group. If the given group was not found, then an empty array is returned.
       def find_group_and_members(name)
-        return [] if APP_CONFIG.disabled?("ldap")
-
-        connection = initialized_adapter
-        results = connection.search(group_search_options(name))
-        return filtered_results(results) if results.present?
-
-        Rails.logger.tagged(:ldap) do
-          o = ldap.get_operation_result
-          msg = o.extended_response ? " and message '#{o.extended_response}'" : ""
-          Rails.logger.info "LDAP group failed with code #{o.code}" + msg
-        end
-        []
+        results = find_group(name)
+        filtered_results(results)
       end
 
       # Returns an array with the name of the groups where this user belongs.
@@ -49,7 +62,11 @@ module Portus
         record = find_user(user)
         return [] if record&.size != 1
 
-        groups_from_unique_member(record.first.dn)
+        dn = record.first.dn
+        groups_from(dn, "uniqueMember") | groups_from(dn, "member")
+      rescue ::Net::LDAP::Error => e
+        Rails.logger.tagged(:ldap) { Rails.logger.warn "Connection error: #{e.message}" }
+        []
       end
 
       # Returns nil if the given user was not found, otherwise it returns an
@@ -65,12 +82,18 @@ module Portus
       protected
 
       # Returns a list with the name of the groups where the given dn is set as
-      # a `uniqueMember`.
-      def groups_from_unique_member(dn)
+      # a `uniqueMember`. It may raise a ::Net::LDAP::Error if the connection
+      # with the LDAP server failed for whatever reason.
+      def groups_from(dn, key)
         connection = initialized_adapter
 
-        options = search_options_for(filter: "(&(cn=*)(uniqueMember=#{dn}))", attributes: %w[cn])
+        options = search_options_for(filter: "(&(cn=*)(#{key}=#{dn}))", attributes: %w[cn])
         results = connection.search(options)
+        unless connection.get_operation_result.code.to_i.zero?
+          Rails.logger.tagged(:ldap) do
+            Rails.logger.debug "Could not find #{dn} based on '#{key}'"
+          end
+        end
         return [] if results.blank?
 
         results.map do |r|
@@ -89,21 +112,14 @@ module Portus
         end
       end
 
-      # Returns the search options for the given team name.
-      # TODO: see search_options_for
-      def group_search_options(name)
-        {}.tap do |opts|
-          group_base        = APP_CONFIG["ldap"]["group_base"]
-          opts[:base]       = group_base if group_base.present?
-          opts[:filter]     = Net::LDAP::Filter.eq("cn", name)
-          opts[:attributes] = %w[uniquemember]
-        end
-      end
-
       # Returns the given LDAP results (uniquemember) and transforms the given
       # list so it contains only the relevant information (i.e. user names).
       def filtered_results(results)
-        results.first[:uniquemember].map do |r|
+        return [] if results.blank?
+
+        members = results.first[:uniquemember]
+        members = results.first[:member] if members.blank?
+        members.map do |r|
           uid = r.split(",").first
           uid.split("=", 2).last
         end

--- a/spec/integration/README.md
+++ b/spec/integration/README.md
@@ -75,11 +75,20 @@ environment variables:
   tests have finished. This is disabled by default so you can check the logs
   after tests have finished, and to re-use these same containers on successive
   runs with the `SKIP_ENV_TESTS` environment variables.
+- `PROFILES`: there are multiple profiles that you can pick when running
+  tests. There are two profiles (by default both of them will be selected):
+  - `clair`: the tests that are inside of `spec/integration` (without
+    subdirectories).
+  - `ldap`: the tests that are inside of `spec/integration/ldap`.
 
 As an example, this is how you'd run this script if you are just interesed in
 the `spec/integration/push.bats` test:
 
     $ TESTS="push" ./bin/test-integration.sh
+
+As another example, if you want to run all the LDAP-only tests, you can perform:
+
+    $ PROFILES=ldap ./bin/test-integration.sh
 
 This script will perform the stages described above. As a final note, the first
 stage (setting up the `build` directory) is done by another script:

--- a/spec/integration/helpers/wait_event_done.rb
+++ b/spec/integration/helpers/wait_event_done.rb
@@ -1,51 +1,52 @@
 # frozen_string_literal: true
 
+require "json"
+require_relative "waiter"
+
 # This runner waits until a registry event related to the given tag (first
 # argument) is marked as done by the background process. This runner will
 # timeout if it takes just too long. Last but not least, you can pass a final
 # argument with the string "pickfirst", which will tell this runner to simply
 # pick the first registry event.
+class EventWaiter < ::Integration::Helpers::Waiter
+  def initialize(sleep_time, timeout, tag, pick_first)
+    super(sleep_time, timeout)
 
-require "json"
-
-TAG = ARGV.first.dup
-
-# Returns true
-def pick_first?
-  ARGV.last == "pickfirst"
-end
-
-# Returns the first registry event that matches the required tag, or nil if none
-# could be found.
-def first_matching_tag
-  r = Registry.get
-  return unless r
-
-  RegistryEvent.all.find_each do |event|
-    data = JSON.parse(event.data)
-    _, _, tag_name = r.get_namespace_from_event(data)
-    return event.dup if tag_name == TAG
+    @tag        = tag
+    @pick_first = pick_first
   end
 
-  nil
+  # Returns true if the event we were interested in has been processed.
+  def done?
+    re = pick_first? ? RegistryEvent.first : first_matching_tag
+    return false unless re
+
+    re.status.to_i == RegistryEvent.statuses[:done].to_i
+  end
+
+  protected
+
+  # Returns the first registry event that matches the required tag, or nil if
+  # none could be found.
+  def first_matching_tag
+    r = Registry.get
+    return unless r
+
+    RegistryEvent.all.find_each do |event|
+      data = JSON.parse(event.data)
+      _, _, tag_name = r.get_namespace_from_event(data)
+      return event.dup if tag_name == @tag
+    end
+
+    nil
+  end
+
+  # Returns true if the pickfirst argument was given.
+  def pick_first?
+    @pick_first == "pickfirst"
+  end
 end
 
-# Returns true if the event we were interested in has been processed.
-def done?
-  re = pick_first? ? RegistryEvent.first : first_matching_tag
-  return false unless re
-
-  re.status.to_i == RegistryEvent.statuses[:done].to_i
-end
-
-SLEEP_TIME = 5.seconds
-TIMEOUT    = 1.minute
-
-current = 0
-while current < TIMEOUT
-  exit 0 if done?
-  sleep SLEEP_TIME
-  current += SLEEP_TIME
-end
-
-exit 1
+waiter = EventWaiter.new(5.seconds, 5.minutes, ARGV.first.dup, ARGV.last)
+status = waiter.run!
+exit status

--- a/spec/integration/helpers/wait_ldap_check.rb
+++ b/spec/integration/helpers/wait_ldap_check.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative "waiter"
+
+# This runner waits until the LDAP background task has performed a check.
+class LDAPCheckWaiter < ::Integration::Helpers::Waiter
+  def initialize(sleep_time, timeout, resource)
+    super(sleep_time, timeout)
+
+    @resource = resource
+  end
+
+  # Returns true when the background job has already marked all rows from the
+  # given resource as checked.
+  def done?
+    const = @resource.capitalize.constantize
+
+    if @resource == "user"
+      const.not_portus.where(ldap_group_checked: const.ldap_statuses[:unchecked]).none?
+    else
+      const.where(ldap_group_checked: const.ldap_statuses[:unchecked]).none?
+    end
+  end
+end
+
+waiter = LDAPCheckWaiter.new(5.seconds, 5.minutes, ARGV.first)
+status = waiter.run!
+exit status

--- a/spec/integration/helpers/waiter.rb
+++ b/spec/integration/helpers/waiter.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# Integration is the module that encapsulates all the utilities for integration
+# tests.
+module Integration
+  # Helpers contains helper classes for integration tests.
+  module Helpers
+    # Waiter implements a simple loop with a given timeout and a sleep
+    # time. This class is meant to be subclassed and the resulting class should
+    # at least implement the `done?` method, which simply returns a boolean
+    # telling the loop whether or not we are done waiting. If `done?` returns a
+    # falsey value, then it will sleep for a given sleep time and then run
+    # `done?` again. This will be done at least until the given timeout is
+    # reached. If `done?` returns a truthy value before that, then it will
+    # return early with a success value.
+    class Waiter
+      def initialize(sleep_time, timeout)
+        @sleep_time = sleep_time
+        @timeout    = timeout
+      end
+
+      # Returns 0 if the loop was successful, and 1 otherwise. Thus, the
+      # returned value should be used as a parameter for an `exit` call. You
+      # should call this method right after instantiating a Waiter object.
+      def run!
+        current = 0
+        while current < @timeout
+          return 0 if done?
+
+          sleep @sleep_time
+          current += @sleep_time
+        end
+
+        1
+      end
+
+      def done?
+        true
+      end
+    end
+  end
+end

--- a/spec/integration/ldap/team.bats
+++ b/spec/integration/ldap/team.bats
@@ -1,0 +1,109 @@
+#!/usr/bin/env bats -t
+
+load ../helpers
+
+function setup() {
+    __setup ldap
+}
+
+@test "LDAP: groupOfUniqueNames: team members are added automatically when team gets created" {
+    helper_runner ldap.rb flordeneu fada
+    [ $status -eq 0 ]
+
+    helper_runner ldap.rb gentil tallaferro
+    [ $status -eq 0 ]
+
+    helper_runner curl.rb post /api/v1/teams flordeneu name=lopirineu
+    [ $status -eq 0 ]
+
+    helper_runner wait_ldap_check.rb team
+    [ $status -eq 0 ]
+
+    ruby_puts "Team.find_by(name:\"lopirineu\").users.map(&:username).join(\",\")"
+    [ $status -eq 0 ]
+    [[ "${lines[-1]}" =~ "flordeneu,gentil" ]]
+}
+
+@test "LDAP: groupOfUniqueNames: team members are added automatically when user logs in for the first time" {
+    helper_runner ldap.rb flordeneu fada
+    [ $status -eq 0 ]
+
+    helper_runner curl.rb post /api/v1/teams flordeneu name=lopirineu
+    [ $status -eq 0 ]
+
+    helper_runner wait_ldap_check.rb team
+    [ $status -eq 0 ]
+
+    helper_runner ldap.rb gentil tallaferro
+    [ $status -eq 0 ]
+
+    helper_runner wait_ldap_check.rb user
+    [ $status -eq 0 ]
+
+    ruby_puts "Team.find_by(name:\"lopirineu\").users.map(&:username).join(\",\")"
+    [ $status -eq 0 ]
+    [[ "${lines[-1]}" =~ "flordeneu,gentil" ]]
+}
+
+@test "LDAP: team members are not added if the team has been disabled" {
+    helper_runner ldap.rb flordeneu fada
+    [ $status -eq 0 ]
+
+    helper_runner curl.rb post /api/v1/teams flordeneu name=lopirineu
+    [ $status -eq 0 ]
+
+    helper_runner wait_ldap_check.rb team
+    [ $status -eq 0 ]
+
+    helper_runner curl.rb post /api/v1/teams/:id/ldap_check flordeneu
+    [ $status -eq 0 ]
+
+    helper_runner ldap.rb gentil tallaferro
+    [ $status -eq 0 ]
+
+    helper_runner wait_ldap_check.rb user
+    [ $status -eq 0 ]
+
+    ruby_puts "Team.find_by(name:\"lopirineu\").users.map(&:username).join(\",\")"
+    [ $status -eq 0 ]
+    [[ "${lines[-1]}" =~ "flordeneu" ]]
+}
+
+@test "LDAP: groupOfNames: team members are added automatically when team gets created" {
+    helper_runner ldap.rb flordeneu fada
+    [ $status -eq 0 ]
+
+    helper_runner ldap.rb gentil tallaferro
+    [ $status -eq 0 ]
+
+    helper_runner curl.rb post /api/v1/teams flordeneu name=arria
+    [ $status -eq 0 ]
+
+    helper_runner wait_ldap_check.rb team
+    [ $status -eq 0 ]
+
+    ruby_puts "Team.find_by(name:\"arria\").users.map(&:username).join(\",\")"
+    [ $status -eq 0 ]
+    [[ "${lines[-1]}" =~ "flordeneu,gentil" ]]
+}
+
+@test "LDAP: groupOfNames: team members are added automatically when user logs in for the first time" {
+    helper_runner ldap.rb flordeneu fada
+    [ $status -eq 0 ]
+
+    helper_runner curl.rb post /api/v1/teams flordeneu name=arria
+    [ $status -eq 0 ]
+
+    helper_runner wait_ldap_check.rb team
+    [ $status -eq 0 ]
+
+    helper_runner ldap.rb gentil tallaferro
+    [ $status -eq 0 ]
+
+    helper_runner wait_ldap_check.rb user
+    [ $status -eq 0 ]
+
+    ruby_puts "Team.find_by(name:\"arria\").users.map(&:username).join(\",\")"
+    [ $status -eq 0 ]
+    [[ "${lines[-1]}" =~ "flordeneu,gentil" ]]
+}

--- a/spec/integration/profiles/ldap.rb
+++ b/spec/integration/profiles/ldap.rb
@@ -94,3 +94,62 @@ ldap.add(
   }
 )
 handle_ldap_result!(ldap, params)
+
+##
+# Adding an organizationUnit and some users that will be placed inside of it.
+
+ldap.add(
+  dn:         "uid=flordeneu,dc=admins,dc=example,dc=org",
+  attributes: {
+    cn:           "Flordeneu",
+    givenName:    "Flordeneu",
+    sn:           "Flordeneu",
+    displayName:  "Flordeneu",
+    objectclass:  %w[top inetorgperson],
+    userPassword: Net::LDAP::Password.generate(:md5, "fada"),
+    mail:         "flordeneu@canigo.cat"
+  }
+)
+handle_ldap_result!(ldap, params)
+
+ldap.add(
+  dn:         "uid=gentil,dc=example,dc=org",
+  attributes: {
+    cn:           "Gentil",
+    givenName:    "Gentil",
+    sn:           "Gentil",
+    displayName:  "Gentil",
+    objectclass:  %w[top inetorgperson],
+    userPassword: Net::LDAP::Password.generate(:md5, "tallaferro"),
+    mail:         "gentil@canigo.cat"
+  }
+)
+handle_ldap_result!(ldap, params)
+
+ldap.add(
+  dn:         "ou=canigo,dc=example,dc=org",
+  attributes: {
+    ou:          "canigo",
+    objectclass: %w[top organizationalUnit],
+    description: "Somni d'aloja que del cel davalla"
+  }
+)
+handle_ldap_result!(ldap, params)
+
+ldap.add(
+  dn:         "cn=lopirineu,ou=canigo,dc=example,dc=org",
+  attributes: {
+    objectclass:  %w[top groupOfUniquenames],
+    uniqueMember: %w[uid=flordeneu,dc=admins,dc=example,dc=org uid=gentil,dc=example,dc=org]
+  }
+)
+handle_ldap_result!(ldap, params)
+
+ldap.add(
+  dn:         "cn=arria,ou=canigo,dc=example,dc=org",
+  attributes: {
+    objectclass: %w[top groupOfNames],
+    member:      %w[uid=gentil,dc=example,dc=org]
+  }
+)
+handle_ldap_result!(ldap, params)

--- a/spec/lib/portus/background/ldap_spec.rb
+++ b/spec/lib/portus/background/ldap_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "portus/background/ldap"
+
+describe ::Portus::Background::LDAP do
+  describe "#sleep_value" do
+    it "returns always 10" do
+      expect(subject.sleep_value).to eq 10
+    end
+  end
+
+  describe "#work?" do
+    it "returns false if LDAP is disabled" do
+      APP_CONFIG["ldap"]["enabled"] = false
+      expect(subject.work?).to be_falsey
+    end
+
+    it "returns false if there are no teams to be checked" do
+      APP_CONFIG["ldap"]["enabled"] = true
+      create(:team, ldap_group_checked: Team.ldap_statuses[:disabled])
+      create(:team, ldap_group_checked: Team.ldap_statuses[:checked])
+
+      expect(subject.work?).to be_falsey
+    end
+
+    it "returns true if LDAP is enabled and there are teams to be checked" do
+      APP_CONFIG["ldap"]["enabled"] = true
+      create(:team, ldap_group_checked: Team.ldap_statuses[:disabled])
+      create(:team, ldap_group_checked: Team.ldap_statuses[:checked])
+      create(:team, ldap_group_checked: Team.ldap_statuses[:unchecked])
+
+      expect(subject.work?).to be_truthy
+    end
+  end
+
+  describe "#execute!" do
+    it "receives the ldap_group_check! method for teams that need a check" do
+      create(:team, ldap_group_checked: Team.ldap_statuses[:disabled])
+      create(:team, ldap_group_checked: Team.ldap_statuses[:checked])
+      unchecked_team = create(:team, ldap_group_checked: Team.ldap_statuses[:unchecked])
+
+      received = []
+      allow_any_instance_of(Team).to receive(:ldap_group_check!) do |t|
+        received << t.name
+        true
+      end
+
+      subject.execute!
+      expect(received.size).to eq 1
+      expect(received.first).to eq unchecked_team.name
+    end
+  end
+
+  describe "#enabled?" do
+    it "returns true if LDAP is enabled" do
+      APP_CONFIG["ldap"]["enabled"] = true
+      expect(subject.enabled?).to be_truthy
+    end
+
+    it "returns false if LDAP is disabled" do
+      APP_CONFIG["ldap"]["enabled"] = false
+      expect(subject.enabled?).to be_falsey
+    end
+
+    it "returns false if LDAP is enabled but group_sync disabled" do
+      APP_CONFIG["ldap"]["enabled"] = true
+      APP_CONFIG["ldap"]["group_sync"]["enabled"] = false
+
+      expect(subject.enabled?).to be_falsey
+    end
+  end
+
+  describe "#disable?" do
+    it "always returns false" do
+      expect(subject.disable?).to be_falsey
+    end
+  end
+
+  describe "#to_s" do
+    it "works" do
+      expect(subject.to_s).to eq "LDAP synchronization"
+    end
+  end
+end

--- a/spec/lib/portus/background/ldap_spec.rb
+++ b/spec/lib/portus/background/ldap_spec.rb
@@ -16,12 +16,22 @@ describe ::Portus::Background::LDAP do
       expect(subject.work?).to be_falsey
     end
 
-    it "returns false if there are no teams to be checked" do
+    it "returns false if there are no teams nor users to be checked" do
+      APP_CONFIG["ldap"]["enabled"] = true
+      create(:team, ldap_group_checked: Team.ldap_statuses[:disabled])
+      create(:team, ldap_group_checked: Team.ldap_statuses[:checked])
+      User.all.update_all(ldap_group_checked: User.ldap_statuses[:checked])
+
+      expect(subject.work?).to be_falsey
+    end
+
+    it "returns true if there are no teams but there are users to be checked" do
       APP_CONFIG["ldap"]["enabled"] = true
       create(:team, ldap_group_checked: Team.ldap_statuses[:disabled])
       create(:team, ldap_group_checked: Team.ldap_statuses[:checked])
 
-      expect(subject.work?).to be_falsey
+      # Because of the onwers automatically created for the above teams.
+      expect(subject.work?).to be_truthy
     end
 
     it "returns true if LDAP is enabled and there are teams to be checked" do
@@ -38,7 +48,8 @@ describe ::Portus::Background::LDAP do
     it "receives the ldap_add_members! method for teams that need a check" do
       create(:team, name: "t1", ldap_group_checked: Team.ldap_statuses[:disabled])
       create(:team, name: "t2", ldap_group_checked: Team.ldap_statuses[:checked])
-      create(:team, name: "t3", ldap_group_checked: Team.ldap_statuses[:checked], checked_at: Time.zone.now)
+      create(:team, name: "t3", ldap_group_checked: Team.ldap_statuses[:checked],
+             checked_at: Time.zone.now)
       create(:team, name: "t4", ldap_group_checked: Team.ldap_statuses[:unchecked])
 
       received = []
@@ -48,13 +59,14 @@ describe ::Portus::Background::LDAP do
       end
 
       subject.execute!
-      expect(received.sort).to eq ["t2", "t4"]
+      expect(received.sort).to eq %w[t2 t4]
     end
 
     it "sets as unchecked the proper teams" do
       create(:team, name: "t1", ldap_group_checked: Team.ldap_statuses[:disabled])
       create(:team, name: "t2", ldap_group_checked: Team.ldap_statuses[:checked])
-      create(:team, name: "t3", ldap_group_checked: Team.ldap_statuses[:checked], checked_at: Time.zone.now)
+      create(:team, name: "t3", ldap_group_checked: Team.ldap_statuses[:checked],
+             checked_at: Time.zone.now)
       create(:team, name: "t4", ldap_group_checked: Team.ldap_statuses[:unchecked])
 
       received = []
@@ -103,7 +115,7 @@ describe ::Portus::Background::LDAP do
     it "does not check users that existed when all teams were checked" do
       # The team factory already creates a user which acts as an owner. This is
       # the user being checked.
-      t = create(:team, ldap_group_checked: Team.ldap_statuses[:unchecked])
+      create(:team, ldap_group_checked: Team.ldap_statuses[:unchecked])
 
       received = []
       allow_any_instance_of(User).to receive(:ldap_add_as_member!) do |u|

--- a/spec/lib/portus/ldap/search_spec.rb
+++ b/spec/lib/portus/ldap/search_spec.rb
@@ -22,4 +22,31 @@ describe ::Portus::LDAP::Search do
       expect(described_class.new.with_error_message("name")).not_to be_nil
     end
   end
+
+  context "#find_group_and_members" do
+    it "returns an empty array if LDAP is disabled" do
+      APP_CONFIG["ldap"]["enabled"] = false
+
+      expect(described_class.new.find_group_and_members("name")).to be_empty
+    end
+
+    it "returns an empty array if calling #search returned an empty value" do
+      APP_CONFIG["ldap"]["enabled"] = true
+      allow_any_instance_of(Net::LDAP).to receive(:search).and_return([])
+
+      expect(described_class.new.find_group_and_members("name")).to be_empty
+    end
+
+    it "returns the results as expected" do
+      APP_CONFIG["ldap"]["enabled"] = true
+      allow_any_instance_of(Net::LDAP).to(
+        receive(:search).and_return(
+          [{ uniquemember: ["uid=another,dc=example,dc=org", "uid=user,dc=example,dc=org"] }]
+        )
+      )
+
+      results = described_class.new.find_group_and_members("name")
+      expect(results.sort).to eq ["another", "user"]
+    end
+  end
 end

--- a/spec/lib/portus/ldap/search_spec.rb
+++ b/spec/lib/portus/ldap/search_spec.rb
@@ -46,7 +46,7 @@ describe ::Portus::LDAP::Search do
       )
 
       results = described_class.new.find_group_and_members("name")
-      expect(results.sort).to eq ["another", "user"]
+      expect(results.sort).to eq %w[another user]
     end
   end
 end

--- a/spec/lib/portus/ldap/search_spec.rb
+++ b/spec/lib/portus/ldap/search_spec.rb
@@ -1,40 +1,119 @@
 # frozen_string_literal: true
 
 describe ::Portus::LDAP::Search do
-  context "#with_error_message" do
+  let(:success) { OpenStruct.new(code: 0) }
+  let(:failure) { OpenStruct.new(code: 1) }
+
+  describe "#with_error_message" do
     it "returns nil if LDAP is disabled" do
       APP_CONFIG["ldap"]["enabled"] = false
 
-      expect(described_class.new.with_error_message("name")).to be_nil
+      expect(subject.with_error_message("name")).to be_nil
     end
 
     it "returns nil if the name doesn't exist" do
       allow_any_instance_of(described_class).to receive(:search_admin_or_user).and_return([])
       APP_CONFIG["ldap"]["enabled"] = true
 
-      expect(described_class.new.with_error_message("name")).to be_nil
+      expect(subject.with_error_message("name")).to be_nil
     end
 
     it "returns the message if the user exist" do
       allow_any_instance_of(described_class).to receive(:search_admin_or_user).and_return([1])
       APP_CONFIG["ldap"]["enabled"] = true
 
-      expect(described_class.new.with_error_message("name")).not_to be_nil
+      expect(subject.with_error_message("name")).not_to be_nil
     end
   end
 
-  context "#find_group_and_members" do
+  describe "#find_user" do
     it "returns an empty array if LDAP is disabled" do
       APP_CONFIG["ldap"]["enabled"] = false
 
-      expect(described_class.new.find_group_and_members("name")).to be_empty
+      expect(subject.find_user("name")).to be_empty
     end
 
     it "returns an empty array if calling #search returned an empty value" do
       APP_CONFIG["ldap"]["enabled"] = true
       allow_any_instance_of(Net::LDAP).to receive(:search).and_return([])
+      allow_any_instance_of(Net::LDAP).to receive(:get_operation_result).and_return(success)
 
-      expect(described_class.new.find_group_and_members("name")).to be_empty
+      expect(subject.find_user("name")).to be_empty
+    end
+
+    it "returns an empty array if calling #search raised an LDAP::Error" do
+      APP_CONFIG["ldap"]["enabled"] = true
+      allow_any_instance_of(Net::LDAP).to receive(:search) do
+        raise ::Net::LDAP::Error.new, "error"
+      end
+
+      expect(subject.find_user("name")).to be_empty
+    end
+  end
+
+  describe "#exists?" do
+    it "returns false if LDAP is disabled" do
+      APP_CONFIG["ldap"]["enabled"] = false
+
+      expect(subject.exists?("name")).to be_falsey
+    end
+
+    it "returns false if calling #search returned an empty value" do
+      APP_CONFIG["ldap"]["enabled"] = true
+      allow_any_instance_of(Net::LDAP).to receive(:search).and_return([])
+      allow_any_instance_of(Net::LDAP).to receive(:get_operation_result).and_return(success)
+
+      expect(subject.exists?("name")).to be_falsey
+    end
+
+    it "returns false if calling #search raised an LDAP::Error" do
+      APP_CONFIG["ldap"]["enabled"] = true
+      allow_any_instance_of(Net::LDAP).to receive(:search) do
+        raise ::Net::LDAP::Error.new, "error"
+      end
+
+      expect(subject.exists?("name")).to be_falsey
+    end
+
+    it "returns true if everything went as expected" do
+      APP_CONFIG["ldap"]["enabled"] = true
+      allow_any_instance_of(Net::LDAP).to(receive(:search).and_return(["somepropercn"]))
+      allow_any_instance_of(Net::LDAP).to receive(:get_operation_result).and_return(success)
+
+      expect(subject.exists?("name")).to be_truthy
+    end
+  end
+
+  describe "#find_group_and_members" do
+    it "returns an empty array if LDAP is disabled" do
+      APP_CONFIG["ldap"]["enabled"] = false
+
+      expect(subject.find_group_and_members("name")).to be_empty
+    end
+
+    it "returns an empty array if calling #search returned an empty value" do
+      APP_CONFIG["ldap"]["enabled"] = true
+      allow_any_instance_of(Net::LDAP).to receive(:search).and_return([])
+      allow_any_instance_of(Net::LDAP).to receive(:get_operation_result).and_return(success)
+
+      expect(subject.find_group_and_members("name")).to be_empty
+    end
+
+    it "returns an empty array if calling #search had a non-zero error" do
+      APP_CONFIG["ldap"]["enabled"] = true
+      allow_any_instance_of(Net::LDAP).to receive(:search).and_return([])
+      allow_any_instance_of(Net::LDAP).to receive(:get_operation_result).and_return(failure)
+
+      expect(subject.find_group_and_members("name")).to be_empty
+    end
+
+    it "returns an empty array if calling #search raised an LDAP::Error" do
+      APP_CONFIG["ldap"]["enabled"] = true
+      allow_any_instance_of(Net::LDAP).to receive(:search) do
+        raise ::Net::LDAP::Error.new, "error"
+      end
+
+      expect(subject.find_group_and_members("name")).to be_empty
     end
 
     it "returns the results as expected" do
@@ -44,8 +123,9 @@ describe ::Portus::LDAP::Search do
           [{ uniquemember: ["uid=another,dc=example,dc=org", "uid=user,dc=example,dc=org"] }]
         )
       )
+      allow_any_instance_of(Net::LDAP).to receive(:get_operation_result).and_return(success)
 
-      results = described_class.new.find_group_and_members("name")
+      results = subject.find_group_and_members("name")
       expect(results.sort).to eq %w[another user]
     end
   end
@@ -60,6 +140,7 @@ describe ::Portus::LDAP::Search do
 
     it "returns an empty array if the user could not be found" do
       allow_any_instance_of(::Portus::LDAP::Search).to receive(:find_user).and_return([])
+      allow_any_instance_of(Net::LDAP).to receive(:get_operation_result).and_return(success)
 
       expect(subject.user_groups("whatever")).to be_empty
     end
@@ -67,6 +148,25 @@ describe ::Portus::LDAP::Search do
     it "returns an empty array if no groups were found" do
       allow_any_instance_of(::Portus::LDAP::Search).to receive(:find_user).and_return(user_entries)
       allow_any_instance_of(Net::LDAP).to receive(:search).and_return([])
+      allow_any_instance_of(Net::LDAP).to receive(:get_operation_result).and_return(success)
+
+      expect(subject.user_groups("user")).to be_empty
+    end
+
+    it "returns an empty array if calling #search raised an LDAP::Error" do
+      APP_CONFIG["ldap"]["enabled"] = true
+      allow_any_instance_of(::Portus::LDAP::Search).to receive(:find_user) do
+        raise ::Net::LDAP::Error.new, "error"
+      end
+
+      expect(subject.user_groups("user")).to be_empty
+    end
+
+    it "returns an empty array if calling #search on #groups_from returned an error" do
+      APP_CONFIG["ldap"]["enabled"] = true
+      allow_any_instance_of(::Portus::LDAP::Search).to receive(:find_user).and_return(user_entries)
+      allow_any_instance_of(Net::LDAP).to receive(:search).and_return([])
+      allow_any_instance_of(Net::LDAP).to receive(:get_operation_result).and_return(failure)
 
       expect(subject.user_groups("user")).to be_empty
     end
@@ -74,6 +174,7 @@ describe ::Portus::LDAP::Search do
     it "returns a list of groups" do
       allow_any_instance_of(::Portus::LDAP::Search).to receive(:find_user).and_return(user_entries)
       allow_any_instance_of(Net::LDAP).to receive(:search).and_return(group_entries)
+      allow_any_instance_of(Net::LDAP).to receive(:get_operation_result).and_return(success)
 
       expect(subject.user_groups("user")).to eq ["team1"]
     end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -11,6 +11,7 @@
 #  hidden             :boolean          default(FALSE)
 #  description        :text(65535)
 #  ldap_group_checked :integer          default(0)
+#  checked_at         :datetime
 #
 # Indexes
 #
@@ -75,11 +76,13 @@ describe Team do
       )
       t = create(:team, owners: [create(:user, username: "user")])
 
+      expect(t.checked_at).to be_nil
       expect { t.ldap_add_members! }.to(
         change { t.ldap_group_checked }
           .from(Team.ldap_statuses[:unchecked])
           .to(Team.ldap_statuses[:checked])
       )
+      expect(t.checked_at).not_to be_nil
     end
 
     it "skips users that already exist" do
@@ -122,7 +125,7 @@ describe Team do
 
       t.ldap_add_members!
       t = t.reload
-      expect(t.owners.map(&:username).sort).to eq ["admin", "user"]
+      expect(t.owners.map(&:username).sort).to eq %w[admin user]
     end
   end
 

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -4,12 +4,13 @@
 #
 # Table name: teams
 #
-#  id          :integer          not null, primary key
-#  name        :string(255)
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  hidden      :boolean          default(FALSE)
-#  description :text(65535)
+#  id                 :integer          not null, primary key
+#  name               :string(255)
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  hidden             :boolean          default(FALSE)
+#  description        :text(65535)
+#  ldap_group_checked :integer          default(0)
 #
 # Indexes
 #
@@ -64,6 +65,78 @@ describe Team do
 
       create(:team, name: "#{name}0")
       expect(described_class.make_valid(name)).to eq "#{name}1"
+    end
+  end
+
+  describe "#ldap_add_members!" do
+    it "marks the team as checked" do
+      allow_any_instance_of(::Portus::LDAP::Search).to(
+        receive(:find_group_and_members).and_return(["user"])
+      )
+      t = create(:team, owners: [create(:user, username: "user")])
+
+      expect { t.ldap_add_members! }.to(
+        change { t.ldap_group_checked }
+          .from(Team.ldap_statuses[:unchecked])
+          .to(Team.ldap_statuses[:checked])
+      )
+    end
+
+    it "skips users that already exist" do
+      allow_any_instance_of(::Portus::LDAP::Search).to(
+        receive(:find_group_and_members).and_return(["user"])
+      )
+      t = create(:team, owners: [create(:user, username: "user")])
+
+      t.ldap_add_members!
+      expect(t).not_to receive(:add_team_member!)
+    end
+
+    it "skips users which are not available on the DB" do
+      allow_any_instance_of(::Portus::LDAP::Search).to(
+        receive(:find_group_and_members).and_return(["another"])
+      )
+      t = create(:team, owners: [create(:user, username: "user")])
+
+      t.ldap_add_members!
+      expect(t).not_to receive(:add_team_member!)
+    end
+
+    it "adds a regular user with the default given role" do
+      allow_any_instance_of(::Portus::LDAP::Search).to(
+        receive(:find_group_and_members).and_return(["user"])
+      )
+      create(:user, username: "user")
+      t = create(:team, owners: [create(:user, username: "admin")])
+
+      t.ldap_add_members!
+      expect(t.viewers.map(&:username)).to eq ["user"]
+    end
+
+    it "adds an admin user as owner" do
+      allow_any_instance_of(::Portus::LDAP::Search).to(
+        receive(:find_group_and_members).and_return(["user"])
+      )
+      create(:admin, username: "user")
+      t = create(:team, owners: [create(:user, username: "admin")])
+
+      t.ldap_add_members!
+      t = t.reload
+      expect(t.owners.map(&:username).sort).to eq ["admin", "user"]
+    end
+  end
+
+  describe "#add_team_member!" do
+    it "does not add a user if there's something wrong about it" do
+      t = create(:team, owners: [create(:user, username: "admin")])
+
+      expect(Rails.logger).to(
+        receive(:warn).with("Could not add team member: User has already been taken")
+      )
+
+      t.add_team_member!(User.portus, "admin")
+      t = t.reload
+      expect(t.owners.map(&:username).sort).to eq ["admin"]
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -123,6 +123,10 @@ RSpec.configure do |config|
       "base_admin"     => "",
       "filter"         => "",
       "uid"            => "uid",
+      "group_sync"     => {
+        "enabled"      => true,
+        "default_role" => "viewer"
+      },
       "authentication" => {
         "enabled"  => false,
         "bind_dn"  => "",


### PR DESCRIPTION
### Description

This PR adds LDAP group support into Portus. After all the discussion from #734, I decided to keep it simple, and instead of being a full blown sync job, I've created a background job that acts as a helper: it will add as team members known Portus users that belong to an LDAP group which matches a given team (this situation being because either a new team was created, or because a user logged in for the first time).

Keeping this simple allows us to have something that is useful for most users, and that doesn't have to go over the myriad of corner cases that might spawn from a full sync (we have already suffered a lot from the registry sync job, for example, and that's supposed to be way easier...).

LDAP group support can be disabled in two ways:

1. Config option: there's the new `ldap.group_sync` option (calling it `sync` might be confusing, but no better name occurred to me... Better names are welcome :smile:), which can be disabled. Notice that this option only makes sense if LDAP is enabled (if LDAP is disabled, then this feature is disabled too).
2. For specific teams: a team can be marked as `disabled` when it comes to the LDAP check through an API endpoint (see the `To do` for more info...). The background job will ignore teams which are marked as disabled.

Fixes #734 

### To do

I've implemented an API endpoint to explicitly disable a team from this LDAP check, but the UI is missing (mainly because I'm not sure where to put it and I'm sure @vitoravelino will do it in half the time I would :sweat_smile:)

### Future

There's plenty of stuff that could be done. For example:

- Take advantage of the `memberOf` property.
- Create a utility allowing to mass import users & teams, and provide with it an interface in which administrators can perform LDAP look-ups.
- Implement `posixGroup` support?
