### PR TITLE
fix style inconsistencies on password reset pages

### DIFF
--- a/app/views/devise/passwords/edit.html.slim
+++ b/app/views/devise/passwords/edit.html.slim
@@ -10,6 +10,7 @@ section.row-0
         = f.password_field :password_confirmation, class: 'input form-control input-lg', placeholder: 'Password confirmation', autocomplete: "off", required: true
 
         = f.button class: 'classbutton btn btn-primary btn-block btn-lg' do
-          i.fa.fa-check  Change my password
+          i.fa.fa-check
+          ' Change my password
 
-        .text-center = link_to 'Go back to the login page', new_user_session_path
+        .text-center = link_to 'Go back to the login page', new_user_session_path, class: 'btn btn-link'

--- a/app/views/devise/passwords/new.html.slim
+++ b/app/views/devise/passwords/new.html.slim
@@ -7,6 +7,7 @@ section.row-0
       = form_for(resource, as: resource_name, url: password_path(resource_name)) do |f|
         = f.email_field :email, class: 'input form-control input-lg', placeholder: 'Email', autofocus: true, required: true
         = f.button class: 'classbutton btn btn-primary btn-block btn-lg' do
-          i.fa.fa-check  Reset password
+          i.fa.fa-check
+          ' Reset password
 
         .text-center = link_to 'Go back to the login page', new_user_session_path, class: 'btn btn-link'


### PR DESCRIPTION
This fixes:
- Button font didn't match login page on both the reset and change password pages.
- 'Go back to login page' text color was wrong on change password page.

Signed-off-by: Ross Dougherty <ross@inomial.com>