### PR TITLE
switch session_store to active_record_store

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "active_record_union"
+gem "activerecord-session_store"
 gem "base32"
 gem "devise"
 gem "font-awesome-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,6 +35,12 @@ GEM
       activemodel (= 5.2.3)
       activesupport (= 5.2.3)
       arel (>= 9.0)
+    activerecord-session_store (1.1.3)
+      actionpack (>= 4.0)
+      activerecord (>= 4.0)
+      multi_json (~> 1.11, >= 1.11.2)
+      rack (>= 1.5.2, < 3)
+      railties (>= 4.0)
     activestorage (5.2.3)
       actionpack (= 5.2.3)
       activerecord (= 5.2.3)
@@ -508,6 +514,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_record_union
+  activerecord-session_store
   annotate
   awesome_print
   base32

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -2,4 +2,4 @@
 
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: "_portus_session"
+Rails.application.config.session_store :active_record_store, :key => '_portus_session'

--- a/db/migrate/20200206172222_add_sessions_table.rb
+++ b/db/migrate/20200206172222_add_sessions_table.rb
@@ -1,0 +1,12 @@
+class AddSessionsTable < ActiveRecord::Migration[5.2]
+  def change
+    create_table :sessions do |t|
+      t.string :session_id, :null => false
+      t.text :data
+      t.timestamps
+    end
+
+    add_index :sessions, :session_id, :unique => true
+    add_index :sessions, :updated_at
+  end
+end


### PR DESCRIPTION
### Summary

Switch session_store to active_record_store

This avoids a CookieOverflow exception caused by more than 4kB of
session data, e.g. after account creation with openid-connect.

Fixes #2282
