### PR TITLE
Set JWT auth token "sub" field by basic auth username instead of "account" HTTP GET parameter

### DIFF
--- a/app/controllers/api/v2/tokens_controller.rb
+++ b/app/controllers/api/v2/tokens_controller.rb
@@ -28,7 +28,7 @@ class Api::V2::TokensController < Api::BaseController
     auth_scopes = []
     auth_scopes = authorize_scopes(registry) unless registry.nil?
 
-    token = Portus::JwtToken.new(params[:account], params[:service], auth_scopes)
+    token = Portus::JwtToken.new(current_user.username, params[:service], auth_scopes)
     logger.tagged("jwt_token", "claim") { logger.debug token.claim }
     render json: token.encoded_hash
   end


### PR DESCRIPTION
As per the [specification](https://github.com/docker/distribution/blob/master/docs/spec/auth/token.md#requesting-a-token) and the [authors of containerd](https://github.com/containerd/containerd/pull/4040) the `account` GET parameter when requesting a JWT auth token is invalid (Even though [docker-cli does it](https://github.com/docker/distribution/blob/a8371794149d1d95f1e846744b05c87f2f825e5a/registry/client/auth/session.go#L428)) and the HTTP basic auth username should be used instead. For example, [Docker BuildX](https://github.com/docker/buildx) via [buildkit](https://github.com/moby/buildkit) via [containerd](https://github.com/containerd/containerd) does [not set this parameter](https://github.com/containerd/containerd/blob/986f2941871087f31865a1d9fd69b4f97e3aea88/remotes/docker/authorizer.go#L400), resulting in Portus being confused.

This pull request fixes this behaviour by using the HTTP auth username.

Signed-off-by: Christoph Honal <christoph.honal@web.de>
