### PR TITLE
db: changed tag size column type to bigint

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -15,7 +15,7 @@
 #  marked        :boolean          default(FALSE)
 #  username      :string(255)
 #  scanned       :integer          default(0)
-#  size          :integer
+#  size          :bigint(8)
 #  pulled_at     :datetime
 #
 # Indexes

--- a/db/migrate/20190314173309_change_tag_size.rb
+++ b/db/migrate/20190314173309_change_tag_size.rb
@@ -1,0 +1,5 @@
+class ChangeTagSize < ActiveRecord::Migration[5.2]
+  def change
+     change_column :tags, :size, :bigint
+  end
+end

--- a/db/schema.mysql.rb
+++ b/db/schema.mysql.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_15_133935) do
+ActiveRecord::Schema.define(version: 2019_03_14_173309) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "trackable_type"
@@ -120,7 +120,7 @@ ActiveRecord::Schema.define(version: 2019_01_15_133935) do
     t.boolean "marked", default: false
     t.string "username"
     t.integer "scanned", default: 0
-    t.integer "size"
+    t.bigint "size"
     t.datetime "pulled_at"
     t.index ["repository_id"], name: "index_tags_on_repository_id"
     t.index ["user_id"], name: "index_tags_on_user_id"

--- a/db/schema.postgresql.rb
+++ b/db/schema.postgresql.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_15_133935) do
+ActiveRecord::Schema.define(version: 2019_03_14_173309) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -123,7 +123,7 @@ ActiveRecord::Schema.define(version: 2019_01_15_133935) do
     t.boolean "marked", default: false
     t.string "username"
     t.integer "scanned", default: 0
-    t.integer "size"
+    t.bigint "size"
     t.datetime "pulled_at"
     t.index ["repository_id"], name: "index_tags_on_repository_id"
     t.index ["user_id"], name: "index_tags_on_user_id"

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -15,7 +15,7 @@
 #  marked        :boolean          default(FALSE)
 #  username      :string(255)
 #  scanned       :integer          default(0)
-#  size          :integer
+#  size          :bigint(8)
 #  pulled_at     :datetime
 #
 # Indexes


### PR DESCRIPTION
Previously its type was integer and it was limited to 4 bytes which the
maximum values would be 2GB in bytes. Since there are images above that
size we need to support it to avoid failure.

Signed-off-by: Vítor Avelino <vavelino@suse.com>

Fixes #2159