### PR TITLE
ui: improved sidebar highlight

### DIFF
--- a/app/assets/stylesheets/components/layout.scss
+++ b/app/assets/stylesheets/components/layout.scss
@@ -94,41 +94,49 @@ body:not([class*="login"]) {
   .container-fluid aside {
     ul {
       li:nth-child(8n+1) {
+        &.active a,
         a:hover {
           border-left: 5px solid $light-blue;
         }
       }
       li:nth-child(8n+2) {
+        &.active a,
         a:hover {
           border-left: 5px solid $yellow;
         }
       }
       li:nth-child(8n+3) {
+        &.active a,
         a:hover {
           border-left: 5px solid $dark-green;
         }
       }
       li:nth-child(8n+4) {
+        &.active a,
         a:hover {
           border-left: 5px solid $pink;
         }
       }
       li:nth-child(8n+5) {
+        &.active a,
         a:hover {
           border-left: 5px solid $blue;
         }
       }
       li:nth-child(8n+6) {
+        &.active a,
         a:hover {
           border-left: 5px solid $orange;
         }
       }
       li:nth-child(8n+7) {
+        &.active a,
         a:hover {
           border-left: 5px solid $green;
         }
       }
       li:nth-child(8n+8) {
+        &.active a,
         a:hover {
           border-left: 5px solid $purple;
         }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -65,6 +65,17 @@ module ApplicationHelper
     APP_CONFIG["pagination"]["before_after"]
   end
 
+  # Returns `active` string if current path includes the passed parameter
+  # or if paremeter is `true`.
+  def active_page?(path_or_bool)
+    case path_or_bool
+    when String
+      "active" if request.fullpath.include?(path_or_bool)
+    when TrueClass
+      "active"
+    end
+  end
+
   # Render markdown to safe HTML.
   # Images, unsafe link protocols and styles are not allowed to render.
   # HTML-Tags will be filtered.

--- a/app/views/shared/_aside.html.slim
+++ b/app/views/shared/_aside.html.slim
@@ -1,45 +1,38 @@
 aside
   ul
-    li.active
+    li class="#{active_page?(current_page?(root_path))}"
       = link_to root_path
         i[class="fa fa-dashboard"]
         | Dashboard
-      - if current_page?(url_for root_path) || current_page?(root_path)
-        .list-selected
-    li.active
+      .list-selected
+    li class="#{active_page?(namespaces_path)}"
       = link_to namespaces_path
         i[class="fa fa-ship"]
         | Namespaces
-      - if current_page?(url_for namespaces_path)
-        .list-selected
-    li.active
+      .list-selected
+    li class="#{active_page?(repositories_path)}"
       = link_to repositories_path
         i[class="fa fa-archive"]
         | Repositories
-      - if current_page?(url_for repositories_path)
-        .list-selected
-    li.active
+      .list-selected
+    li class="#{active_page?(teams_path)}"
       = link_to teams_path
         i[class="fa fa-users"]
         | Teams
-      - if current_page?(url_for teams_path)
-        .list-selected
+      .list-selected
     - if current_user.admin?
-      li.active
+      li class="#{active_page?(admin_users_path)}"
         = link_to admin_users_path
           i[class="fa fa-user"]
           | Users
-        - if current_page?(url_for controller: 'admin/users', action: 'index')
-          .list-selected
-      li.active
+        .list-selected
+      li class="#{active_page?(admin_registries_path)}"
         = link_to admin_registries_path
           i[class="fa fa-server"]
           | Registries
-        - if current_page?(url_for controller: 'admin/registries', action: 'index')
-          .list-selected
-    li.active
+        .list-selected
+    li class="#{active_page?(help_index_path)}"
       = link_to help_index_path
         i[class="fa fa-life-ring"]
         | Help
-      - if current_page?(url_for help_index_path)
-        .list-selected
+      .list-selected

--- a/vendor/assets/stylesheets/lifeitup/layout.scss
+++ b/vendor/assets/stylesheets/lifeitup/layout.scss
@@ -130,57 +130,20 @@ body:not([class*="login"]) {
             }
           }
         }
-        li:nth-child(8n+1) {
-          a:hover {
-            border-left: 5px solid $light-blue;
-          }
-        }
-        li:nth-child(8n+2) {
-          a:hover {
-            border-left: 5px solid $blue;
-          }
-        }
-        li:nth-child(8n+3) {
-          a:hover {
-            border-left: 5px solid $dark-green;
-          }
-        }
-        li:nth-child(8n+4) {
-          a:hover {
-            border-left: 5px solid $green;
-          }
-        }
-        li:nth-child(8n+5) {
-          a:hover {
-            border-left: 5px solid $yellow;
-          }
-        }
-        li:nth-child(8n+6) {
-          a:hover {
-            border-left: 5px solid $orange;
-          }
-        }
-        li:nth-child(8n+7) {
-          a:hover {
-            border-left: 5px solid $pink;
-          }
-        }
-        li:nth-child(8n+8) {
-          a:hover {
-            border-left: 5px solid $purple;
-          }
-        }
       }
+
+      li.active a,
+      a:hover {
+        background: darken($aside,10%);
+        text-decoration: none;
+      }
+
       a {
         color: $link-aside;
         background: $aside;
         display: block;
         padding: 25px 15px;
         border-left: 5px solid $aside;
-        &:hover {
-          background: darken($aside,10%);
-          text-decoration: none;
-        }
       }
     }
     section {


### PR DESCRIPTION
Previously the highlight was only happening when hovering and when the
`#index` pages where selected. When the user selected a page or were
navigating in a sub-page (e.g. /repositories/1), the highlight
disappeared.

With this patch we are enforcing the highlight in every single page the
user visits. This will give more context for the user.

Signed-off-by: Vítor Avelino <vavelino@suse.com>

Fixes #2114 

![screenshot-20190121171354-546x650](https://user-images.githubusercontent.com/188554/51496854-02c5c880-1da0-11e9-8c2b-d969a5c14d90.png)
![screenshot-20190121171404-477x538](https://user-images.githubusercontent.com/188554/51496855-035e5f00-1da0-11e9-8578-42bb38c752cc.png)
![screenshot-20190121171411-424x550](https://user-images.githubusercontent.com/188554/51496856-035e5f00-1da0-11e9-9d5a-4508663ed29e.png)
