### PR TITLE
packaging: pull gcc-c++ as a build require

### DIFF
--- a/packaging/suse/portus.spec.in
+++ b/packaging/suse/portus.spec.in
@@ -58,6 +58,7 @@ Requires:       portusctl
 BuildRequires: systemd-rpm-macros
 %endif
 BuildRequires:  fdupes
+BuildRequires:  gcc-c++
 BuildRequires:  ruby-macros >= 5
 %{?systemd_requires}
 Provides:       Portus = %{version}


### PR DESCRIPTION
This is needed by the sassc gem.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>