### PR TITLE
ci: don't build the dev image on master

### DIFF
--- a/bin/test-integration.sh
+++ b/bin/test-integration.sh
@@ -103,12 +103,16 @@ run_tests() {
 ##
 # Setup environment
 
+# Build the image if needed.
+if [[ -z "$PORTUS_INTEGRATION_BUILD_IMAGE" ]]; then
+    pushd $ROOT_DIR
+    docker rmi -f opensuse/portus:development
+    docker build -t opensuse/portus:development .
+    popd
+fi
+
 # We build the development image only once.
 export PORTUS_INTEGRATION_BUILD_IMAGE=false
-pushd $ROOT_DIR
-docker rmi -f opensuse/portus:development
-docker build -t opensuse/portus:development .
-popd
 
 # Integration tests will play with the following images
 export DEVEL_NAME="busybox"

--- a/lib/tasks/test/integration.rake
+++ b/lib/tasks/test/integration.rake
@@ -42,8 +42,10 @@ namespace :test do
       str = env.map { |k, v| "#{k}##{v}" }.join(" ")
       puts "[integration] Environment string: #{str}"
 
-      # Don't build the image multiple times on Travis.
-      ENV["PORTUS_INTEGRATION_BUILD_IMAGE"] = "false" if ENV["CI"].present?
+      # Don't build the image for Travis on master.
+      if ENV["CI"].present? && ENV["TRAVIS_PULL_REQUEST"] == "false"
+        ENV["PORTUS_INTEGRATION_BUILD_IMAGE"] = "false"
+      end
 
       ENV["PORTUS_TEST_INTEGRATION"] = str if str.present?
       ENV["TEARDOWN_TESTS"] = "true"


### PR DESCRIPTION
This is a small optimization targeted towards Travis CI on the master
branch. Before this commit, it always built the development image, and
this is not required on this branch.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>