### PR TITLE
Fixed all? and delete? namespace policies

### DIFF
--- a/spec/api/v2/token_spec.rb
+++ b/spec/api/v2/token_spec.rb
@@ -135,6 +135,8 @@ describe "/v2/token", type: :request do
       end
 
       it "does not allow a regular user to delete an image from another user" do
+        APP_CONFIG["delete"]["enabled"] = true
+
         scope = "repository:#{user.username}/busybox:*"
 
         # It works for the regular user


### PR DESCRIPTION
Before this commit, the all? policy from namespaces was an alias to
push?, but doing that was ignoring various rules we have in regards to
how delete works depending on the configuration. The same thing can be
applied to the new delete? method.

Fixes #2123

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>