### PR TITLE
fixed deletion for registry 2.7

### DIFF
--- a/app/policies/namespace_policy.rb
+++ b/app/policies/namespace_policy.rb
@@ -65,6 +65,8 @@ class NamespacePolicy
     delete_enabled? && (@user.admin? || owner? || can_contributor_delete)
   end
 
+  alias delete? destroy?
+
   def update?
     raise Pundit::NotAuthorizedError, "must be logged in" unless user
 


### PR DESCRIPTION
The latest release of docker registry changed the way of interacting
with the jwt issuer and now requires the explicit "delete" permission
instead if "*" permission.

We've just added the proper method to namespace policy and allowed the
request to passthrough with that.

Signed-off-by: Vítor Avelino <vavelino@suse.com>