### PR TITLE
packaging: fixed wrong link on public_activity

### DIFF
--- a/packaging/suse/portus.spec.in
+++ b/packaging/suse/portus.spec.in
@@ -158,6 +158,7 @@ echo "__COMMIT__" >> .gitcommit
 # Remove unneeded directories/files
 rm -rf \
    vendor/cache \
+   vendor/bundle/ruby/%{rb_ver}/gems/public_activity-1.6.3/test \
    node_modules \
    public/assets/application-*.js* \
    vendor/assets \


### PR DESCRIPTION
Apparently there is a soft link on a test of public_activity, and OBS
build doesn't quite like them. So, this commit simply nukes the `test`
directory of this gem (which is, for our purposes, is never really
needed).

This has already been tried on OBS directly and it worked.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>