### PR TITLE
show explore link on login page when ldap auth is enabled

### DIFF
--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -9,12 +9,8 @@ section.row-0
           = f.text_field :username, class: 'input form-control input-lg first', placeholder: 'Username', autofocus: true, required: true
           = f.password_field :password, class: 'input form-control input-lg last', placeholder: 'Password', autocomplete: 'off', required: true
           = f.button id: "login-btn", class: 'classbutton btn btn-primary btn-block btn-lg' do
-            - if APP_CONFIG.enabled?("ldap")
-              i.fa.fa-check
-              ' LDAP Login
-            - else
-              i.fa.fa-check
-              ' Login
+            i.fa.fa-check
+            ' Login
 
         .row
           - if signup_enabled?
@@ -32,6 +28,9 @@ section.row-0
             - if APP_CONFIG.enabled?("oauth.local_login")
               .forgot-password
                 = link_to "I forgot my password", new_user_password_path, class: 'btn btn-link'
+          - elsif APP_CONFIG.enabled?("anonymous_browsing")
+            .explore
+              = link_to "Explore", explore_index_path, id: "explore", class: 'btn btn-link', title: "Explore existing images from this registry"
 
         - if show_first_user_alert?
           .alert.alert-info


### PR DESCRIPTION
When LDAP auth is enabled the 'Explore' link on the login page will never show even when anonymous browsing is enabled.

This change makes the explore link show when LDAP is enabled and also makes the login button text just 'Login' regardless of LDAP being enabled or not as Portus now supports running local users along side LDAP auth.

On a side note maybe the signup and forgot password options should be available when LDAP auth is enabled if local logins are also enabled. 

Signed-off-by: Ross Dougherty <ross@inomial.com>