### PR TITLE
Support oauth against custom github server (eg github enterprise)

### DIFF
--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -102,16 +102,18 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
   # Checks if the user member of github organization and team.
   def github_member?(conf)
+    server = conf.fetch("server", "").presence || "github.com"
+    
     if conf["team"].present?
       # Get user's teams.
-      is_member = member_of("https://api.github.com/user/teams") do |t|
+      is_member = member_of("https://api.#{server}/user/teams") do |t|
         t["name"] == conf["team"] &&
           t["organization"]["login"] == conf["organization"]
       end
       "The Github account isn't in allowed team." unless is_member
     elsif conf["organization"].present?
       # Get user's organizations.
-      is_member = member_of("https://api.github.com/user/orgs") do |t|
+      is_member = member_of("https://api.#{server}/user/orgs") do |t|
         t["login"] == conf["organization"]
       end
       "The Github account isn't in allowed organization." unless is_member

--- a/config/config.yml
+++ b/config/config.yml
@@ -221,6 +221,8 @@ oauth:
     team: ""
      # If a domain (e.g. mycompany.com) is set, then only signups with email from this domain are allowed.
     domain: ""
+    # The Github server to be used. If empty, then github.com is assumed.
+    server: ""
 
   # Gitlab authentication support.
   # Callback url: <host>/users/auth/gitlab/callback

--- a/config/initializers/devise/oauth.rb
+++ b/config/initializers/devise/oauth.rb
@@ -53,7 +53,17 @@ def openid_connect_fetch_options
 end
 
 def github_fetch_options
-  { scope: "read:user,user:email,read:org" }
+  server = APP_CONFIG["oauth"]["github"]["server"].presence || "github.com"
+
+  {
+    scope: "read:user,user:email,read:org",
+    client_options: {
+      site: "https://api.#{server}",
+      authorize_url: "https://#{server}/login/oauth/authorize",
+      token_url: "https://#{server}/login/oauth/access_token",
+    }
+  }
+
 end
 
 def gitlab_fetch_options


### PR DESCRIPTION
### Summary

Proposed fix for issue 2169.

This set of patches works for me but has not been formally tested - I included a guess at a possible rspec test but was not sure about the correct infrastructure setup to run it.

In this patch, I assume that the github api is located at the hostname `api.{#servername}`, which is true for our github enterprise installation, but I don't know if this is universally true.
