### PR TITLE
Fix tag size calculation crashing on special manifests

### DIFF
--- a/lib/portus/registry_client.rb
+++ b/lib/portus/registry_client.rb
@@ -88,9 +88,10 @@ module Portus
     # The json navigation is based on Image Manifest Version 2, Schema 2 that
     # is available at https://docs.docker.com/registry/spec/manifest-v2-2/
     def calculate_tag_size(manifest)
+      size = 0
       layers = manifest["layers"]
-      size = manifest["config"]["size"]
-      layers.each { |layer| size += layer["size"] } if layers.present?
+      size += manifest["config"]["size"] if manifest.key?("config") && manifest["config"].key?("size")
+      layers.each { |layer| size += layer["size"] } if !layers.nil? && layers.present?
 
       size
     end


### PR DESCRIPTION
This pull request fixes the tag size calculation for some exotic manifests, like those used by [Docker BuildX](https://github.com/docker/buildx) / [buildkit](https://github.com/moby/buildkit) for [build caching](https://github.com/moby/buildkit#cache). Those manifests do not always contain the `size` field.

This pull request changes the behavior of the tag size calculation to return 0 in those cases instead of crashing the background worker.

Signed-off-by: Christoph Honal <christoph.honal@web.de>
