### PR TITLE
auth: remove unused address scope from openid connect

### DIFF
--- a/config/initializers/devise/oauth.rb
+++ b/config/initializers/devise/oauth.rb
@@ -32,7 +32,7 @@ end
 def openid_connect_fetch_options
   {
     name:           :openid_connect,
-    scope:          %i[openid email profile address],
+    scope:          %i[openid email profile],
     response_type:  :code,
     discovery:      true,
     issuer:         APP_CONFIG["oauth"]["openid_connect"]["issuer"],


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

### Summary

I just set up Portus with OpenID Connect authentication using Dex which doesn't support the `address` scope. I just checked through the code and data returned from that scope is not used at all, so I have removed it from the OAuth request.