### PR TITLE
specs: fixed failures after wording

### DIFF
--- a/spec/system/admin/users_spec.rb
+++ b/spec/system/admin/users_spec.rb
@@ -23,7 +23,7 @@ describe "Admin - Users panel", type: :system, js: true do
       fill_in "user[password]",        with: "password123"
       fill_in "Password confirmation", with: "password123"
 
-      click_button "Create"
+      click_button "Save"
 
       expect(page).to have_current_path(admin_users_path)
       expect(page).to have_content("User 'username' was created successfully")
@@ -40,7 +40,7 @@ describe "Admin - Users panel", type: :system, js: true do
       fill_in "Password confirmation", with: "password123"
       check "Bot"
 
-      click_button "Create"
+      click_button "Save"
       expect(page).to have_content("Bot 'username' was created successfully")
       expect(page).not_to have_content("undefined")
 
@@ -72,7 +72,7 @@ describe "Admin - Users panel", type: :system, js: true do
       fill_in "user[password]",        with: "password123"
       fill_in "Password confirmation", with: "password123"
 
-      click_button "Create"
+      click_button "Save"
 
       expect(page).to have_current_path(admin_users_path)
       expect(page).to have_content("User '#{user.username}' was created successfully")
@@ -181,7 +181,7 @@ describe "Admin - Users panel", type: :system, js: true do
       expect(focused_element_id).to eq "application_token_application"
       fill_in "Application", with: "awesome-application"
 
-      click_button "Create"
+      click_button "Save"
 
       expect(page).to have_css("#float-alert")
       expect(page).to have_content("was created successfully")

--- a/spec/system/application_tokens_spec.rb
+++ b/spec/system/application_tokens_spec.rb
@@ -17,7 +17,7 @@ describe "Application tokens" do
       expect(focused_element_id).to eq "application_token_application"
       fill_in "Application", with: "awesome-application"
 
-      click_button "Create"
+      click_button "Save"
 
       expect(page).to have_css("#float-alert")
       expect(page).to have_content("was created successfully")
@@ -33,7 +33,7 @@ describe "Application tokens" do
       expect(focused_element_id).to eq "application_token_application"
       fill_in "Application", with: "awesome-application"
 
-      click_button "Create"
+      click_button "Save"
 
       expect(page).to have_css("#float-alert")
       expect(page).to have_content("Application has already been taken")
@@ -48,7 +48,7 @@ describe "Application tokens" do
       expect(focused_element_id).to eq "application_token_application"
       fill_in "Application", with: "awesome-application"
 
-      click_button "Create"
+      click_button "Save"
 
       expect(page).to have_css("#float-alert")
       expect(page).to have_content("was created successfully")

--- a/spec/system/namespaces_spec.rb
+++ b/spec/system/namespaces_spec.rb
@@ -32,7 +32,7 @@ describe "Namespaces support", type: :system, js: true do
 
     context "invalid fields" do
       it "disables submit button" do
-        expect(page).to have_button("Create", disabled: true)
+        expect(page).to have_button("Save", disabled: true)
       end
 
       it "shows name can't be blank message" do
@@ -40,21 +40,21 @@ describe "Namespaces support", type: :system, js: true do
         clear_field("#namespace_name")
 
         expect(page).to have_content("Name can't be blank")
-        expect(page).to have_button("Create", disabled: true)
+        expect(page).to have_button("Save", disabled: true)
       end
 
       it "shows name invalid chars message" do
         fill_in "Name", with: "!@#!@#"
 
         expect(page).to have_content("Name can only contain lower case alphanumeric characters")
-        expect(page).to have_button("Create", disabled: true)
+        expect(page).to have_button("Save", disabled: true)
       end
 
       it "shows namespace that already exists message" do
         fill_in "Name", with: Namespace.first.name
 
         expect(page).to have_content("Name has already been taken")
-        expect(page).to have_button("Create", disabled: true)
+        expect(page).to have_button("Save", disabled: true)
       end
 
       it "shows team not found message" do
@@ -62,14 +62,14 @@ describe "Namespaces support", type: :system, js: true do
         fill_vue_multiselect(".namespace_team", Team.where(hidden: true).first.name)
 
         expect(page).to have_content("Oops! No team found.")
-        expect(page).to have_button("Create", disabled: true)
+        expect(page).to have_button("Save", disabled: true)
       end
     end
 
     it "creates a namespace" do
       fill_in "Name", with: "valid-namespace"
       select_vue_multiselect(".namespace_team", namespace.team.name)
-      click_button "Create"
+      click_button "Save"
 
       expect(page).to have_content("Namespace 'valid-namespace' was created successfully")
       expect(page).to have_link("valid-namespace")

--- a/spec/system/teams_spec.rb
+++ b/spec/system/teams_spec.rb
@@ -23,7 +23,7 @@ describe "Teams support", type: :system, js: true do
     context "when admin" do
       context "invalid fields" do
         it "disables submit button" do
-          expect(page).to have_button("Add", disabled: true)
+          expect(page).to have_button("Save", disabled: true)
         end
 
         it "shows name can't be blank message" do
@@ -31,14 +31,14 @@ describe "Teams support", type: :system, js: true do
           clear_field("#team_name")
 
           expect(page).to have_content("Name can't be blank")
-          expect(page).to have_button("Add", disabled: true)
+          expect(page).to have_button("Save", disabled: true)
         end
 
         it "shows name is reserved/taken message" do
           fill_in "Name", with: Team.last.name
 
           expect(page).to have_content("Name is reserved or has already been taken")
-          expect(page).to have_button("Add", disabled: true)
+          expect(page).to have_button("Save", disabled: true)
         end
       end
 
@@ -46,7 +46,7 @@ describe "Teams support", type: :system, js: true do
         fill_in "Name", with: "valid-team"
         select admin.username, from: "team_owner_id"
 
-        click_button "Add"
+        click_button "Save"
 
         expect(page).to have_content("Team 'valid-team' was created successfully")
         expect(page).to have_link("valid-team")
@@ -67,7 +67,7 @@ describe "Teams support", type: :system, js: true do
         fill_in "Name", with: "another"
         select another_user.username, from: "team_owner_id"
 
-        click_button "Add"
+        click_button "Save"
 
         expect(page).to have_content("Team 'another' was created successfully")
         expect(page).to have_link("another")
@@ -94,7 +94,7 @@ describe "Teams support", type: :system, js: true do
         toggle_new_team_form
         fill_in "Name", with: "valid-team2"
 
-        click_button "Add"
+        click_button "Save"
 
         expect(page).to have_content("Team 'valid-team2' was created successfully")
         expect(page).to have_link("valid-team2")
@@ -205,7 +205,7 @@ describe "Teams support", type: :system, js: true do
       toggle_new_namespace_form
 
       fill_in "Name", with: "new-namespace"
-      click_button "Create"
+      click_button "Save"
 
       expect(page).to have_content("Namespace 'new-namespace' was created successfully")
       expect(page).to have_link("new-namespace")


### PR DESCRIPTION
Some buttons have changed its name and specs failed. This commit is to
simply fix those failed caused by the previous commit.

Signed-off-by: Vítor Avelino <vavelino@suse.com>