### PR TITLE
config: improved garbage collector options

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -74,6 +74,24 @@ class Repository < ApplicationRecord
     destroyed
   end
 
+  # Handle a pull event from the registry.
+  def self.handle_pull_event(event)
+    registry = Registry.find_from_event(event)
+    return if registry.nil?
+
+    namespace, repo_name, tag_name = registry.get_namespace_from_event(event)
+    return if namespace.nil?
+
+    repository = namespace.repositories.find_by(name: repo_name)
+    return if repository.nil?
+
+    tag = repository.tags.find_by(name: tag_name)
+    return if tag.nil?
+
+    tag.update_columns(pulled_at: Time.current)
+    tag
+  end
+
   # Handle a push event from the registry.
   def self.handle_push_event(event)
     registry = Registry.find_from_event(event)

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -16,6 +16,7 @@
 #  username      :string(255)
 #  scanned       :integer          default(0)
 #  size          :integer
+#  pulled_at     :datetime
 #
 # Indexes
 #

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -87,6 +87,9 @@ class Webhook < ApplicationRecord
     hydra.run
   end
 
+  # Pull event is not handled on Webhook yet.
+  def self.handle_pull_event(event); end
+
   # Handle a delete event from the registry. All enabled webhooks of the provided
   # namespace are triggered in parallel.
   def self.handle_delete_event(event)

--- a/config/config.yml
+++ b/config/config.yml
@@ -63,9 +63,16 @@ delete:
   garbage_collector:
     enabled: false
 
-    # Remove images older than a specific value. This value is interpreted as
-    # the number of days.
+    # Remove images not pulled and older than a specific value. This value is
+    # interpreted as the number of days.
+    #
+    # e.g.: If an image wasn't pulled in the latest 30 days and the image wasn't
+    # updated somehow in the latest 30 days, the image will be deleted.
     older_than: 30
+
+    # Keep the latest X images regardless if it's older than the value set in
+    # `older_than` configuration.
+    keep_latest: 5
 
     # Provide a string containing a regular expression. If you provide a
     # valid regular expression, garbage collector will only be applied into tags

--- a/db/migrate/20190115133935_add_pulled_at_to_tags.rb
+++ b/db/migrate/20190115133935_add_pulled_at_to_tags.rb
@@ -1,0 +1,5 @@
+class AddPulledAtToTags < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tags, :pulled_at, :datetime, default: nil
+  end
+end

--- a/db/schema.mysql.rb
+++ b/db/schema.mysql.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_09_112643) do
+ActiveRecord::Schema.define(version: 2019_01_15_133935) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "trackable_type"
@@ -121,6 +121,7 @@ ActiveRecord::Schema.define(version: 2019_01_09_112643) do
     t.string "username"
     t.integer "scanned", default: 0
     t.integer "size"
+    t.datetime "pulled_at"
     t.index ["repository_id"], name: "index_tags_on_repository_id"
     t.index ["user_id"], name: "index_tags_on_user_id"
   end

--- a/db/schema.postgresql.rb
+++ b/db/schema.postgresql.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_09_112643) do
+ActiveRecord::Schema.define(version: 2019_01_15_133935) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -124,6 +124,7 @@ ActiveRecord::Schema.define(version: 2019_01_09_112643) do
     t.string "username"
     t.integer "scanned", default: 0
     t.integer "size"
+    t.datetime "pulled_at"
     t.index ["repository_id"], name: "index_tags_on_repository_id"
     t.index ["user_id"], name: "index_tags_on_user_id"
   end

--- a/lib/portus/registry_notification.rb
+++ b/lib/portus/registry_notification.rb
@@ -5,7 +5,7 @@ module Portus
   # consumed later on.
   class RegistryNotification
     # An array with the events that a handler has to support.
-    HANDLED_EVENTS = %w[push delete].freeze
+    HANDLED_EVENTS = %w[push delete pull].freeze
 
     # It filters the event from the registry so the background job can actually
     # handle this request.

--- a/spec/lib/portus/registry_notification_spec.rb
+++ b/spec/lib/portus/registry_notification_spec.rb
@@ -7,15 +7,16 @@ describe Portus::RegistryNotification do
   let(:relevant)  { ::Portus::Fixtures::RegistryEvent::RELEVANT.dup }
   let(:delete)    { ::Portus::Fixtures::RegistryEvent::DELETE.dup }
   let(:version23) { ::Portus::Fixtures::RegistryEvent::VERSION23.dup }
+  let(:pull)      { ::Portus::Fixtures::RegistryEvent::PULL.dup }
 
   it "processes all the relevant events" do
-    evaluated_events = [relevant, delete, version23]
+    evaluated_events = [relevant, delete, version23, pull]
     evaluated_events.each { |e| body["events"] << e }
 
     described_class.process!(body)
 
     events = RegistryEvent.order(:event_id)
-    expect(events.size).to eq 3
+    expect(events.size).to eq 4
     events.each_with_index do |e, idx|
       data = JSON.parse(e.data)
 

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -16,6 +16,7 @@
 #  username      :string(255)
 #  scanned       :integer          default(0)
 #  size          :integer
+#  pulled_at     :datetime
 #
 # Indexes
 #

--- a/spec/support/registry_events.rb
+++ b/spec/support/registry_events.rb
@@ -12,11 +12,34 @@ module Portus
             { "action" => "push" },
             { "action" => "push", "target" => { "mediaType" => "some" } },
             {
-              "action" => "pull", "target" => {
-                "mediaType" => "application/vnd.docker.distribution.manifest.v1+json"
+              "action" => "irrelevant",
+              "target" => {
+                "mediaType" => "application/vnd.docker.distribution.manifest.v2+json"
               }
             }
           ]
+        }.freeze
+
+      PULL =
+        {
+          "id"        => "847f45bb-5f19-4c1b-b198-6c5ba467c127",
+          "timestamp" => "2019-01-15T20:17:10.595087128Z",
+          "action"    => "pull",
+          "target"    => {
+            "mediaType"  => "application/vnd.docker.distribution.manifest.v2+json",
+            "size"       => 2193,
+            "digest"     => "sha256:095ca87493f6a2147b8543a669f2d773097df9be7e17a981033c",
+            "length"     => 2193,
+            "repository" => "vitoravelino/etcd",
+            "tag"        => "v3.2.25-arm64"
+          },
+          "actor"     => {
+            "name" => "vitoravelino"
+          },
+          "source"    => {
+            "addr"       => "50549da63cc2:5000",
+            "instanceID" => "a481f8c8-a71c-4395-b90c-f8d32a083d02"
+          }
         }.freeze
 
       RELEVANT =


### PR DESCRIPTION
So far the garbage collector only had one simple option that was to
delete images older than X days.

In this patch we are introducing a new option and a new behavior. User
will now be able to keep the latest N images through `keep_latest`
option. And the images won't be deleted even if older than X days if
they were pulled in the latest X days.

Signed-off-by: Vítor Avelino <vavelino@suse.com>