### PR TITLE
ldap: improved logger messages

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -3,4 +3,4 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+Rails.application.config.filter_parameters += %i[password reset_password_token authenticity_token]

--- a/spec/lib/portus/ldap/authenticatable_spec.rb
+++ b/spec/lib/portus/ldap/authenticatable_spec.rb
@@ -672,5 +672,12 @@ describe ::Portus::LDAP::Authenticatable do
       allow_any_instance_of(Net::LDAP).to receive(:search).and_return(multiple_emails)
       assert_guess_email(params, "user1@example.com", "email")
     end
+
+    it "returns a nil email if search raises an error" do
+      allow_any_instance_of(Net::LDAP).to receive(:search) do
+        raise ::Net::LDAP::Error, "I AM ERROR"
+      end
+      assert_guess_email(params, nil)
+    end
   end
 end


### PR DESCRIPTION
After some review, only the login.rb file had poor debug messages.
Moreover, the `guess_email` method was also missing a needed rescue that
would, for example, make Portus crash for connection issues.

Furthermore, I've also added some more parameters to filter when
logging.

Fixes #1988

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>